### PR TITLE
Feature/#22 add announcement bottomsheet

### DIFF
--- a/android/core/ui/build.gradle.kts
+++ b/android/core/ui/build.gradle.kts
@@ -22,6 +22,7 @@ dependencies {
 
     // lifecycle
     implementation(libs.androidx.lifecycle.viewModelCompose)
+    implementation(libs.androidx.lifecycle.runtime.ktx)
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)

--- a/android/core/ui/build.gradle.kts
+++ b/android/core/ui/build.gradle.kts
@@ -20,6 +20,9 @@ dependencies {
     // paging
     implementation(libs.androidx.paging.compose)
 
+    // lifecycle
+    implementation(libs.androidx.lifecycle.viewModelCompose)
+
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/InvitationAddAnnouncementBottomSheet.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/InvitationAddAnnouncementBottomSheet.kt
@@ -1,0 +1,197 @@
+package com.andlife.ui.component
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.BottomSheetDefaults
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import com.andlife.designsystem.component.InvitationButton
+import com.andlife.designsystem.component.InvitationTextField
+import com.andlife.designsystem.preview.PreviewTheme
+import com.andlife.designsystem.theme.InvitationElevation
+import com.andlife.designsystem.theme.InvitationSpacing
+import com.andlife.designsystem.theme.InvitationTheme
+import com.andlife.ui.R
+
+@Composable
+fun TitleAndTextField(
+    title: String,
+    textFieldValue: String,
+    onTextFieldValueChange: (String) -> Unit,
+    textFieldPlaceholder: String,
+    modifier: Modifier = Modifier,
+    minLines: Int = 1,
+) {
+    Column(
+        horizontalAlignment = Alignment.Start,
+        modifier = modifier,
+    ) {
+        Text(
+            text = title,
+            style = InvitationTheme.typography.bodyMediumSemiBold,
+            color = InvitationTheme.colorScheme.textPrimary,
+        )
+        Spacer(modifier = Modifier.height(InvitationSpacing.small))
+        InvitationTextField(
+            value = textFieldValue,
+            onValueChange = onTextFieldValueChange,
+            placeholder = textFieldPlaceholder,
+            modifier = Modifier.fillMaxWidth(),
+            minLines = minLines,
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun InvitationAddAnnouncementBottomSheet(
+    onConfirm: (String, String) -> Unit,
+    onDismiss: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val sheetState =
+        rememberModalBottomSheetState(
+            skipPartiallyExpanded = true,
+        )
+
+    var title by remember { mutableStateOf("") }
+    var content by remember { mutableStateOf("") }
+
+    ModalBottomSheet(
+        onDismissRequest = { },
+        sheetState = sheetState,
+        containerColor = InvitationTheme.colorScheme.backgroundPrimary,
+        dragHandle = {
+            BottomSheetDefaults.DragHandle(
+                color = InvitationTheme.colorScheme.textSecondary,
+            )
+        },
+        modifier = modifier,
+    ) {
+        Box(
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                text = "공지사항 추가",
+                style = InvitationTheme.typography.headingSmallSemiBold,
+                color = InvitationTheme.colorScheme.textPrimary,
+                modifier = Modifier.align(Alignment.Center),
+            )
+
+            Box(
+                modifier =
+                    Modifier
+                        .align(Alignment.CenterEnd)
+                        .padding(horizontal = InvitationSpacing.large)
+                        .clickable { onDismiss() },
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(
+                    painter = painterResource(id = R.drawable.ic_close_24),
+                    contentDescription = "닫기",
+                    tint = InvitationTheme.colorScheme.textPrimary,
+                )
+            }
+        }
+        Column(
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = InvitationSpacing.large)
+                    .padding(bottom = InvitationSpacing.large),
+        ) {
+            Spacer(modifier = Modifier.height(InvitationSpacing.large))
+
+            TitleAndTextField(
+                title = "공지사항 제목",
+                textFieldValue = title,
+                onTextFieldValueChange = { title = it },
+                textFieldPlaceholder = "제목을 입력해주세요",
+                modifier = Modifier.fillMaxWidth(),
+            )
+
+            Spacer(modifier = Modifier.height(InvitationSpacing.medium))
+
+            TitleAndTextField(
+                title = "공지사항 내용",
+                textFieldValue = content,
+                onTextFieldValueChange = { content = it },
+                textFieldPlaceholder = "내용을 입력해주세요",
+                modifier = Modifier.fillMaxWidth(),
+                minLines = 5,
+            )
+
+            Row(
+                Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End,
+            ) {
+                TextButton(
+                    onClick = {
+                        title = ""
+                        content = ""
+                    },
+                    contentPadding = PaddingValues(vertical = InvitationSpacing.medium),
+                ) {
+                    Text(
+                        text = "모두 지우기",
+                        color = InvitationTheme.colorScheme.iconPrimary,
+                        style = InvitationTheme.typography.bodyMediumSemiBold,
+                    )
+                }
+            }
+
+            Spacer(modifier = Modifier.height(InvitationSpacing.medium))
+
+            InvitationButton(
+                onClick = {
+                    onConfirm(title, content)
+                },
+                modifier = Modifier.fillMaxWidth(),
+                contentPadding = PaddingValues(vertical = InvitationSpacing.medium),
+                elevation =
+                    ButtonDefaults.buttonElevation(
+                        defaultElevation = InvitationElevation.none,
+                        pressedElevation = InvitationElevation.none,
+                    ),
+            ) {
+                Text(
+                    text = "등록",
+                    style = InvitationTheme.typography.bodyLargeSemiBold,
+                )
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@PreviewTheme
+@Composable
+private fun InvitationAddAnnouncementBottomSheetPreview() {
+    InvitationTheme {
+        InvitationAddAnnouncementBottomSheet(
+            onConfirm = { _, _ -> },
+            onDismiss = {},
+        )
+    }
+}

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/InvitationAddAnnouncementBottomSheet.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/InvitationAddAnnouncementBottomSheet.kt
@@ -10,11 +10,11 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.BottomSheetDefaults
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.ModalBottomSheetProperties
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
@@ -22,6 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -33,6 +34,7 @@ import com.andlife.designsystem.theme.InvitationElevation
 import com.andlife.designsystem.theme.InvitationSpacing
 import com.andlife.designsystem.theme.InvitationTheme
 import com.andlife.ui.R
+import kotlinx.coroutines.launch
 
 @Composable
 fun TitleAndTextField(
@@ -75,18 +77,22 @@ fun InvitationAddAnnouncementBottomSheet(
             skipPartiallyExpanded = true,
         )
 
+    val scope = rememberCoroutineScope()
+
     var title by remember { mutableStateOf("") }
     var content by remember { mutableStateOf("") }
 
     ModalBottomSheet(
-        onDismissRequest = { },
+        onDismissRequest = { }, // 사용하지 않음
         sheetState = sheetState,
         containerColor = InvitationTheme.colorScheme.backgroundPrimary,
-        dragHandle = {
-            BottomSheetDefaults.DragHandle(
-                color = InvitationTheme.colorScheme.textSecondary,
-            )
-        },
+        dragHandle = null,
+        sheetGesturesEnabled = false,
+        properties =
+            ModalBottomSheetProperties(
+                shouldDismissOnBackPress = false,
+                shouldDismissOnClickOutside = false,
+            ),
         modifier = modifier,
     ) {
         Box(
@@ -104,7 +110,12 @@ fun InvitationAddAnnouncementBottomSheet(
                     Modifier
                         .align(Alignment.CenterEnd)
                         .padding(horizontal = InvitationSpacing.large)
-                        .clickable { onDismiss() },
+                        .clickable {
+                            scope.launch {
+                                sheetState.hide()
+                                onDismiss()
+                            }
+                        },
                 contentAlignment = Alignment.Center,
             ) {
                 Icon(

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/addannouncement/AnnouncementDraft.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/addannouncement/AnnouncementDraft.kt
@@ -1,0 +1,6 @@
+package com.andlife.ui.component.addannouncement
+
+data class AnnouncementDraft(
+    val title: String = "",
+    val content: String = "",
+)

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/addannouncement/InvitationAddAnnouncementBottomSheet.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/addannouncement/InvitationAddAnnouncementBottomSheet.kt
@@ -19,13 +19,13 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.andlife.designsystem.component.InvitationButton
 import com.andlife.designsystem.component.InvitationTextField
@@ -50,7 +50,7 @@ fun InvitationAddAnnouncementBottomSheet(
         )
 
     val scope = rememberCoroutineScope()
-    val draft by viewModel.announcementDraft.collectAsState()
+    val draft by viewModel.announcementDraft.collectAsStateWithLifecycle()
 
     ModalBottomSheet(
         onDismissRequest = { }, // 사용하지 않음

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/addannouncement/InvitationAddAnnouncementBottomSheet.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/addannouncement/InvitationAddAnnouncementBottomSheet.kt
@@ -73,7 +73,7 @@ fun InvitationAddAnnouncementBottomSheet(
     onConfirm: (String, String) -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: AddAnnouncementViewModel = viewModel(),
+    viewModel: InvitationAddAnnouncementViewModel = viewModel(),
 ) {
     val sheetState =
         rememberModalBottomSheetState(

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/addannouncement/InvitationAddAnnouncementBottomSheet.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/addannouncement/InvitationAddAnnouncementBottomSheet.kt
@@ -42,6 +42,7 @@ fun TitleAndTextField(
     onTextFieldValueChange: (String) -> Unit,
     textFieldPlaceholder: String,
     modifier: Modifier = Modifier,
+    singleLine: Boolean = true,
     minLines: Int = 1,
 ) {
     Column(
@@ -60,6 +61,7 @@ fun TitleAndTextField(
             placeholder = textFieldPlaceholder,
             modifier = Modifier.fillMaxWidth(),
             minLines = minLines,
+            singleLine = singleLine,
         )
     }
 }
@@ -151,6 +153,7 @@ fun InvitationAddAnnouncementBottomSheet(
                 onTextFieldValueChange = viewModel::updateContent,
                 textFieldPlaceholder = "내용을 입력해주세요",
                 modifier = Modifier.fillMaxWidth(),
+                singleLine = false,
                 minLines = 5,
             )
 

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/addannouncement/InvitationAddAnnouncementBottomSheet.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/addannouncement/InvitationAddAnnouncementBottomSheet.kt
@@ -176,6 +176,7 @@ fun InvitationAddAnnouncementBottomSheet(
                     onConfirm(draft.title, draft.content)
                     viewModel.clearDraft()
                 },
+                enabled = draft.title.isNotBlank() && draft.content.isNotBlank(),
                 modifier = Modifier.fillMaxWidth(),
                 contentPadding = PaddingValues(vertical = InvitationSpacing.medium),
                 elevation =

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/addannouncement/InvitationAddAnnouncementBottomSheet.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/addannouncement/InvitationAddAnnouncementBottomSheet.kt
@@ -6,9 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -16,7 +14,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.ModalBottomSheetProperties
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -102,11 +99,9 @@ fun InvitationAddAnnouncementBottomSheet(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = InvitationSpacing.large)
-                    .padding(bottom = InvitationSpacing.large),
+                    .padding(all = InvitationSpacing.large),
+            verticalArrangement = Arrangement.spacedBy(InvitationSpacing.medium),
         ) {
-            Spacer(modifier = Modifier.height(InvitationSpacing.large))
-
             TitleAndTextField(
                 title = stringResource(R.string.label_announcement_title),
                 textFieldValue = draft.title,
@@ -114,8 +109,6 @@ fun InvitationAddAnnouncementBottomSheet(
                 textFieldPlaceholder = stringResource(R.string.tf_announcement_title_hint),
                 modifier = Modifier.fillMaxWidth(),
             )
-
-            Spacer(modifier = Modifier.height(InvitationSpacing.medium))
 
             TitleAndTextField(
                 title = stringResource(R.string.label_announcement_content),
@@ -131,21 +124,17 @@ fun InvitationAddAnnouncementBottomSheet(
                 Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.End,
             ) {
-                TextButton(
-                    onClick = {
-                        viewModel.clearDraft()
-                    },
-                    contentPadding = PaddingValues(vertical = InvitationSpacing.medium),
-                ) {
-                    Text(
-                        text = stringResource(R.string.txt_delete_all),
-                        color = InvitationTheme.colorScheme.iconPrimary,
-                        style = InvitationTheme.typography.bodyMediumSemiBold,
-                    )
-                }
+                Text(
+                    text = stringResource(R.string.txt_delete_all),
+                    modifier =
+                        Modifier
+                            .clickable {
+                                viewModel.clearDraft()
+                            },
+                    color = InvitationTheme.colorScheme.iconPrimary,
+                    style = InvitationTheme.typography.bodyMediumSemiBold,
+                )
             }
-
-            Spacer(modifier = Modifier.height(InvitationSpacing.medium))
 
             InvitationButton(
                 onClick = {
@@ -181,6 +170,7 @@ fun TitleAndTextField(
     minLines: Int = 1,
 ) {
     Column(
+        verticalArrangement = Arrangement.spacedBy(InvitationSpacing.small),
         horizontalAlignment = Alignment.Start,
         modifier = modifier,
     ) {
@@ -189,7 +179,6 @@ fun TitleAndTextField(
             style = InvitationTheme.typography.bodyMediumSemiBold,
             color = InvitationTheme.colorScheme.textPrimary,
         )
-        Spacer(modifier = Modifier.height(InvitationSpacing.small))
         InvitationTextField(
             value = textFieldValue,
             onValueChange = onTextFieldValueChange,

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/addannouncement/InvitationAddAnnouncementBottomSheet.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/addannouncement/InvitationAddAnnouncementBottomSheet.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.andlife.designsystem.component.InvitationButton
 import com.andlife.designsystem.component.InvitationTextField
@@ -102,7 +103,7 @@ fun InvitationAddAnnouncementBottomSheet(
                     .padding(top = InvitationSpacing.twoXLarge),
         ) {
             Text(
-                text = "공지사항 추가",
+                text = stringResource(R.string.label_add_announcement),
                 style = InvitationTheme.typography.headingSmallSemiBold,
                 color = InvitationTheme.colorScheme.textPrimary,
                 modifier = Modifier.align(Alignment.Center),
@@ -123,7 +124,7 @@ fun InvitationAddAnnouncementBottomSheet(
             ) {
                 Icon(
                     painter = painterResource(id = R.drawable.ic_close_24),
-                    contentDescription = "닫기",
+                    contentDescription = stringResource(R.string.desc_close),
                     tint = InvitationTheme.colorScheme.textPrimary,
                 )
             }
@@ -138,20 +139,20 @@ fun InvitationAddAnnouncementBottomSheet(
             Spacer(modifier = Modifier.height(InvitationSpacing.large))
 
             TitleAndTextField(
-                title = "공지사항 제목",
+                title = stringResource(R.string.label_announcement_title),
                 textFieldValue = draft.title,
                 onTextFieldValueChange = viewModel::updateTitle,
-                textFieldPlaceholder = "제목을 입력해주세요",
+                textFieldPlaceholder = stringResource(R.string.tf_announcement_title_hint),
                 modifier = Modifier.fillMaxWidth(),
             )
 
             Spacer(modifier = Modifier.height(InvitationSpacing.medium))
 
             TitleAndTextField(
-                title = "공지사항 내용",
+                title = stringResource(R.string.label_announcement_content),
                 textFieldValue = draft.content,
                 onTextFieldValueChange = viewModel::updateContent,
-                textFieldPlaceholder = "내용을 입력해주세요",
+                textFieldPlaceholder = stringResource(R.string.tf_announcement_content_hint),
                 modifier = Modifier.fillMaxWidth(),
                 singleLine = false,
                 minLines = 5,
@@ -168,7 +169,7 @@ fun InvitationAddAnnouncementBottomSheet(
                     contentPadding = PaddingValues(vertical = InvitationSpacing.medium),
                 ) {
                     Text(
-                        text = "모두 지우기",
+                        text = stringResource(R.string.txt_delete_all),
                         color = InvitationTheme.colorScheme.iconPrimary,
                         style = InvitationTheme.typography.bodyMediumSemiBold,
                     )
@@ -192,7 +193,7 @@ fun InvitationAddAnnouncementBottomSheet(
                     ),
             ) {
                 Text(
-                    text = "등록",
+                    text = stringResource(R.string.txt_submit),
                     style = InvitationTheme.typography.bodyLargeSemiBold,
                 )
             }

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/addannouncement/InvitationAddAnnouncementBottomSheet.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/addannouncement/InvitationAddAnnouncementBottomSheet.kt
@@ -94,7 +94,10 @@ fun InvitationAddAnnouncementBottomSheet(
         modifier = modifier,
     ) {
         Box(
-            modifier = Modifier.fillMaxWidth(),
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .padding(top = InvitationSpacing.twoXLarge),
         ) {
             Text(
                 text = "공지사항 추가",

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/addannouncement/InvitationAddAnnouncementBottomSheet.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/addannouncement/InvitationAddAnnouncementBottomSheet.kt
@@ -1,4 +1,4 @@
-package com.andlife.ui.component
+package com.andlife.ui.component.addannouncement
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -19,14 +19,13 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.andlife.designsystem.component.InvitationButton
 import com.andlife.designsystem.component.InvitationTextField
 import com.andlife.designsystem.preview.PreviewTheme
@@ -71,6 +70,7 @@ fun InvitationAddAnnouncementBottomSheet(
     onConfirm: (String, String) -> Unit,
     onDismiss: () -> Unit,
     modifier: Modifier = Modifier,
+    viewModel: AddAnnouncementViewModel = viewModel(),
 ) {
     val sheetState =
         rememberModalBottomSheetState(
@@ -78,9 +78,7 @@ fun InvitationAddAnnouncementBottomSheet(
         )
 
     val scope = rememberCoroutineScope()
-
-    var title by remember { mutableStateOf("") }
-    var content by remember { mutableStateOf("") }
+    val draft by viewModel.announcementDraft.collectAsState()
 
     ModalBottomSheet(
         onDismissRequest = { }, // 사용하지 않음
@@ -136,8 +134,8 @@ fun InvitationAddAnnouncementBottomSheet(
 
             TitleAndTextField(
                 title = "공지사항 제목",
-                textFieldValue = title,
-                onTextFieldValueChange = { title = it },
+                textFieldValue = draft.title,
+                onTextFieldValueChange = viewModel::updateTitle,
                 textFieldPlaceholder = "제목을 입력해주세요",
                 modifier = Modifier.fillMaxWidth(),
             )
@@ -146,8 +144,8 @@ fun InvitationAddAnnouncementBottomSheet(
 
             TitleAndTextField(
                 title = "공지사항 내용",
-                textFieldValue = content,
-                onTextFieldValueChange = { content = it },
+                textFieldValue = draft.content,
+                onTextFieldValueChange = viewModel::updateContent,
                 textFieldPlaceholder = "내용을 입력해주세요",
                 modifier = Modifier.fillMaxWidth(),
                 minLines = 5,
@@ -159,8 +157,7 @@ fun InvitationAddAnnouncementBottomSheet(
             ) {
                 TextButton(
                     onClick = {
-                        title = ""
-                        content = ""
+                        viewModel.clearDraft()
                     },
                     contentPadding = PaddingValues(vertical = InvitationSpacing.medium),
                 ) {
@@ -176,7 +173,8 @@ fun InvitationAddAnnouncementBottomSheet(
 
             InvitationButton(
                 onClick = {
-                    onConfirm(title, content)
+                    onConfirm(draft.title, draft.content)
+                    viewModel.clearDraft()
                 },
                 modifier = Modifier.fillMaxWidth(),
                 contentPadding = PaddingValues(vertical = InvitationSpacing.medium),

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/addannouncement/InvitationAddAnnouncementBottomSheet.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/addannouncement/InvitationAddAnnouncementBottomSheet.kt
@@ -36,37 +36,6 @@ import com.andlife.designsystem.theme.InvitationTheme
 import com.andlife.ui.R
 import kotlinx.coroutines.launch
 
-@Composable
-fun TitleAndTextField(
-    title: String,
-    textFieldValue: String,
-    onTextFieldValueChange: (String) -> Unit,
-    textFieldPlaceholder: String,
-    modifier: Modifier = Modifier,
-    singleLine: Boolean = true,
-    minLines: Int = 1,
-) {
-    Column(
-        horizontalAlignment = Alignment.Start,
-        modifier = modifier,
-    ) {
-        Text(
-            text = title,
-            style = InvitationTheme.typography.bodyMediumSemiBold,
-            color = InvitationTheme.colorScheme.textPrimary,
-        )
-        Spacer(modifier = Modifier.height(InvitationSpacing.small))
-        InvitationTextField(
-            value = textFieldValue,
-            onValueChange = onTextFieldValueChange,
-            placeholder = textFieldPlaceholder,
-            modifier = Modifier.fillMaxWidth(),
-            minLines = minLines,
-            singleLine = singleLine,
-        )
-    }
-}
-
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun InvitationAddAnnouncementBottomSheet(
@@ -198,6 +167,37 @@ fun InvitationAddAnnouncementBottomSheet(
                 )
             }
         }
+    }
+}
+
+@Composable
+fun TitleAndTextField(
+    title: String,
+    textFieldValue: String,
+    onTextFieldValueChange: (String) -> Unit,
+    textFieldPlaceholder: String,
+    modifier: Modifier = Modifier,
+    singleLine: Boolean = true,
+    minLines: Int = 1,
+) {
+    Column(
+        horizontalAlignment = Alignment.Start,
+        modifier = modifier,
+    ) {
+        Text(
+            text = title,
+            style = InvitationTheme.typography.bodyMediumSemiBold,
+            color = InvitationTheme.colorScheme.textPrimary,
+        )
+        Spacer(modifier = Modifier.height(InvitationSpacing.small))
+        InvitationTextField(
+            value = textFieldValue,
+            onValueChange = onTextFieldValueChange,
+            placeholder = textFieldPlaceholder,
+            modifier = Modifier.fillMaxWidth(),
+            minLines = minLines,
+            singleLine = singleLine,
+        )
     }
 }
 

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/addannouncement/InvitationAddAnnouncementViewModel.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/addannouncement/InvitationAddAnnouncementViewModel.kt
@@ -1,0 +1,25 @@
+package com.andlife.ui.component.addannouncement
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+class AddAnnouncementViewModel : ViewModel() {
+    private val _announcementDraft = MutableStateFlow(AnnouncementDraft())
+    val announcementDraft: StateFlow<AnnouncementDraft> = _announcementDraft.asStateFlow()
+
+    fun updateTitle(title: String) {
+        _announcementDraft.value =
+            _announcementDraft.value.copy(title = title)
+    }
+
+    fun updateContent(content: String) {
+        _announcementDraft.value =
+            _announcementDraft.value.copy(content = content)
+    }
+
+    fun clearDraft() {
+        _announcementDraft.value = AnnouncementDraft()
+    }
+}

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/addannouncement/InvitationAddAnnouncementViewModel.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/addannouncement/InvitationAddAnnouncementViewModel.kt
@@ -5,7 +5,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
-class AddAnnouncementViewModel : ViewModel() {
+class InvitationAddAnnouncementViewModel : ViewModel() {
     private val _announcementDraft = MutableStateFlow(AnnouncementDraft())
     val announcementDraft: StateFlow<AnnouncementDraft> = _announcementDraft.asStateFlow()
 

--- a/android/core/ui/src/main/res/drawable/ic_close_24.xml
+++ b/android/core/ui/src/main/res/drawable/ic_close_24.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="960" android:viewportWidth="960" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M256,760L200,704L424,480L200,256L256,200L480,424L704,200L760,256L536,480L760,704L704,760L480,536L256,760Z"/>
+    
+</vector>

--- a/android/core/ui/src/main/res/values/strings.xml
+++ b/android/core/ui/src/main/res/values/strings.xml
@@ -8,4 +8,14 @@
     <string name="des_invitation_list_image">초대장 리스트 카드의 이미지</string>
     <string name="des_invitation_more_btn">초대장 리스트 카드의 더보기 아이콘 버튼</string>
     <string name="des_invitation_icon">초대장 시간 장소 아이콘</string>
+
+    <string name="label_add_announcement">공지사항 추가</string>
+    <string name="label_announcement_title">공지사항 제목</string>
+    <string name="tf_announcement_title_hint">제목을 입력해주세요</string>
+    <string name="label_announcement_content">공지사항 내용</string>
+    <string name="tf_announcement_content_hint">내용을 입력해주세요</string>
+    <string name="desc_close">닫기</string>
+    <string name="txt_delete_all">모두 지우기</string>
+    <string name="txt_submit">등록</string>
+
 </resources>


### PR DESCRIPTION
## 🔍 변경 사항
공지사항 추가 바텀시트

<img width="400" height="191" alt="스크린샷 2026-01-04 오후 9 36 27" src="https://github.com/user-attachments/assets/9d1e328c-8fe2-49b0-afc5-cefcc58563ea" />

core/ui/component/addannouncement 하위에 InvitationAddAnnoouncementBottomSheet를 추가했습니다.
- ViewModel을 Compose에서 사용하기 위해 core/ui 모듈에 lifecycle-viewmodel-compose 의존성을 추가했습니다.
+) core/ui 모듈에 androidx.lifecycle.runtime.ktx 의존성을 추가했습니다
- 입력 텍스트 필드는 공통 컴포넌트인 InvitationTextField를 사용했습니다.



### 사용 예시
```kotlin
var showAnnounceBottomSheet by remember { mutableStateOf(false) }

var titleText by remember { mutableStateOf("") }
var contentText by remember { mutableStateOf("") }

if (showAnnounceBottomSheet) {
    InvitationAddAnnouncementBottomSheet(
        onConfirm = { title, content ->
            titleText = title
            contentText = content
            showAnnounceBottomSheet = false
        },
        onDismiss = {
            showAnnounceBottomSheet = false
        }
    )
}
```

### 바텀시트 dismiss 정책 제어
바텀시트는 뒤로가기 버튼, 바깥영역 터치, 아래로 드래그했을 경우에 닫히는데, 이것들을 무효화하고 오직 우상단에 추가한 x 버튼으로만 닫히도록 처리했습니다.

```kotlin
properties = ModalBottomSheetProperties(
    shouldDismissOnBackPress = false,
    shouldDismissOnClickOutside = false,
)
```

뒤로가기 버튼 및 바깥 영역 터치로 바텀시트가 닫히지 않도록 false로 설정했습니다. (기본값은 true)
내부 코드([공식 문서](https://composables.com/docs/androidx.compose.material3/material3/classes/ModalBottomSheetProperties))를 확인한 결과, 해당 값을 true로 설정할 경우
- onDismissRequest()로 지정한 코드를 실행합니다.
- rememberCoroutineScope()를 통해 scope.launch { sheetState.hide() }가 실행됩니다.

그리고 `ModalBottomSheet()`에서 `sheetGesturesEnabled = false,` 로 설정해 바텀시트에 대한 드래그 제스처를 무효화했습니다.
이렇게 설정하고 나니 `onDismissRequest` 파라미터로 지정하는 코드는 호출되는 경우가 없어서 비워두었습니다.

x 버튼 클릭 시 자연스러운 닫힘 애니메이션을 위해 `scope.launch { sheetState.hide() }`를 명시적으로 호출해주었고,
애니메이션 종료되고 나면 `onDismiss()`를 호출하여 바텀시트 상태를 정리했습니다.


### 바텀시트를 닫았다가 열어도 이전 입력값 유지

입력 중인 제목/내용은 `InvitationAddAnnouncementViewModel`에서 관리됩니다.

```kotlin
data class AnnouncementDraft(
    val title: String = "",
    val content: String = "",
)
```
초안 을 의미하는 AnnouncementDraft 를 정의했고, 텍스트필드의 onValueChange 때마다 MutableStateFlow인 `_announcementDraft` 값을 업데이트하는 방식으로 진행했습니다.


## 📸 스크린샷 (선택)
[Screen_recording_20260104_210347.webm](https://github.com/user-attachments/assets/fd934af0-d807-4833-95dd-8e4857efa58a)


초기화 버튼의 위치랑 텍스트(-> 모두 지우기)를 바꿔보았는데 의견 주시면 감사하겠습니다.
<기존>

<img width="333" height="485" alt="스크린샷 2026-01-05 오전 10 24 37" src="https://github.com/user-attachments/assets/98dcb86b-631b-4c6d-80a0-f774448f075d" />


## 🔗 관련 이슈
- #22 
- Close #22

## ✅ 체크리스트
- [x] 팀 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 import는 삭제했나요?
