### PR TITLE
Feature/#19 api response

### DIFF
--- a/backend/src/main/kotlin/com/andlife/InvitationServer/controller/SampleController.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/controller/SampleController.kt
@@ -1,6 +1,7 @@
 package com.andlife.InvitationServer.controller
 
 import com.andlife.InvitationServer.entity.Sample
+import com.andlife.InvitationServer.response.BaseResponse
 import com.andlife.InvitationServer.service.SampleService
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController
@@ -11,8 +12,9 @@ class SampleController(
 ) {
 
     @GetMapping("/")
-    fun getSamples(): List<Sample> {
-        return sampleService.getAllSamples()
+    fun getSamples(): BaseResponse<List<Sample>> {
+        val samples = sampleService.getAllSamples()
+        return BaseResponse.success(samples)
     }
 
 }

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/entity/AnnouncementSection.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/entity/AnnouncementSection.kt
@@ -1,0 +1,32 @@
+package com.andlife.InvitationServer.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "announcement_sections")
+class AnnouncementSection(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "invitation_id")
+    val invitation: Invitation,
+
+    @Column(nullable = false)
+    val title: String,
+
+    @Column(nullable = false)
+    val content: String,
+
+    @Column(name = "display_order", nullable = false)
+    val displayOrder: Int,
+): BaseCreatedEntity()

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/entity/BaseTimeEntity.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/entity/BaseTimeEntity.kt
@@ -1,0 +1,24 @@
+package com.andlife.InvitationServer.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.MappedSuperclass
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener::class)
+abstract class BaseCreatedEntity {
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now()
+}
+
+@MappedSuperclass
+abstract class BaseTimeEntity : BaseCreatedEntity() {
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    var updatedAt: LocalDateTime = LocalDateTime.now()
+}

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/entity/GuestBook.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/entity/GuestBook.kt
@@ -1,0 +1,102 @@
+package com.andlife.InvitationServer.entity
+
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.OneToMany
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "guestbooks")
+class GuestBook(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "invitation_id")
+    val invitation: Invitation,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    val user: User,
+
+    @Column(name = "text_content", columnDefinition = "TEXT", nullable = false)
+    var textContent: String,
+
+    @OneToMany(mappedBy = "guestBook", cascade = [CascadeType.ALL])
+    val images: MutableList<GuestBookImage> = mutableListOf(),
+
+    @OneToMany(mappedBy = "guestBook", cascade = [CascadeType.ALL])
+    val audios: MutableList<GuestBookAudio> = mutableListOf(),
+
+    @OneToMany(mappedBy = "guestBook", cascade = [CascadeType.ALL])
+    val videos: MutableList<GuestBookVideo> = mutableListOf()
+) : BaseTimeEntity()
+
+@Entity
+@Table(name = "guestbook_images")
+class GuestBookImage(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "guestbook_post_id")
+    val guestBook: GuestBook,
+
+    @Column(name = "image_url", nullable = false)
+    val imageUrl: String,
+
+    @Column(name = "display_order", nullable = false)
+    val displayOrder: Int = 0
+)
+
+@Entity
+@Table(name = "guestbook_audios")
+class GuestBookAudio(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "guestbook_post_id")
+    val guestBook: GuestBook,
+
+    @Column(name = "audio_url", nullable = false)
+    val audioUrl: String,
+
+    @Column(name = "duration_seconds", nullable = false)
+    val durationSeconds: Int,
+
+    @Column(name = "display_order", nullable = false)
+    val displayOrder: Int = 0
+)
+
+@Entity
+@Table(name = "guestbook_videos")
+class GuestBookVideo(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "guestbook_post_id")
+    val guestBook: GuestBook,
+
+    @Column(name = "video_url", nullable = false)
+    val videoUrl: String,
+
+    @Column(name = "thumbnail_url", nullable = false)
+    val thumbnailUrl: String,
+
+
+    @Column(name = "duration_seconds", nullable = false)
+    val durationSeconds: Int,
+
+    @Column(name = "display_order", nullable = false)
+    val displayOrder: Int = 0
+)

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/entity/GuestBook.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/entity/GuestBook.kt
@@ -20,11 +20,11 @@ class GuestBook(
     val id: Long = 0,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "invitation_id")
+    @JoinColumn(name = "invitation_id", nullable = false)
     val invitation: Invitation,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     val user: User,
 
     @Column(name = "text_content", columnDefinition = "TEXT", nullable = false)
@@ -47,7 +47,7 @@ class GuestBookImage(
     val id: Long = 0,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "guestbook_post_id")
+    @JoinColumn(name = "guestbook_post_id", nullable = false)
     val guestBook: GuestBook,
 
     @Column(name = "image_url", nullable = false)
