### PR TITLE
Feature/#62 invitation detail UI 초대장 상세 화면 구현

### DIFF
--- a/android/core/ui/src/main/kotlin/com/andlife/ui/section/detail/InvitationCardSection.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/section/detail/InvitationCardSection.kt
@@ -39,12 +39,12 @@ fun InvitationCardSection(
     isEditable: Boolean = false,
     onEditClick: () -> Unit = {},
 ) {
-    if (invitationCardUiModel == null) return
 
-    val isCardEmpty = invitationCardUiModel.contentJson.isEmpty()
-    val iconRes = if (isCardEmpty) R.drawable.ic_add_24 else R.drawable.ic_edit_24
+    if (invitationCardUiModel == null && !isEditable) return
+
+    val iconRes = if (invitationCardUiModel == null) R.drawable.ic_add_24 else R.drawable.ic_edit_24
     val buttonText =
-        if (isCardEmpty) {
+        if (invitationCardUiModel == null) {
             stringResource(R.string.txt_card_create)
         } else {
             stringResource(R.string.txt_card_edit)
@@ -100,7 +100,7 @@ fun InvitationCardSection(
                     containerColor = NachoTheme.colorScheme.backgroundSecondary,
                 ),
         ) {
-            if (isCardEmpty) {
+            if (invitationCardUiModel == null) {
                 EmptyCardGuide()
             } else {
                 Box(

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/detail/InvitationDetailSideEffect.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/detail/InvitationDetailSideEffect.kt
@@ -4,4 +4,6 @@ import com.andlife.ui.base.BaseSideEffect
 
 sealed interface InvitationDetailSideEffect : BaseSideEffect {
     data object NavigateBack : InvitationDetailSideEffect
+
+    data object ShowMapErrorSnackbar : InvitationDetailSideEffect
 }

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/detail/InvitationDetailUiEvent.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/detail/InvitationDetailUiEvent.kt
@@ -1,7 +1,21 @@
 package com.andlife.invitation.model.detail
 
 import com.andlife.ui.base.BaseUiEvent
+import kotlinx.collections.immutable.ImmutableList
 
 sealed interface InvitationDetailUiEvent : BaseUiEvent {
     data object ClickBack : InvitationDetailUiEvent
+
+    data object ClickThanksCard : InvitationDetailUiEvent
+
+    data object ClickDelete : InvitationDetailUiEvent
+
+    data class ClickImage(
+        val imageList: ImmutableList<String>,
+        val index: Int,
+    ) : InvitationDetailUiEvent
+
+    data object MapError : InvitationDetailUiEvent
+
+    data object RetryLoad : InvitationDetailUiEvent
 }

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/detail/InvitationDetailUiModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/detail/InvitationDetailUiModel.kt
@@ -1,5 +1,0 @@
-package com.andlife.invitation.model.detail
-
-data class InvitationDetailUiModel(
-    val id: Long,
-)

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/detail/InvitationDetailUiState.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/detail/InvitationDetailUiState.kt
@@ -1,8 +1,11 @@
 package com.andlife.invitation.model.detail
 
+import com.andlife.model.invitation.InvitationContentsUiModel
 import com.andlife.ui.base.BaseUiState
 
 data class InvitationDetailUiState(
-    val id: Long = 0L,
-    val isLoading: Boolean = false,
+    val isLoading: Boolean = true,
+    val isError: Boolean = false,
+    val hasThanksCard: Boolean = false,
+    val invitationContentsUiModel: InvitationContentsUiModel = InvitationContentsUiModel(),
 ) : BaseUiState

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/detail/InvitationContentsScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/detail/InvitationContentsScreen.kt
@@ -1,0 +1,95 @@
+package com.andlife.invitation.screen.detail
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.andlife.designsystem.preview.PreviewTheme
+import com.andlife.designsystem.theme.NachoTheme
+import com.andlife.invitation.model.detail.InvitationDetailUiState
+import com.andlife.ui.section.detail.AddressSection
+import com.andlife.ui.section.detail.AnnouncementSection
+import com.andlife.ui.section.detail.AuthorSection
+import com.andlife.ui.section.detail.DateSection
+import com.andlife.ui.section.detail.ImageSection
+import com.andlife.ui.section.detail.InvitationCardSection
+import com.andlife.ui.section.detail.PlaceGuideSection
+import com.andlife.ui.section.detail.TitleSection
+
+
+@Composable
+fun InvitationContentsScreen(
+    uiState: InvitationDetailUiState,
+    onClickImage: (Int) -> Unit,
+    onMapError: () -> Unit,
+    isMapVisible: Boolean,
+    modifier: Modifier = Modifier,
+) {
+    val model = uiState.invitationContentsUiModel
+    val scrollState = rememberScrollState()
+
+    Column(
+        modifier =
+            modifier
+                .fillMaxSize()
+                .background(NachoTheme.colorScheme.backgroundTertiary)
+                .verticalScroll(scrollState),
+    ) {
+        ImageSection(
+            imageUrls = model.imageList,
+            onImageClick = onClickImage,
+        )
+
+        TitleSection(
+            title = model.title,
+        )
+
+        AuthorSection(
+            profileUrl = model.hostInfo.profileUrl,
+            author = model.hostInfo.name,
+        )
+
+        DateSection(
+            dateTime = model.dateTime,
+        )
+
+        AddressSection(
+            placeName = model.location.name,
+            placeAddress = model.location.address,
+        )
+
+        InvitationCardSection(
+            invitationCardUiModel = model.invitationCard,
+            isEditable = false,
+        )
+
+        AnnouncementSection(
+            announcements = model.announcement,
+        )
+
+        PlaceGuideSection(
+            location = model.location,
+            onMapError = onMapError,
+            isMapVisible = isMapVisible,
+        )
+    }
+}
+
+@PreviewTheme
+@Composable
+private fun InvitationContentsScreenPreview() {
+    NachoTheme {
+        InvitationContentsScreen(
+            uiState =
+                InvitationDetailUiState(
+                    isLoading = false,
+                ),
+            onClickImage = {},
+            onMapError = {},
+            isMapVisible = true,
+        )
+    }
+}

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/detail/InvitationDetailScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/detail/InvitationDetailScreen.kt
@@ -1,21 +1,35 @@
 package com.andlife.invitation.screen.detail
 
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.andlife.designsystem.theme.NachoSpacing
@@ -27,11 +41,13 @@ import com.andlife.invitation.model.detail.InvitationDetailUiState
 import com.andlife.invitation.screen.guestbook.InvitationCollectionRoute
 import com.andlife.invitation.viewmodel.InvitationDetailViewModel
 import com.andlife.ui.component.GenericTabRow
+import com.andlife.ui.component.loading.InvitationLoadingError
+import com.andlife.ui.component.loading.InvitationLoadingIndicator
 import com.andlife.ui.util.collectWithLifecycle
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import com.andlife.designsystem.R as designR
-
-private const val TAG = "InvitationDetailScreen"
 
 @Composable
 fun InvitationDetailRoute(
@@ -40,17 +56,28 @@ fun InvitationDetailRoute(
     viewModel: InvitationDetailViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val snackbarHostState = remember { SnackbarHostState() }
+    val coroutineScope = rememberCoroutineScope()
+    val mapErrorMessage = stringResource(R.string.snack_load_error_map)
 
     viewModel.effectFlow.collectWithLifecycle { effect ->
         when (effect) {
             InvitationDetailSideEffect.NavigateBack -> {
                 onNavigateBack()
             }
+            InvitationDetailSideEffect.ShowMapErrorSnackbar -> {
+                coroutineScope.launch {
+                    snackbarHostState.showSnackbar(
+                        message = mapErrorMessage
+                    )
+                }
+            }
         }
     }
 
     InvitationDetailScreen(
         uiState = uiState,
+        snackbarHostState = snackbarHostState,
         onEvent = viewModel::onEvent,
         modifier = modifier,
     )
@@ -59,37 +86,92 @@ fun InvitationDetailRoute(
 @Composable
 private fun InvitationDetailScreen(
     uiState: InvitationDetailUiState,
+    snackbarHostState: SnackbarHostState,
     onEvent: (InvitationDetailUiEvent) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val tabTitles = stringArrayResource(R.array.txt_tap_title).toImmutableList()
+    val coroutineScope = rememberCoroutineScope()
+    var isMapVisible by remember { mutableStateOf(true) }
+
+    val navigateBackWithMapCleanup: () -> Unit = {
+        isMapVisible = false
+        coroutineScope.launch {
+            delay(50L)
+            onEvent(InvitationDetailUiEvent.ClickBack)
+        }
+    }
+
+    BackHandler(onBack = navigateBackWithMapCleanup)
 
     Scaffold(
         modifier = modifier.fillMaxSize(),
+        snackbarHost = {
+            SnackbarHost(snackbarHostState)
+        },
         topBar = {
             InvitationDetailTopBar(
-                title = "초대장 id: ${uiState.id}", // TODO: topbar 임시 제목
-                onBack = { onEvent(InvitationDetailUiEvent.ClickBack) },
+                title = uiState.invitationContentsUiModel.title,
+                hasThanksCard = uiState.hasThanksCard,
+                showActions = !uiState.isLoading && !uiState.isError,
+                onBack = navigateBackWithMapCleanup,
+                onClickThanksCard = { onEvent(InvitationDetailUiEvent.ClickThanksCard) },
+                onDelete = { onEvent(InvitationDetailUiEvent.ClickDelete) },
             )
         },
         containerColor = NachoTheme.colorScheme.backgroundPrimary,
     ) { paddingValues ->
+        if (uiState.isLoading) {
+            InvitationLoadingIndicator(
+                modifier = Modifier
+                    .padding(paddingValues),
+                text = stringResource(R.string.txt_loading_invitation),
+            )
+            return@Scaffold
+        }
+
+        if (uiState.isError) {
+            InvitationLoadingError(
+                onRetry = { onEvent(InvitationDetailUiEvent.RetryLoad) },
+                modifier = Modifier
+                    .fillMaxSize()
+                    .padding(paddingValues),
+            )
+            return@Scaffold
+        }
+
         Column(
             modifier =
                 Modifier
                     .fillMaxSize()
                     .padding(paddingValues)
-                    .padding(horizontal = NachoSpacing.medium),
         ) {
             GenericTabRow(
                 tabs = tabTitles,
-                content = { index ->
+                content =
+                    { index ->
                     when (index) {
-                        0 -> Text("초대장 콘텐츠")
+                        0 -> {
+                            InvitationContentsScreen(
+                                uiState = uiState,
+                                onClickImage =
+                                    { idx ->
+                                        onEvent(
+                                            InvitationDetailUiEvent.ClickImage(
+                                                uiState.invitationContentsUiModel.imageList,
+                                                idx,
+                                            ),
+                                        )
+                                    },
+                                onMapError = { onEvent(InvitationDetailUiEvent.MapError) },
+                                isMapVisible = isMapVisible,
+                                modifier = Modifier.fillMaxSize(),
+                            )
+                        }
                         1 -> Text("방명록 화면")
                         2 ->
                             InvitationCollectionRoute(
-                                uiState.id,
+                                //uiState.id,
                             )
                     }
                 },
@@ -103,7 +185,11 @@ private fun InvitationDetailScreen(
 private fun InvitationDetailTopBar(
     title: String,
     onBack: () -> Unit,
+    onClickThanksCard: () -> Unit,
+    onDelete: () -> Unit,
     modifier: Modifier = Modifier,
+    showActions: Boolean = true,
+    hasThanksCard: Boolean = false,
 ) {
     TopAppBar(
         modifier = modifier,
@@ -112,6 +198,8 @@ private fun InvitationDetailTopBar(
                 text = title,
                 style = NachoTheme.typography.headingSmallSemiBold,
                 color = NachoTheme.colorScheme.textPrimary,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis,
             )
         },
         navigationIcon = {
@@ -123,9 +211,67 @@ private fun InvitationDetailTopBar(
                 )
             }
         },
+        actions = {
+            if (showActions) {
+                if (hasThanksCard) {
+                    IconButton(onClick = onClickThanksCard) {
+                        Icon(
+                            painter = painterResource(designR.drawable.ic_thankscard),
+                            contentDescription = stringResource(R.string.desc_top_bar_thanks_card),
+                            tint = Color.Unspecified,
+                        )
+                    }
+                }
+                InvitationMoreMenu(
+                    onDelete = onDelete,
+                )
+            }
+        },
         colors =
             TopAppBarDefaults.topAppBarColors(
                 containerColor = NachoTheme.colorScheme.backgroundPrimary,
             ),
     )
 }
+
+
+@Composable
+private fun InvitationMoreMenu(
+    onDelete: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    var isMenuExpanded by remember { mutableStateOf(false) }
+
+    Box(modifier = modifier) {
+        IconButton(onClick = { isMenuExpanded = true }) {
+            Icon(
+                painter = painterResource(designR.drawable.ic_more_vert_24),
+                contentDescription = stringResource(R.string.desc_top_bar_more),
+                tint = NachoTheme.colorScheme.iconSecondary,
+            )
+        }
+
+        DropdownMenu(
+            expanded = isMenuExpanded,
+            onDismissRequest = { isMenuExpanded = false },
+            modifier = Modifier.background(NachoTheme.colorScheme.backgroundPrimary),
+            shape = RoundedCornerShape(NachoSpacing.medium),
+        ) {
+
+            DropdownMenuItem(
+                text = {
+                    Text(
+                        text = stringResource(R.string.txt_delete),
+                        style = NachoTheme.typography.bodyMediumMedium,
+                        color = NachoTheme.colorScheme.textPrimary,
+                    )
+                },
+                onClick = {
+                    isMenuExpanded = false
+                    onDelete()
+                },
+            )
+        }
+    }
+}
+

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/detail/InvitationDetailScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/detail/InvitationDetailScreen.kt
@@ -65,6 +65,7 @@ fun InvitationDetailRoute(
             InvitationDetailSideEffect.NavigateBack -> {
                 onNavigateBack()
             }
+
             InvitationDetailSideEffect.ShowMapErrorSnackbar -> {
                 coroutineScope.launch {
                     snackbarHostState.showSnackbar(
@@ -123,8 +124,7 @@ private fun InvitationDetailScreen(
     ) { paddingValues ->
         if (uiState.isLoading) {
             InvitationLoadingIndicator(
-                modifier = Modifier
-                    .padding(paddingValues),
+                modifier = Modifier.padding(paddingValues),
                 text = stringResource(R.string.txt_loading_invitation),
             )
             return@Scaffold
@@ -141,38 +141,33 @@ private fun InvitationDetailScreen(
         }
 
         Column(
-            modifier =
-                Modifier
-                    .fillMaxSize()
-                    .padding(paddingValues)
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues)
         ) {
             GenericTabRow(
                 tabs = tabTitles,
-                content =
-                    { index ->
+                content = { index ->
                     when (index) {
                         0 -> {
                             InvitationContentsScreen(
                                 uiState = uiState,
-                                onClickImage =
-                                    { idx ->
-                                        onEvent(
-                                            InvitationDetailUiEvent.ClickImage(
-                                                uiState.invitationContentsUiModel.imageList,
-                                                idx,
-                                            ),
-                                        )
-                                    },
+                                onClickImage = { idx ->
+                                    onEvent(
+                                        InvitationDetailUiEvent.ClickImage(
+                                            uiState.invitationContentsUiModel.imageList,
+                                            idx,
+                                        ),
+                                    )
+                                },
                                 onMapError = { onEvent(InvitationDetailUiEvent.MapError) },
                                 isMapVisible = isMapVisible,
                                 modifier = Modifier.fillMaxSize(),
                             )
                         }
+
                         1 -> Text("방명록 화면")
-                        2 ->
-                            InvitationCollectionRoute(
-                                //uiState.id,
-                            )
+                        2 -> InvitationCollectionRoute()
                     }
                 },
             )
@@ -227,10 +222,9 @@ private fun InvitationDetailTopBar(
                 )
             }
         },
-        colors =
-            TopAppBarDefaults.topAppBarColors(
-                containerColor = NachoTheme.colorScheme.backgroundPrimary,
-            ),
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = NachoTheme.colorScheme.backgroundPrimary,
+        ),
     )
 }
 

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationCollectionScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationCollectionScreen.kt
@@ -1,7 +1,6 @@
 package com.andlife.invitation.screen.guestbook
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.window.Dialog
@@ -24,14 +23,9 @@ import kotlinx.datetime.toLocalDateTime
 
 @Composable
 fun InvitationCollectionRoute(
-    invitationId: Long,
     modifier: Modifier = Modifier,
     viewModel: InvitationCollectionViewModel = hiltViewModel(),
 ) {
-    LaunchedEffect(invitationId) {
-        viewModel.initInvitationId(invitationId)
-    }
-
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     InvitationCollectionScreen(

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationCollectionViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationCollectionViewModel.kt
@@ -1,10 +1,13 @@
 package com.andlife.invitation.viewmodel
 
 import android.util.Log
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
 import com.andlife.domain.repository.guestbook.GuestBookRepository
 import com.andlife.domain.util.onFailure
 import com.andlife.domain.util.onSuccess
+import com.andlife.invitation.InvitationDetail
 import com.andlife.invitation.model.guestbook.collection.InvitationCollectionSideEffect
 import com.andlife.invitation.model.guestbook.collection.InvitationCollectionUiEvent
 import com.andlife.invitation.model.guestbook.collection.InvitationCollectionUiState
@@ -12,94 +15,97 @@ import com.andlife.invitation.model.guestbook.collection.toUiModel
 import com.andlife.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
-import kotlin.properties.Delegates
 
 @HiltViewModel
-class InvitationCollectionViewModel
-    @Inject
-    constructor(
-        private val guestBookRepository: GuestBookRepository,
-    ) : BaseViewModel<InvitationCollectionUiState, InvitationCollectionUiEvent, InvitationCollectionSideEffect>(
-            initialState = InvitationCollectionUiState(),
-        ) {
-        private var invitationId: Long by Delegates.notNull<Long>()
+class InvitationCollectionViewModel @Inject constructor(
+    savedStateHandle: SavedStateHandle,
+    private val guestBookRepository: GuestBookRepository,
+) : BaseViewModel<InvitationCollectionUiState, InvitationCollectionUiEvent, InvitationCollectionSideEffect>(
+    initialState = InvitationCollectionUiState(),
+) {
 
-        override val uiState: StateFlow<InvitationCollectionUiState> = mutableUiState
+    private val invitationId: Long = savedStateHandle.toRoute<InvitationDetail>().id
 
-        override fun onEvent(event: InvitationCollectionUiEvent) {
-            when (event) {
-                is InvitationCollectionUiEvent.OpenStory -> openStory(event.index)
-                is InvitationCollectionUiEvent.CloseStory -> closeStory()
-                is InvitationCollectionUiEvent.PageChanged -> pageChanged(event.index)
-                is InvitationCollectionUiEvent.ToggleExpand -> toggleExpand()
-            }
-        }
+    override val uiState: StateFlow<InvitationCollectionUiState> =
+        mutableUiState
+            .onStart {
+                loadMediaCollection()
+            }.stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5_000),
+                initialValue = InvitationCollectionUiState(),
+            )
 
-        fun initInvitationId(id: Long) {
-            runCatching { invitationId }.onSuccess { if (it == id) return }
-
-            invitationId = id
-            loadMediaCollection()
-        }
-
-        private fun loadMediaCollection() {
-            viewModelScope.launch {
-                Log.d("ViewModel", "id:$invitationId")
-                updateState { copy(isLoading = true) }
-
-                guestBookRepository
-                    .getMediaCollection(invitationId)
-                    .onSuccess { mediaList ->
-                        updateState {
-                            copy(
-                                isLoading = false,
-                                mediaItems = mediaList.map { it.toUiModel() }.toImmutableList(),
-                            )
-                        }
-                        Log.d("ViewModel", "미디어 리스트: $mediaList")
-                    }.onFailure {
-                        updateState { copy(isLoading = false) }
-                        Log.e("ViewModel", "에러 발생: $it")
-                    }
-            }
-        }
-
-        private fun openStory(index: Int) {
-            updateState {
-                copy(
-                    isDetailMode = true,
-                    selectedIndex = index,
-                )
-            }
-            Log.d("ViewModel", "선택된 인덱스: $index")
-        }
-
-        private fun closeStory() {
-            updateState {
-                copy(
-                    isDetailMode = false,
-                    selectedIndex = -1,
-                )
-            }
-        }
-
-        private fun pageChanged(index: Int) {
-            updateState {
-                copy(
-                    selectedIndex = index,
-                )
-            }
-            Log.d("ViewModel", "바뀐 인덱스: $index")
-        }
-
-        private fun toggleExpand() {
-            updateState {
-                copy(
-                    isTextExpanded = !isTextExpanded,
-                )
-            }
+    override fun onEvent(event: InvitationCollectionUiEvent) {
+        when (event) {
+            is InvitationCollectionUiEvent.OpenStory -> openStory(event.index)
+            is InvitationCollectionUiEvent.CloseStory -> closeStory()
+            is InvitationCollectionUiEvent.PageChanged -> pageChanged(event.index)
+            is InvitationCollectionUiEvent.ToggleExpand -> toggleExpand()
         }
     }
+
+    private fun loadMediaCollection() {
+        viewModelScope.launch {
+            Log.d("ViewModel", "id:$invitationId")
+            updateState { copy(isLoading = true) }
+
+            guestBookRepository
+                .getMediaCollection(invitationId)
+                .onSuccess { mediaList ->
+                    updateState {
+                        copy(
+                            isLoading = false,
+                            mediaItems = mediaList.map { it.toUiModel() }.toImmutableList(),
+                        )
+                    }
+                    Log.d("ViewModel", "미디어 리스트: $mediaList")
+                }.onFailure {
+                    updateState { copy(isLoading = false) }
+                    Log.e("ViewModel", "에러 발생: $it")
+                }
+        }
+    }
+
+    private fun openStory(index: Int) {
+        updateState {
+            copy(
+                isDetailMode = true,
+                selectedIndex = index,
+            )
+        }
+        Log.d("ViewModel", "선택된 인덱스: $index")
+    }
+
+    private fun closeStory() {
+        updateState {
+            copy(
+                isDetailMode = false,
+                selectedIndex = -1,
+            )
+        }
+    }
+
+    private fun pageChanged(index: Int) {
+        updateState {
+            copy(
+                selectedIndex = index,
+            )
+        }
+        Log.d("ViewModel", "바뀐 인덱스: $index")
+    }
+
+    private fun toggleExpand() {
+        updateState {
+            copy(
+                isTextExpanded = !isTextExpanded,
+            )
+        }
+    }
+}

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationDetailViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationDetailViewModel.kt
@@ -4,12 +4,17 @@ import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
+import com.andlife.domain.repository.invitation.InvitationRepository
+import com.andlife.domain.util.onFailure
+import com.andlife.domain.util.onSuccess
 import com.andlife.invitation.InvitationDetail
 import com.andlife.invitation.model.detail.InvitationDetailSideEffect
 import com.andlife.invitation.model.detail.InvitationDetailUiEvent
 import com.andlife.invitation.model.detail.InvitationDetailUiState
+import com.andlife.model.invitation.toContentsUiModel
 import com.andlife.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.onStart
@@ -20,6 +25,7 @@ import javax.inject.Inject
 @HiltViewModel
 class InvitationDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
+    private val invitationRepository: InvitationRepository,
 ) : BaseViewModel<InvitationDetailUiState, InvitationDetailUiEvent, InvitationDetailSideEffect>(
     initialState = InvitationDetailUiState(),
 ) {
@@ -28,7 +34,7 @@ class InvitationDetailViewModel @Inject constructor(
     override val uiState: StateFlow<InvitationDetailUiState> =
         mutableUiState
             .onStart {
-                loadInvitationDetail()
+                loadInvitation()
             }
             .stateIn(
                 scope = viewModelScope,
@@ -36,24 +42,53 @@ class InvitationDetailViewModel @Inject constructor(
                 initialValue = InvitationDetailUiState()
             )
 
-    private fun loadInvitationDetail() {
+    private suspend fun loadInvitation() {
+        updateState { copy(isLoading = true, isError = false) }
 
-        viewModelScope.launch {
-            // TODO: 초대장 상세 정보 로드 구현 필요
-            // - Repository를 통해 초대장 정보 조회 (invitationId 사용)
-            // - API 호출 후 uiState 업데이트
-            Log.d("DeepLink", "전달받은 ID: $invitationId")
-            updateState { copy(id = invitationId) }
-        }
+        invitationRepository.getInvitation(invitationId)
+            .onSuccess { invitation ->
+                updateState {
+                    copy(
+                        isLoading = false,
+                        isError = false,
+                        hasThanksCard = false, // TODO: 감사카드 존재 여부는 별도 API로 확인 필요
+                        invitationContentsUiModel = invitation.toContentsUiModel(),
+                    )
+                }
+            }.onFailure {
+                updateState { copy(isLoading = false, isError = true) }
+                Log.e("InvitationDetailViewModel", "에러 발생: $it")
+            }
     }
 
     override fun onEvent(event: InvitationDetailUiEvent) {
         when (event) {
             is InvitationDetailUiEvent.ClickBack -> clickClose()
+            is InvitationDetailUiEvent.ClickThanksCard -> showThanksCardOnboarding()
+            is InvitationDetailUiEvent.ClickDelete -> deleteInvitation()
+            is InvitationDetailUiEvent.ClickImage -> navigateToFullScreenImage(event.imageList, event.index)
+            is InvitationDetailUiEvent.MapError -> showMapErrorSnackbar()
+            is InvitationDetailUiEvent.RetryLoad -> retryLoad()
         }
     }
 
     private fun clickClose() {
         sendEffect(InvitationDetailSideEffect.NavigateBack)
+    }
+
+    private fun deleteInvitation() { /* TODO: 초대장 삭제 로직 */ }
+
+    private fun showThanksCardOnboarding() { /* TODO: 감사카드 온보딩 */ }
+
+    private fun navigateToFullScreenImage(imageList: ImmutableList<String>, index: Int) { /* TODO: 이미지 풀스크린*/ }
+
+    private fun showMapErrorSnackbar() {
+        sendEffect(InvitationDetailSideEffect.ShowMapErrorSnackbar)
+    }
+
+    private fun retryLoad() {
+        viewModelScope.launch {
+            loadInvitation()
+        }
     }
 }

--- a/android/feature/invitation/src/main/res/values/strings.xml
+++ b/android/feature/invitation/src/main/res/values/strings.xml
@@ -1,12 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <string name="desc_top_bar_back">초대장 상세 창을 닫는 뒤로가기 아이콘 버튼</string>
+    <string name="desc_top_bar_thanks_card">초대장 상세 감사카드 아이콘 버튼</string>
+    <string name="desc_top_bar_more">초대장 상세 더보기 아이콘 버튼</string>
 
-    <!--  방명록 페이지 상단 탭  -->
+    <string name="txt_delete">삭제하기</string>
+
+    <string name="txt_loading_invitation">초대장을 불러오는 중...</string>
+
     <string-array name="txt_tap_title">
         <item>초대장</item>
         <item>방명록</item>
         <item>모아보기</item>
     </string-array>
+
+    <string name="snack_load_error_map">설치된 지도 앱이 없습니다.</string>
 </resources>
 


### PR DESCRIPTION
## 🔍 변경 사항
- #41  #60
- 위의 나의 초대 상세 PR과 유사하며, 각 Section 재사용하여 초대장 상세화면 구현하였습니다.
- 나의 초대와 초대장 상세화면의 차이점
  - 상단 탑바 공유 버튼 없음
  - 초대카드 없을시 해당 영역 보여지지 않음

## 📸 스크린샷
<p align="center">
  <img src="https://github.com/user-attachments/assets/746daa9d-7188-4d84-9a43-f850bebb517f" width="45%">
  <img src="https://github.com/user-attachments/assets/9f2595c0-3df0-411a-9cc3-4b7c4f919c2e" width="45%">
</p>

## 🔗 관련 이슈
- Close #62 

## ✅ 체크리스트
- [x] 팀 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 import는 삭제했나요?
