### PR TITLE
demo 브랜치 생성 및 demo용 EC2 컨테이너 분리

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -2,7 +2,7 @@ name: 서버 배포 자동화
 
 on:
   push:
-    branches: [ "dev" ]
+    branches: [ "dev", "demo" ]
     paths:
       - 'backend/**'
 
@@ -25,6 +25,19 @@ jobs:
           ./gradlew clean build -x test
         working-directory: ./backend
 
+      - name: 배포 환경 설정 (브랜치별 분기)
+        id: set-env
+        run: |
+          if [[ "${{ github.ref_name }}" == "demo" ]]; then
+            echo "target_dir=/home/ubuntu/andlife-demo" >> $GITHUB_OUTPUT
+            echo "server_port=8081" >> $GITHUB_OUTPUT
+            echo "db_port=3307" >> $GITHUB_OUTPUT
+          else
+            echo "target_dir=/home/ubuntu/andlife" >> $GITHUB_OUTPUT
+            echo "server_port=8080" >> $GITHUB_OUTPUT
+            echo "db_port=3306" >> $GITHUB_OUTPUT
+          fi
+
       - name: 빌드 결과물과 설정 파일들을 EC2로 전송
         uses: appleboy/scp-action@master
         with:
@@ -32,7 +45,7 @@ jobs:
           username: ubuntu
           key: ${{ secrets.AWS_EC2_SSH_KEY }}
           source: "backend/build/libs/*.jar,backend/Dockerfile,backend/docker-compose.yaml"
-          target: "/home/ubuntu/andlife"
+          target: ${{ steps.set-env.outputs.target_dir }} # 동적 경로
           strip_components: 1
 
       - name: EC2에서 Docker Compose 실행
@@ -42,12 +55,8 @@ jobs:
           username: ubuntu
           key: ${{ secrets.AWS_EC2_SSH_KEY }}
           script: |
-            cd /home/ubuntu/andlife
-            export MYSQL_PASSWORD="${{ secrets.MYSQL_PASSWORD }}"
-            export R2_ACCESS_KEY="${{ secrets.R2_ACCESS_KEY }}"
-            export R2_ENDPOINT="${{ secrets.R2_ENDPOINT }}"
-            export R2_PUBLIC_URL="${{ secrets.R2_PUBLIC_URL }}"
-            export R2_SECRET_KEY="${{ secrets.R2_SECRET_KEY }}"
-
+            cd ${{ steps.set-env.outputs.target_dir }}
+            export SERVER_PORT=${{ steps.set-env.outputs.server_port }}
+            export DB_PORT=${{ steps.set-env.outputs.db_port }}
             docker compose down
             docker compose up --build -d

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -1,25 +1,22 @@
 services:
   db:
     image: mysql:8.4
-    container_name: mysql_db
+    container_name: mysql_db_${SERVER_PORT}
     restart: always
-    environment:
-      MYSQL_DATABASE: andlife
-      MYSQL_ROOT_PASSWORD: ${MYSQL_PASSWORD}
+    env_file:
+      - .env
     ports:
-      - "3306:3306"
-
+      - "${DB_PORT}:3306"
 
   app:
     build: .
+    container_name: spring_app_${SERVER_PORT}
+    restart: always
     env_file:
       - .env
-    container_name: spring_app
-    restart: always
     ports:
-      - "8080:8080"
+      - "${SERVER_PORT}:8080"
     environment:
       SPRING_DATASOURCE_URL: jdbc:mysql://db:3306/andlife?serverTimezone=UTC
-      SPRING_DATASOURCE_PASSWORD: ${MYSQL_PASSWORD}
     depends_on:
       - db


### PR DESCRIPTION
## 🔍 변경 사항
> 이번 PR에서 변경된 핵심 내용을 간단히 설명해주세요.

- EC2에서 demo / dev 두 개의 가상 서버를 띄우도록 수정

dev와 demo가 서로 같은 포트를 공유할 경우
서로 push 되는 내역에 따라 꼬일 수도 있다고 생각이 들어
컨테이너를 분리하기로 결정했습니다.

dev는 기존 IP:8080 포트이며
demo는 기존 IP:8081 포트입니다.

## 📸 스크린샷 (선택)
> UI 변경 사항이 있다면 이미지를 첨부해주세요.

## 🔗 관련 이슈
> 해당 PR과 연결된 이슈 번호를 적어주세요. (예: #1)

- #55 

## ✅ 체크리스트
- [ ] 팀 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 import는 삭제했나요?