@@ -64,7 +64,7 @@ class GuestBookAudio(
     val id: Long = 0,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "guestbook_post_id")
+    @JoinColumn(name = "guestbook_post_id", nullable = false)
     val guestBook: GuestBook,
 
     @Column(name = "audio_url", nullable = false)
@@ -84,7 +84,7 @@ class GuestBookVideo(
     val id: Long = 0,
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "guestbook_post_id")
+    @JoinColumn(name = "guestbook_post_id", nullable = false)
     val guestBook: GuestBook,
 
     @Column(name = "video_url", nullable = false)
@@ -98,5 +98,26 @@ class GuestBookVideo(
     val durationSeconds: Int,
 
     @Column(name = "display_order", nullable = false)
-    val displayOrder: Int = 0
+    val displayOrder: Int = 0,
+
+    @OneToMany(mappedBy = "video", cascade = [CascadeType.ALL])
+    val previewThumbnails: MutableList<VideoPreviewThumbnail> = mutableListOf()
+)
+
+
+@Entity
+@Table(name = "video_preview_thumbnails")
+class VideoPreviewThumbnail(
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "guestbook_video_id", nullable = false)
+    val video: GuestBookVideo,
+
+    @Column(name = "thumbnail_url", nullable = false)
+    val thumbnailUrl: String,
+
+    @Column(name = "time_seconds", nullable = false)
+    val timeSeconds: Double
 )

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/entity/Invitation.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/entity/Invitation.kt
@@ -1,0 +1,61 @@
+package com.andlife.InvitationServer.entity
+
+import com.andlife.InvitationServer.util.StringListConverter
+import jakarta.persistence.Column
+import jakarta.persistence.Convert
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.ManyToOne
+import jakarta.persistence.Table
+import java.time.LocalDate
+import java.time.LocalTime
+
+@Entity
+@Table(name = "invitations")
+class Invitation(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "host_id", nullable = false)
+    val host: User,
+
+    @Column(nullable = false)
+    var title: String,
+
+    @Column(name = "display_host_name", nullable = false)
+    var displayHostName: String,
+
+    @Convert(converter = StringListConverter::class)
+    @Column(name = "thumbnail_urls")
+    var thumbnailUrls: List<String> = emptyList(),
+
+    @Column(name = "invitation_date", nullable = false)
+    val invitationDate: LocalDate,
+
+    @Column(name = "start_time", nullable = false)
+    val startTime: LocalTime,
+
+    @Column(name = "end_time")
+    val endTime: LocalTime? = null,
+
+    @Column(name = "place_name", nullable = false)
+    var placeName: String,
+
+    @Column(nullable = false)
+    var address: String,
+
+    @Column(nullable = false)
+    val lat: Double,
+
+    @Column(nullable = false)
+    val lng: Double,
+
+    @Column(name = "location_guide")
+    var locationGuide: String? = null
+) : BaseTimeEntity()

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/entity/InvitationCard.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/entity/InvitationCard.kt
@@ -1,0 +1,29 @@
+package com.andlife.InvitationServer.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "invitation_cards")
+class InvitationCard(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "invitation_id", nullable = false)
+    val invitation: Invitation,
+
+    @Column(name = "content_json", columnDefinition = "TEXT")
+    var contentJson: String,
+
+    @Column(name = "background_image_url")
+    var backgroundImageUrl: String? = null
+)

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/entity/InvitationParticipant.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/entity/InvitationParticipant.kt
@@ -1,0 +1,33 @@
+package com.andlife.InvitationServer.entity
+
+import jakarta.persistence.*
+import org.hibernate.annotations.CreationTimestamp
+import java.time.LocalDateTime
+
+@Entity
+@Table(
+    name = "invitation_participants",
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_invitation_user",
+            columnNames = ["invitation_id", "user_id"]
+        )
+    ]
+)
+class InvitationParticipant(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "invitation_id", nullable = false)
+    val invitation: Invitation,
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    val user: User,
+
+    @CreationTimestamp
+    @Column(name = "joined_at", nullable = false, updatable = false)
+    val joinedAt: LocalDateTime = LocalDateTime.now()
+)

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/entity/ThanksCard.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/entity/ThanksCard.kt
@@ -1,0 +1,29 @@
+package com.andlife.InvitationServer.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+import jakarta.persistence.Table
+
+@Entity
+@Table(name = "thanks_cards")
+class ThanksCard(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "invitation_id", nullable = false)
+    val invitation: Invitation,
+
+    @Column(name = "content_json", columnDefinition = "TEXT")
+    var contentJson: String,
+
+    @Column(name = "background_image_url")
+    var backgroundImageUrl: String? = null
+): BaseTimeEntity()

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/entity/User.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/entity/User.kt
@@ -9,7 +9,7 @@ import jakarta.persistence.Id
 
 @Entity
 @Table(name = "users")
-data class User(
+class User(
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     val id: Long,

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/entity/User.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/entity/User.kt
@@ -6,9 +6,6 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Table
 import jakarta.persistence.Id
-import org.hibernate.annotations.CreationTimestamp
-import org.hibernate.annotations.UpdateTimestamp
-import java.time.LocalDateTime
 
 @Entity
 @Table(name = "users")
@@ -25,12 +22,4 @@ data class User(
 
     @Column(name = "profile_image_url")
     val profileImageUrl: String? = null,
-
-    @CreationTimestamp
-    @Column(name = "created_at", nullable = false, updatable = false)
-    val createdAt: LocalDateTime = LocalDateTime.now(),
-
-    @UpdateTimestamp
-    @Column(name = "updated_at", nullable = false)
-    val updatedAt: LocalDateTime = LocalDateTime.now()
-)
+): BaseTimeEntity()

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/entity/User.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/entity/User.kt
@@ -1,0 +1,36 @@
+package com.andlife.InvitationServer.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Table
+import jakarta.persistence.Id
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import java.time.LocalDateTime
+
+@Entity
+@Table(name = "users")
+data class User(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long,
+
+    @Column(nullable = false, unique = true)
+    val email: String,
+
+    @Column(nullable = false)
+    val name: String,
+
+    @Column(name = "profile_image_url")
+    val profileImageUrl: String? = null,
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    val createdAt: LocalDateTime = LocalDateTime.now(),
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    val updatedAt: LocalDateTime = LocalDateTime.now()
+)

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/response/BaseResponse.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/response/BaseResponse.kt
@@ -1,0 +1,33 @@
+package com.andlife.InvitationServer.response
+
+data class BaseResponse<T>(
+    val code: Int,
+    val data: T?,
+    val message: String?
+) {
+    companion object {
+
+        fun <T> success(
+            data: T? = null,
+            responseCode: ResponseCode = CommonResponseCode.OK
+        ): BaseResponse<T> {
+            return BaseResponse(
+                code = responseCode.httpStatus.value(),
+                data = data,
+                message = responseCode.message
+            )
+        }
+
+        fun error(
+            responseCode: ResponseCode,
+            customMessage: String? = null
+        ): BaseResponse<Nothing> {
+            return BaseResponse(
+                code = responseCode.httpStatus.value(),
+                data = null,
+                message = customMessage ?: responseCode.message
+            )
+        }
+    }
+
+}

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/response/ResponseCode.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/response/ResponseCode.kt
@@ -7,3 +7,19 @@ interface ResponseCode {
     val message: String
     val name: String
 }
+
+enum class CommonResponseCode(
+    override val httpStatus: HttpStatus,
+    override val message: String
+): ResponseCode {
+    // 2xx 성공
+    OK(HttpStatus.OK, "성공적으로 처리되었습니다."),
+
+    // 4xx 클라이언트 에러
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증 정보가 유효하지 않습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 정보를 찾을 수 없습니다."),
+    BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+
+    // 5xx 서버 에러
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버에 오류가 발생했습니다. 잠시 후 다시 시도해주세요.")
+}

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/response/ResponseCode.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/response/ResponseCode.kt
@@ -1,0 +1,9 @@
+package com.andlife.InvitationServer.response
+
+import org.springframework.http.HttpStatus
+
+interface ResponseCode {
+    val httpStatus: HttpStatus
+    val message: String
+    val name: String
+}

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/response/home/LatestGuestBookResponse.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/response/home/LatestGuestBookResponse.kt
@@ -1,0 +1,35 @@
+package com.andlife.InvitationServer.response.home
+
+import java.time.LocalDateTime
+
+data class LatestGuestBookResponse(
+    val id: Long,
+    val userName: String,
+    val userProfileUrl: String,
+    val content: String,
+    val createAt: LocalDateTime,
+    val images: List<GuestbookImageResponse> = emptyList(),
+    val audios: List<GuestbookAudioResponse> = emptyList(),
+    val videos: List<GuestbookVideoResponse> = emptyList()
+)
+
+data class GuestbookImageResponse(
+    val id: Long,
+    val imageUrl: String,
+    val displayOrder: Int
+)
+
+data class GuestbookAudioResponse(
+    val id: Long,
+    val audioUrl: String,
+    val durationSeconds: Int,
+    val displayOrder: Int
+)
+
+data class GuestbookVideoResponse(
+    val id: Long,
+    val videoUrl: String,
+    val thumbnailUrl: String,
+    val durationSeconds: Int,
+    val displayOrder: Int
+)

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/response/home/UpcomingInvitationResponse.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/response/home/UpcomingInvitationResponse.kt
@@ -1,0 +1,12 @@
+package com.andlife.InvitationServer.response.home
+
+import java.time.LocalDateTime
+
+data class UpcomingInvitationResponse(
+    val id: Long,
+    val title: String,
+    val hostName: String,
+    val startTime: LocalDateTime,
+    val thumbnailUrl: String,
+    val dDay: Int
+)

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/util/StringListConverter.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/util/StringListConverter.kt
@@ -1,0 +1,21 @@
+package com.andlife.InvitationServer.util
+
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+
+@Converter
+class StringListConverter : AttributeConverter<List<String>, String> {
+
+    private val splitChar = ","
+
+    // 엔티티의 List를 DB에 넣을 String으로 변환 (List -> "url1,url2")
+    override fun convertToDatabaseColumn(attribute: List<String>?): String? {
+        return attribute?.joinToString(splitChar)
+    }
+
+    // DB에서 가져온 String을 엔티티의 List로 변환 ("url1,url2" -> List)
+    override fun convertToEntityAttribute(dbData: String?): List<String> {
+        return dbData?.split(splitChar)?.filter { it.isNotBlank() } ?: emptyList()
+    }
+
+}


### PR DESCRIPTION
## 🔍 변경 사항
> 이번 PR에서 변경된 핵심 내용을 간단히 설명해주세요.
- BE `BaseResponse` 정의
  - `CommonResponseCode` 정의
- ERD에 대응되는 Entity 정의
- Home 화면에 필요한 다가오는 초대, 최신 게시물 Response 정의

## 🔗 관련 이슈
> 해당 PR과 연결된 이슈 번호를 적어주세요. (예: #1)

- #19 

## ✅ 체크리스트
- [x] 팀 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 import는 삭제했나요?

## 리뷰 요청
### D-Day 계산은 어디서 할 것인지?
오늘 팀 회의에서 깜빡하고 말씀을 못 드렸던 부분이 있어서 남깁니다!
<img width="445" height="481" alt="image" src="https://github.com/user-attachments/assets/5a6eaa05-1dac-492f-a7cd-ef4a8f96ab91" />

저희 다가오는 초대나 초대장 리스트 등에서 D-Day를 보여주는 기능이 있습니다.
이 부분을 서버에서 계산해서 내려줄 것인지, 클라이언트에서 계산할 것인지를 정하면 좋을 것 같습니다!

```Kotlin
data class UpcomingInvitationResponse(
    val id: Long,
    val title: String,
    val hostName: String,
    val startTime: LocalDateTime,
    val thumbnailUrl: String,
    val dDay: Int
)
```

현재는 Response에 D-Day 필드까지 넣어놓은 상태인데,
정해지는 방향에 따라서 변경하도록 하겠습니다.

### Entity 분리를 하는 것이 좋을지?
현재는 하위 Entity를 분리하지 않고 부모 Entity 밑에 선언해뒀습니다. (GuestBook 하위에 GuestBookVideo 등)
이 부분을 외부 파일로 분리하는 것이 좋을지 현재 형태도 괜찮을지 의견 주시면 감사하겠습니다.

### 리스트형 필드에 대한 대응
<img width="278" height="519" alt="image" src="https://github.com/user-attachments/assets/2c1e2334-8d77-46a1-a0c6-224c7d4531c8" />

```Kotlin
@Converter
class StringListConverter : AttributeConverter<List<String>, String> {

    private val splitChar = ","

    // 엔티티의 List를 DB에 넣을 String으로 변환 (List -> "url1,url2")
    override fun convertToDatabaseColumn(attribute: List<String>?): String? {
        return attribute?.joinToString(splitChar)
    }

    // DB에서 가져온 String을 엔티티의 List로 변환 ("url1,url2" -> List)
    override fun convertToEntityAttribute(dbData: String?): List<String> {
        return dbData?.split(splitChar)?.filter { it.isNotBlank() } ?: emptyList()
    }

}
```

필드에 리스트형식으로 데이터가 들어가야 하는 필드가 있습니다.
MySQL에서 5.7 버전부터 JSON 형식으로 저장이 가능한 것으로 알고 있는데,
지금 형태 (리스트 -> 문자열 -> 문자열로 저장 -> 문자열 불러옴 -> 리스트로 변환)를 유지하는 것이 좋을지
JSON 형태로 저장하는 것이 좋을지 의견을 주시면 감사하겠습니다.