### PR TITLE
Feature/#75 방명록 수정/삭제 구현

### DIFF
--- a/android/core/data/src/main/kotlin/com/andlife/data/datasource/remote/invitation/guestbook/GuestBookRemoteDataSource.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/datasource/remote/invitation/guestbook/GuestBookRemoteDataSource.kt
@@ -23,4 +23,6 @@ interface GuestBookRemoteDataSource {
         guestBookId: Long,
         request: UpdateGuestBookRequest
     ): Result<GuestBookResponse, DataError>
+
+    suspend fun deleteGuestBook(guestBookId: Long): Result<Long, DataError>
 }

--- a/android/core/data/src/main/kotlin/com/andlife/data/datasource/remote/invitation/guestbook/GuestBookRemoteDataSource.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/datasource/remote/invitation/guestbook/GuestBookRemoteDataSource.kt
@@ -4,6 +4,7 @@ import com.andlife.domain.error.DataError
 import com.andlife.domain.util.Result
 import com.andlife.network.api.guestbook.GuestBookRequest
 import com.andlife.network.api.guestbook.GuestBookResponse
+import com.andlife.network.api.guestbook.UpdateGuestBookRequest
 import com.andlife.network.model.PagingResponse
 import com.andlife.network.model.invitation.guestbook.CollectionResponse
 
@@ -17,4 +18,9 @@ interface GuestBookRemoteDataSource {
     ): Result<PagingResponse<GuestBookResponse>, DataError>
 
     suspend fun createGuestBook(invitationId: Long, request: GuestBookRequest): Result<GuestBookResponse, DataError>
+
+    suspend fun updateGuestBook(
+        guestBookId: Long,
+        request: UpdateGuestBookRequest
+    ): Result<GuestBookResponse, DataError>
 }

--- a/android/core/data/src/main/kotlin/com/andlife/data/datasource/remote/invitation/guestbook/GuestBookRemoteDataSourceImpl.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/datasource/remote/invitation/guestbook/GuestBookRemoteDataSourceImpl.kt
@@ -35,4 +35,8 @@ internal class GuestBookRemoteDataSourceImpl @Inject constructor(
         request: UpdateGuestBookRequest
     ): Result<GuestBookResponse, DataError> =
         apiCall { guestBookService.updateGuestBook(guestBookId, request) }
+
+    override suspend fun deleteGuestBook(guestBookId: Long): Result<Long, DataError> =
+        apiCall { guestBookService.deleteGuestBook(guestBookId) }
+
 }

--- a/android/core/data/src/main/kotlin/com/andlife/data/datasource/remote/invitation/guestbook/GuestBookRemoteDataSourceImpl.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/datasource/remote/invitation/guestbook/GuestBookRemoteDataSourceImpl.kt
@@ -6,6 +6,7 @@ import com.andlife.domain.util.Result
 import com.andlife.network.api.guestbook.GuestBookRequest
 import com.andlife.network.api.guestbook.GuestBookResponse
 import com.andlife.network.api.guestbook.GuestBookService
+import com.andlife.network.api.guestbook.UpdateGuestBookRequest
 import com.andlife.network.model.PagingResponse
 import com.andlife.network.model.invitation.guestbook.CollectionResponse
 import javax.inject.Inject
@@ -28,4 +29,10 @@ internal class GuestBookRemoteDataSourceImpl @Inject constructor(
         request: GuestBookRequest
     ): Result<GuestBookResponse, DataError> =
         apiCall { guestBookService.createGuestBook(invitationId, request) }
+
+    override suspend fun updateGuestBook(
+        guestBookId: Long,
+        request: UpdateGuestBookRequest
+    ): Result<GuestBookResponse, DataError> =
+        apiCall { guestBookService.updateGuestBook(guestBookId, request) }
 }

--- a/android/core/data/src/main/kotlin/com/andlife/data/repository/guestbook/GuestBookRepositoryImpl.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/repository/guestbook/GuestBookRepositoryImpl.kt
@@ -79,6 +79,9 @@ internal class GuestBookRepositoryImpl @Inject constructor(
         return result.map { it.toDomain() }
     }
 
+    override suspend fun deleteGuestBook(guestBookId: Long): Result<Long, DataError> =
+        guestBookRemoteDataSource.deleteGuestBook(guestBookId)
+
     companion object {
         private const val PAGE_SIZE = 10
     }

--- a/android/core/data/src/main/kotlin/com/andlife/data/repository/guestbook/GuestBookRepositoryImpl.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/repository/guestbook/GuestBookRepositoryImpl.kt
@@ -13,6 +13,7 @@ import com.andlife.domain.repository.guestbook.GuestBookRepository
 import com.andlife.domain.util.Result
 import com.andlife.domain.util.map
 import com.andlife.network.api.guestbook.GuestBookRequest
+import com.andlife.network.api.guestbook.UpdateGuestBookRequest
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
@@ -55,6 +56,26 @@ internal class GuestBookRepositoryImpl @Inject constructor(
                 medias = medias.map { it.toRequest() },
             )
         val result = guestBookRemoteDataSource.createGuestBook(invitationId, request)
+        return result.map { it.toDomain() }
+    }
+
+    override suspend fun updateGuestBook(
+        guestBookId: Long,
+        textContent: String,
+        existingImageIds: List<Long>,
+        existingVideoIds: List<Long>,
+        existingAudioIds: List<Long>,
+        newMedias: List<GuestBookMedia>
+    ): Result<GuestBook, DataError> {
+        val request =
+            UpdateGuestBookRequest(
+                textContent = textContent,
+                existingImageIds = existingImageIds,
+                existingVideoIds = existingVideoIds,
+                existingAudioIds = existingAudioIds,
+                newMedias = newMedias.map { it.toRequest() },
+            )
+        val result = guestBookRemoteDataSource.updateGuestBook(guestBookId, request)
         return result.map { it.toDomain() }
     }
 

--- a/android/core/network/src/main/kotlin/com/andlife/network/api/guestbook/GuestBookService.kt
+++ b/android/core/network/src/main/kotlin/com/andlife/network/api/guestbook/GuestBookService.kt
@@ -6,6 +6,7 @@ import com.andlife.network.model.invitation.guestbook.CollectionResponse
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
+import retrofit2.http.PUT
 import retrofit2.http.Path
 import retrofit2.http.Query
 
@@ -26,5 +27,11 @@ interface GuestBookService {
     suspend fun createGuestBook(
         @Path("invitationId") invitationId: Long,
         @Body request: GuestBookRequest,
+    ): BaseResponse<GuestBookResponse>
+
+    @PUT("/api/guestbooks/{guestBookId}")
+    suspend fun updateGuestBook(
+        @Path("guestBookId") guestBookId: Long,
+        @Body request: UpdateGuestBookRequest,
     ): BaseResponse<GuestBookResponse>
 }

--- a/android/core/network/src/main/kotlin/com/andlife/network/api/guestbook/GuestBookService.kt
+++ b/android/core/network/src/main/kotlin/com/andlife/network/api/guestbook/GuestBookService.kt
@@ -4,6 +4,7 @@ import com.andlife.network.model.BaseResponse
 import com.andlife.network.model.PagingResponse
 import com.andlife.network.model.invitation.guestbook.CollectionResponse
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.PUT
@@ -34,4 +35,9 @@ interface GuestBookService {
         @Path("guestBookId") guestBookId: Long,
         @Body request: UpdateGuestBookRequest,
     ): BaseResponse<GuestBookResponse>
+
+    @DELETE("/api/guestbooks/{guestBookId}")
+    suspend fun deleteGuestBook(
+        @Path("guestBookId") guestBookId: Long,
+    ): BaseResponse<Long>
 }

--- a/android/core/network/src/main/kotlin/com/andlife/network/api/guestbook/UpdateGuestBookRequest.kt
+++ b/android/core/network/src/main/kotlin/com/andlife/network/api/guestbook/UpdateGuestBookRequest.kt
@@ -1,0 +1,9 @@
+package com.andlife.network.api.guestbook
+
+data class UpdateGuestBookRequest(
+    val textContent: String,
+    val existingImageIds: List<Long>,
+    val existingVideoIds: List<Long>,
+    val existingAudioIds: List<Long>,
+    val newMedias: List<GuestBookMediaRequest>,
+)

--- a/android/core/network/src/main/kotlin/com/andlife/network/api/guestbook/UpdateGuestBookRequest.kt
+++ b/android/core/network/src/main/kotlin/com/andlife/network/api/guestbook/UpdateGuestBookRequest.kt
@@ -1,5 +1,11 @@
+@file:OptIn(InternalSerializationApi::class)
+
 package com.andlife.network.api.guestbook
 
+import kotlinx.serialization.InternalSerializationApi
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class UpdateGuestBookRequest(
     val textContent: String,
     val existingImageIds: List<Long>,

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/guestbook/GuestBookItem.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/guestbook/GuestBookItem.kt
@@ -83,13 +83,25 @@ fun GuestBookItem(
     onAudioMediaClick: (GuestBookMediaUiModel) -> Unit,
     modifier: Modifier = Modifier,
     shouldPlayVideo: Boolean = false,
+    isEditing: Boolean = false,
     onMenuClick: () -> Unit = {},
-    onEditClick: (Long) -> Unit = {},
-    onDeleteClick: (Long) -> Unit = {},
+    onEditClick: (GuestBookUiModel) -> Unit = {},
+    onDeleteClick: (GuestBookUiModel) -> Unit = {},
     onInvitationTitleClick: (Long) -> Unit? = {},
 ) {
+    val backgroundColor = if (isEditing) {
+        NachoTheme.colorScheme.backgroundBorder
+    } else {
+        NachoTheme.colorScheme.backgroundPrimary
+    }
+
     Column(
-        modifier = modifier,
+        modifier = modifier
+            .fillMaxWidth()
+            .background(
+                color = backgroundColor,
+                shape = NachoTheme.shapes.medium,
+            ),
         verticalArrangement = Arrangement.spacedBy(NachoSpacing.medium),
     ) {
         GuestBookItemHeader(
@@ -97,8 +109,8 @@ fun GuestBookItem(
             createdAt = guestBook.createdAt,
             isOwner = guestBook.isOwner,
             onMenuClick = onMenuClick,
-            onEditClick = { onEditClick(guestBook.id) },
-            onDeleteClick = { onDeleteClick(guestBook.id) },
+            onEditClick = { onEditClick(guestBook) },
+            onDeleteClick = { onDeleteClick(guestBook) },
         )
         GuestBookItemTextSection(
             invitation = guestBook.invitation,

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/guestbook/GuestBookItem.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/guestbook/GuestBookItem.kt
@@ -15,10 +15,12 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -79,9 +81,11 @@ fun GuestBookItem(
     videoPlayerPool: AutoVideoPlayerPool,
     onVisualMediaClick: (GuestBookMediaUiModel) -> Unit,
     onAudioMediaClick: (GuestBookMediaUiModel) -> Unit,
-    onMenuClick: () -> Unit,
     modifier: Modifier = Modifier,
     shouldPlayVideo: Boolean = false,
+    onMenuClick: () -> Unit = {},
+    onEditClick: (Long) -> Unit = {},
+    onDeleteClick: (Long) -> Unit = {},
     onInvitationTitleClick: (Long) -> Unit? = {},
 ) {
     Column(
@@ -93,6 +97,8 @@ fun GuestBookItem(
             createdAt = guestBook.createdAt,
             isOwner = guestBook.isOwner,
             onMenuClick = onMenuClick,
+            onEditClick = { onEditClick(guestBook.id) },
+            onDeleteClick = { onDeleteClick(guestBook.id) },
         )
         GuestBookItemTextSection(
             invitation = guestBook.invitation,
@@ -135,9 +141,13 @@ private fun GuestBookItemHeader(
     author: AuthorUiModel,
     createdAt: LocalDateTime,
     isOwner: Boolean,
+    onEditClick: () -> Unit,
+    onDeleteClick: () -> Unit,
     onMenuClick: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    var isMenuExpanded by remember { mutableStateOf(false) }
+
     Row(
         modifier = modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.spacedBy(NachoSpacing.small),
@@ -170,12 +180,48 @@ private fun GuestBookItemHeader(
             )
         }
         if (isOwner) {
-            IconButton(onClick = onMenuClick) {
-                Icon(
-                    painter = painterResource(R.drawable.ic_more_vert_24),
-                    contentDescription = stringResource(R.string.desc_edit_guest_book),
-                    tint = NachoTheme.colorScheme.textPrimary,
-                )
+            Box {
+                IconButton(onClick = { isMenuExpanded = true }) {
+                    Icon(
+                        painter = painterResource(R.drawable.ic_more_vert_24),
+                        contentDescription = stringResource(R.string.desc_edit_guest_book),
+                        tint = NachoTheme.colorScheme.textPrimary,
+                    )
+                }
+                DropdownMenu(
+                    expanded = isMenuExpanded,
+                    onDismissRequest = { isMenuExpanded = false },
+                    modifier = Modifier.width(200.dp),
+                    containerColor = NachoTheme.colorScheme.backgroundPrimary,
+                    shape = NachoTheme.shapes.medium,
+                ) {
+                    Text(
+                        text = stringResource(R.string.txt_label_edit),
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    isMenuExpanded = false
+                                    onEditClick()
+                                }
+                                .padding(NachoSpacing.large),
+                        style = NachoTheme.typography.bodyMediumMedium,
+                        color = NachoTheme.colorScheme.textPrimary,
+                    )
+                    Text(
+                        text = stringResource(R.string.txt_label_delete),
+                        modifier =
+                            Modifier
+                                .fillMaxWidth()
+                                .clickable {
+                                    isMenuExpanded = false
+                                    onDeleteClick()
+                                }
+                                .padding(NachoSpacing.large),
+                        style = NachoTheme.typography.bodyMediumMedium,
+                        color = NachoTheme.colorScheme.textPrimary,
+                    )
+                }
             }
         }
     }
@@ -406,6 +452,7 @@ private fun VideoPlayerContainer(
                     override fun onRenderedFirstFrame() {
                         isVideoReady = true
                     }
+
                     override fun onPlaybackStateChanged(state: Int) {
                         if (state == Player.STATE_READY && currentPlayer.exoPlayer.playWhenReady) {
                             isVideoReady = true
@@ -646,6 +693,8 @@ private fun GuestBookItemPreview() {
                     onVisualMediaClick = {},
                     onAudioMediaClick = {},
                     onMenuClick = {},
+                    onEditClick = {},
+                    onDeleteClick = {},
                 )
             }
         }

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/guestbook/GuestBookItem.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/guestbook/GuestBookItem.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
@@ -47,7 +46,6 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.datasource.cache.CacheDataSource
 import androidx.media3.exoplayer.ExoPlayer
 import androidx.media3.ui.AspectRatioFrameLayout
 import androidx.media3.ui.PlayerView
@@ -57,8 +55,8 @@ import com.andlife.designsystem.preview.PreviewTheme
 import com.andlife.designsystem.theme.NachoSpacing
 import com.andlife.designsystem.theme.NachoStroke
 import com.andlife.designsystem.theme.NachoTheme
+import com.andlife.media.video.AutoVideoPlayer
 import com.andlife.media.video.AutoVideoPlayerPool
-import com.andlife.media.video.AutoVideoPlayerPoolImpl
 import com.andlife.model.common.AuthorUiModel
 import com.andlife.model.guestbook.GuestBookInvitationUiModel
 import com.andlife.model.guestbook.GuestBookMediaUiModel
@@ -90,7 +88,7 @@ fun GuestBookItem(
     onInvitationTitleClick: (Long) -> Unit? = {},
 ) {
     val backgroundColor = if (isEditing) {
-        NachoTheme.colorScheme.backgroundBorder
+        NachoTheme.colorScheme.brandLight
     } else {
         NachoTheme.colorScheme.backgroundPrimary
     }
@@ -98,10 +96,8 @@ fun GuestBookItem(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .background(
-                color = backgroundColor,
-                shape = NachoTheme.shapes.medium,
-            ),
+            .background(backgroundColor)
+            .padding(horizontal = NachoSpacing.large),
         verticalArrangement = Arrangement.spacedBy(NachoSpacing.medium),
     ) {
         GuestBookItemHeader(
@@ -161,7 +157,9 @@ private fun GuestBookItemHeader(
     var isMenuExpanded by remember { mutableStateOf(false) }
 
     Row(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(top = NachoSpacing.large),
         horizontalArrangement = Arrangement.spacedBy(NachoSpacing.small),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -571,7 +569,7 @@ private fun GuestBookAudioItem(
             modifier
                 .fillMaxWidth()
                 .background(
-                    color = NachoTheme.colorScheme.brandLight,
+                    color = NachoTheme.colorScheme.backgroundSurface,
                     shape = NachoTheme.shapes.small,
                 )
                 .padding(NachoSpacing.large),
@@ -640,9 +638,7 @@ private fun GuestBookAudioItem(
 private fun GuestBookItemPreview() {
     NachoTheme {
         LazyColumn(
-            modifier =
-                Modifier
-                    .padding(NachoSpacing.large),
+            modifier = Modifier.fillMaxWidth(),
             verticalArrangement = Arrangement.spacedBy(NachoSpacing.large),
         ) {
             item {
@@ -697,10 +693,74 @@ private fun GuestBookItemPreview() {
                             createdAt = LocalDateTime(2025, 6, 1, 12, 0),
                             updatedAt = LocalDateTime(2025, 6, 1, 12, 0),
                         ),
-                    videoPlayerPool = AutoVideoPlayerPoolImpl(LocalContext.current, CacheDataSource.Factory()),
+                    videoPlayerPool = FakeAutoVideoPlayerPool(),
                     shouldPlayVideo = false,
                     isAudioPlaying = true,
                     playingAudioUrl = null,
+                    isEditing = true,
+                    onInvitationTitleClick = {},
+                    onVisualMediaClick = {},
+                    onAudioMediaClick = {},
+                    onMenuClick = {},
+                    onEditClick = {},
+                    onDeleteClick = {},
+                )
+                GuestBookItem(
+                    guestBook =
+                        GuestBookUiModel(
+                            id = 1L,
+                            invitation =
+                                GuestBookInvitationUiModel(
+                                    id = 1001L,
+                                    title = "우리 결혼해요!",
+                                ),
+                            author =
+                                AuthorUiModel(
+                                    id = 5001L,
+                                    name = "홍길동",
+                                    profileImageUrl = null,
+                                ),
+                            textContent = "축하합니다!\n 행복하세요!축하합니다! 행복하세요!축하합니다! 행복하세요!축하합니다! 행복하세요!축하합니다! 행복하세요!축하합니다! 행복하세요!축하",
+                            visualMedias =
+                                listOf(
+                                    GuestBookMediaUiModel(
+                                        id = 1L,
+                                        type = MediaUiType.IMAGE,
+                                        url = "",
+                                        thumbnailUrl = "",
+                                        durationSeconds = 34,
+                                        displayOrder = 0,
+                                    ),
+                                    GuestBookMediaUiModel(
+                                        id = 2L,
+                                        type = MediaUiType.VIDEO,
+                                        url = "",
+                                        thumbnailUrl = "",
+                                        durationSeconds = 30,
+                                        displayOrder = 1,
+                                    ),
+                                ).toImmutableList(),
+                            audioMedias =
+                                listOf(
+                                    GuestBookMediaUiModel(
+                                        id = 3L,
+                                        type = MediaUiType.AUDIO,
+                                        url = "",
+                                        thumbnailUrl = "",
+                                        durationSeconds = 45,
+                                        displayOrder = 0,
+                                    ),
+                                ).toImmutableList(),
+                            totalVisualCount = 2,
+                            isOwner = true,
+                            createdAt = LocalDateTime(2025, 6, 1, 12, 0),
+                            updatedAt = LocalDateTime(2025, 6, 1, 12, 0),
+                        ),
+                    videoPlayerPool = FakeAutoVideoPlayerPool(),
+                    shouldPlayVideo = false,
+                    isAudioPlaying = false,
+                    playingAudioUrl = null,
+                    isEditing = false,
                     onInvitationTitleClick = {},
                     onVisualMediaClick = {},
                     onAudioMediaClick = {},
@@ -711,4 +771,18 @@ private fun GuestBookItemPreview() {
             }
         }
     }
+}
+
+class FakeAutoVideoPlayerPool : AutoVideoPlayerPool {
+    override fun preparePlayers() {}
+    override fun getPlayer(url: String): AutoVideoPlayer {
+        throw NotImplementedError("Not yet implemented")
+    }
+
+    override fun playPlayer(url: String, itemId: Long) {}
+    override fun pausePlayer(url: String) {}
+    override fun pauseAllPlayers() {}
+    override fun resumeLastPlayed() {}
+    override fun resetPool() {}
+    override fun releaseAllPlayers() {}
 }

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/InvitationGuestBookForm.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/InvitationGuestBookForm.kt
@@ -16,7 +16,6 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -174,16 +173,6 @@ fun InvitationGuestBookForm(
                 enabled = isSubmittable,
             ) {
                 Box(contentAlignment = Alignment.Center) {
-//                    Text(
-//                        text = stringResource(R.string.txt_submit),
-//                        color = if (isUploading) Color.Transparent else Color.Unspecified
-//                    )
-//                    if (isUploading) {
-//                        CircularProgressIndicator(
-//                            modifier = Modifier.size(NachoIconSize.small),
-//                            color = NachoTheme.colorScheme.textDisabled,
-//                        )
-//                    }
                     if (isUploading) {
                         CircularProgressIndicator(
                             modifier = Modifier.size(NachoIconSize.small),

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/InvitationGuestBookForm.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/InvitationGuestBookForm.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -51,9 +52,16 @@ fun InvitationGuestBookForm(
     onUploadClick: () -> Unit,
     onFocusChanged: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
+    editingGuestBookId: Long? = null,
 ) {
     val context = LocalContext.current
     val focusRequester = remember { FocusRequester() }
+
+    LaunchedEffect(editingGuestBookId) {
+        if (editingGuestBookId != null) {
+            focusRequester.requestFocus()
+        }
+    }
 
     val launcher =
         rememberLauncherForActivityResult(

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/InvitationGuestBookForm.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/InvitationGuestBookForm.kt
@@ -14,8 +14,12 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.focus.onFocusChanged
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
@@ -45,9 +49,11 @@ fun InvitationGuestBookForm(
     onMediaRemove: (SelectedMedia) -> Unit,
     onTextContentChange: (String) -> Unit,
     onUploadClick: () -> Unit,
+    onFocusChanged: (Boolean) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val context = LocalContext.current
+    val focusRequester = remember { FocusRequester() }
 
     val launcher =
         rememberLauncherForActivityResult(
@@ -86,7 +92,12 @@ fun InvitationGuestBookForm(
                     }
                 },
                 placeholder = stringResource(R.string.txt_please_leave_a_message),
-                modifier = Modifier.fillMaxWidth(),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .focusRequester(focusRequester)
+                    .onFocusChanged { focusState ->
+                        onFocusChanged(focusState.isFocused)
+                    },
                 singleLine = false,
                 minLines = 3,
             )
@@ -201,6 +212,7 @@ private fun InvitationGuestBookFormPreview() {
             onMediaRemove = {},
             onTextContentChange = {},
             onUploadClick = {},
+            onFocusChanged = {},
         )
     }
 }

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/InvitationGuestBookForm.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/InvitationGuestBookForm.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -166,22 +167,19 @@ fun InvitationGuestBookForm(
                             },
                 )
             }
-
-            // 업로드 버튼
             NachoButton(
                 onClick = onUploadClick,
                 enabled = isSubmittable,
             ) {
                 Box(contentAlignment = Alignment.Center) {
+                    Text(
+                        text = stringResource(R.string.txt_submit),
+                        color = if (isUploading) Color.Transparent else Color.Unspecified
+                    )
                     if (isUploading) {
                         CircularProgressIndicator(
                             modifier = Modifier.size(NachoIconSize.small),
-                            color = NachoTheme.colorScheme.textOnPrimary,
-                        )
-                    } else {
-                        Text(
-                            text = stringResource(R.string.txt_submit),
-                            color = NachoTheme.colorScheme.textOnPrimary,
+                            color = NachoTheme.colorScheme.brandOnPrimary,
                         )
                     }
                 }

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/InvitationGuestBookForm.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/InvitationGuestBookForm.kt
@@ -25,7 +25,6 @@ import com.andlife.designsystem.component.NachoTextField
 import com.andlife.designsystem.preview.PreviewTheme
 import com.andlife.designsystem.theme.NachoIconSize
 import com.andlife.designsystem.theme.NachoSpacing
-import com.andlife.designsystem.theme.NachoStroke
 import com.andlife.designsystem.theme.NachoTheme
 import com.andlife.ui.R
 import com.andlife.ui.util.media.uriToSelectedMedia
@@ -41,6 +40,7 @@ fun InvitationGuestBookForm(
     selectedMedias: ImmutableList<SelectedMedia>,
     textContent: String,
     isUploading: Boolean,
+    isSubmittable: Boolean,
     onMediasSelected: (ImmutableList<SelectedMedia>) -> Unit,
     onMediaRemove: (SelectedMedia) -> Unit,
     onTextContentChange: (String) -> Unit,
@@ -171,17 +171,28 @@ fun InvitationGuestBookForm(
             // 업로드 버튼
             NachoButton(
                 onClick = onUploadClick,
-                enabled = (selectedMedias.isNotEmpty() || textContent.isNotEmpty()) && !isUploading,
+                enabled = isSubmittable,
             ) {
                 Box(contentAlignment = Alignment.Center) {
-                    Text(
-                        text = stringResource(R.string.txt_submit),
-                        color = if (isUploading) Color.Transparent else Color.Unspecified
-                    )
+//                    Text(
+//                        text = stringResource(R.string.txt_submit),
+//                        color = if (isUploading) Color.Transparent else Color.Unspecified
+//                    )
+//                    if (isUploading) {
+//                        CircularProgressIndicator(
+//                            modifier = Modifier.size(NachoIconSize.small),
+//                            color = NachoTheme.colorScheme.textDisabled,
+//                        )
+//                    }
                     if (isUploading) {
                         CircularProgressIndicator(
                             modifier = Modifier.size(NachoIconSize.small),
-                            color = NachoTheme.colorScheme.textDisabled,
+                            color = NachoTheme.colorScheme.textOnPrimary,
+                        )
+                    } else {
+                        Text(
+                            text = stringResource(R.string.txt_submit),
+                            color = NachoTheme.colorScheme.textOnPrimary,
                         )
                     }
                 }
@@ -198,6 +209,7 @@ private fun InvitationGuestBookFormPreview() {
             selectedMedias = persistentListOf(),
             textContent = "",
             isUploading = false,
+            isSubmittable = false,
             onMediasSelected = {},
             onMediaRemove = {},
             onTextContentChange = {},

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/InvitationGuestBookForm.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/InvitationGuestBookForm.kt
@@ -16,6 +16,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -24,6 +25,7 @@ import com.andlife.designsystem.component.NachoTextField
 import com.andlife.designsystem.preview.PreviewTheme
 import com.andlife.designsystem.theme.NachoIconSize
 import com.andlife.designsystem.theme.NachoSpacing
+import com.andlife.designsystem.theme.NachoStroke
 import com.andlife.designsystem.theme.NachoTheme
 import com.andlife.ui.R
 import com.andlife.ui.util.media.uriToSelectedMedia
@@ -171,13 +173,17 @@ fun InvitationGuestBookForm(
                 onClick = onUploadClick,
                 enabled = (selectedMedias.isNotEmpty() || textContent.isNotEmpty()) && !isUploading,
             ) {
-                if (isUploading) {
-                    CircularProgressIndicator(
-                        modifier = modifier.size(NachoIconSize.small),
-                        color = NachoTheme.colorScheme.brandOnPrimary,
+                Box(contentAlignment = Alignment.Center) {
+                    Text(
+                        text = stringResource(R.string.txt_submit),
+                        color = if (isUploading) Color.Transparent else Color.Unspecified
                     )
-                } else {
-                    Text(text = stringResource(R.string.txt_submit))
+                    if (isUploading) {
+                        CircularProgressIndicator(
+                            modifier = Modifier.size(NachoIconSize.small),
+                            color = NachoTheme.colorScheme.textDisabled,
+                        )
+                    }
                 }
             }
         }

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/SelectedMedia.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/SelectedMedia.kt
@@ -9,4 +9,5 @@ data class SelectedMedia(
     val uri: String,
     val type: UiMediaType,
     val duration: Int? = null,
+    val thumbnailUrl: String? = null,
 )

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/SelectedMedia.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/SelectedMedia.kt
@@ -5,6 +5,7 @@ import com.andlife.model.guestbook.UiMediaType
 
 @Immutable
 data class SelectedMedia(
+    val id: Long? = null,
     val uri: String,
     val type: UiMediaType,
     val duration: Int? = null,

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/SelectedMediaItem.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/SelectedMediaItem.kt
@@ -12,6 +12,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -67,14 +68,22 @@ fun SelectedMediaItem(
 
             UiMediaType.VIDEO -> {
                 Box(modifier = Modifier.fillMaxSize()) {
-                    AsyncImage(
-                        model = media.uri, // TODO: 영상 썸네일 이미지로 변경
-                        contentDescription = stringResource(R.string.desc_media_video),
-                        modifier = Modifier.fillMaxSize(),
-                        contentScale = ContentScale.Crop,
-                        placeholder = painterResource(R.drawable.ic_image_24),
-                        error = painterResource(R.drawable.ic_error_image_24),
-                    )
+                    if (media.thumbnailUrl != null) {
+                        AsyncImage(
+                            model = media.thumbnailUrl,
+                            contentDescription = stringResource(R.string.desc_media_video),
+                            modifier = Modifier.fillMaxSize(),
+                            contentScale = ContentScale.Crop,
+                            placeholder = painterResource(R.drawable.ic_image_24),
+                            error = painterResource(R.drawable.ic_error_image_24),
+                        )
+                    } else {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(Color.Black),
+                        )
+                    }
                     Icon(
                         painter = painterResource(id = R.drawable.ic_play_circle_24),
                         contentDescription = stringResource(R.string.desc_ic_play),

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/SelectedMediaItem.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/SelectedMediaItem.kt
@@ -106,9 +106,9 @@ private fun EditModeVideoItemPreview() {
     NachoTheme {
         SelectedMediaItem(
             SelectedMedia(
-                "https://picsum.photos/400/600?random=3",
-                UiMediaType.VIDEO,
-                828,
+                uri = "https://picsum.photos/400/600?random=3",
+                type = UiMediaType.VIDEO,
+                duration = 828,
             ),
         )
     }
@@ -120,6 +120,7 @@ private fun EditModeAudioItemPreview() {
     NachoTheme {
         SelectedMediaItem(
             SelectedMedia(
+                1L,
                 "https://picsum.photos/400/600?random=3",
                 UiMediaType.AUDIO,
                 314,

--- a/android/core/ui/src/main/res/values/strings.xml
+++ b/android/core/ui/src/main/res/values/strings.xml
@@ -66,7 +66,8 @@
     <string name="txt_add_media">미디어 추가</string>
     <string name="desc_remove_media">미디어 제거</string>
     <string name="txt_please_leave_a_message">메시지를 남겨주세요.</string>
-
+    <string name="txt_label_edit">수정</string>
+    <string name="txt_label_delete">삭제</string>ㄱ
 
     <!--  ImageSection  -->
     <string name="desc_invitation_image">초대장 상세 이미지</string>

--- a/android/core/ui/src/main/res/values/strings.xml
+++ b/android/core/ui/src/main/res/values/strings.xml
@@ -67,7 +67,7 @@
     <string name="desc_remove_media">미디어 제거</string>
     <string name="txt_please_leave_a_message">메시지를 남겨주세요.</string>
     <string name="txt_label_edit">수정</string>
-    <string name="txt_label_delete">삭제</string>ㄱ
+    <string name="txt_label_delete">삭제</string>
 
     <!--  ImageSection  -->
     <string name="desc_invitation_image">초대장 상세 이미지</string>

--- a/android/domain/src/main/kotlin/com/andlife/domain/repository/guestbook/GuestBookRepository.kt
+++ b/android/domain/src/main/kotlin/com/andlife/domain/repository/guestbook/GuestBookRepository.kt
@@ -28,4 +28,6 @@ interface GuestBookRepository {
         existingAudioIds: List<Long>,
         newMedias: List<GuestBookMedia>,
     ): Result<GuestBook, DataError>
+
+    suspend fun deleteGuestBook(guestBookId: Long): Result<Long, DataError>
 }

--- a/android/domain/src/main/kotlin/com/andlife/domain/repository/guestbook/GuestBookRepository.kt
+++ b/android/domain/src/main/kotlin/com/andlife/domain/repository/guestbook/GuestBookRepository.kt
@@ -19,4 +19,13 @@ interface GuestBookRepository {
         textContent: String,
         medias: List<GuestBookMedia>,
     ): Result<GuestBook, DataError>
+
+    suspend fun updateGuestBook(
+        guestBookId: Long,
+        textContent: String,
+        existingImageIds: List<Long>,
+        existingVideoIds: List<Long>,
+        existingAudioIds: List<Long>,
+        newMedias: List<GuestBookMedia>,
+    ): Result<GuestBook, DataError>
 }

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/guestbook/InvitationGuestBookSideEffect.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/guestbook/InvitationGuestBookSideEffect.kt
@@ -8,4 +8,8 @@ sealed interface InvitationGuestBookSideEffect : BaseSideEffect {
     ) : InvitationGuestBookSideEffect
 
     data object CreateGuestBookSuccess : InvitationGuestBookSideEffect
+
+    data object UpdateGuestBookSuccess : InvitationGuestBookSideEffect
+
+    data object DeleteGuestBookSuccess : InvitationGuestBookSideEffect
 }

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/guestbook/InvitationGuestBookUiEvent.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/guestbook/InvitationGuestBookUiEvent.kt
@@ -1,5 +1,6 @@
 package com.andlife.invitation.model.guestbook
 
+import com.andlife.model.guestbook.GuestBookUiModel
 import com.andlife.ui.base.BaseUiEvent
 import com.andlife.ui.component.invitation.SelectedMedia
 
@@ -35,4 +36,10 @@ sealed interface InvitationGuestBookUiEvent : BaseUiEvent {
     data class ClickAudioMedia(
         val url: String,
     ) : InvitationGuestBookUiEvent
+
+    data class ClickEditMenu(
+        val guestBook: GuestBookUiModel,
+    ) : InvitationGuestBookUiEvent
+
+    data object CancelEdit : InvitationGuestBookUiEvent
 }

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/guestbook/InvitationGuestBookUiEvent.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/guestbook/InvitationGuestBookUiEvent.kt
@@ -42,4 +42,8 @@ sealed interface InvitationGuestBookUiEvent : BaseUiEvent {
     ) : InvitationGuestBookUiEvent
 
     data object CancelEdit : InvitationGuestBookUiEvent
+
+    data class ClickDeleteMenu(
+        val guestBookId: Long,
+    ) : InvitationGuestBookUiEvent
 }

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/guestbook/InvitationGuestBookUiState.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/guestbook/InvitationGuestBookUiState.kt
@@ -16,4 +16,8 @@ data class InvitationGuestBookUiState(
     val editingGuestBookId: Long? = null,
     val isLoadingGuestBooks: Boolean = false,
     val guestBooksErrorMessage: String? = null,
-) : BaseUiState
+) : BaseUiState {
+
+    val isSubmittable: Boolean
+        get() = textContent.isNotBlank() || selectedMedias.isNotEmpty()
+}

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/guestbook/InvitationGuestBookUiState.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/guestbook/InvitationGuestBookUiState.kt
@@ -5,11 +5,14 @@ import com.andlife.ui.base.BaseUiState
 import com.andlife.ui.component.invitation.SelectedMedia
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
+import kotlin.collections.sorted
 
 data class InvitationGuestBookUiState(
     val selectedMedias: ImmutableList<SelectedMedia> = persistentListOf(),
     val textContent: String = "",
     val isUploading: Boolean = false,
+    val originalTextContent: String = "",
+    val originalMediaIds: Set<Long> = emptySet(),
     val errorMessage: String? = null,
     val playingAudioUrl: String? = null,
     val isAudioPlaying: Boolean = false,
@@ -18,6 +21,18 @@ data class InvitationGuestBookUiState(
     val guestBooksErrorMessage: String? = null,
 ) : BaseUiState {
 
+    val isContentChanged: Boolean
+        get() {
+            if (editingGuestBookId == null) return true
+            val isTextChanged = textContent != originalTextContent
+            val currentMediaIds = selectedMedias.mapNotNull { it.id }.toSet()
+            val isMediaChanged = currentMediaIds != originalMediaIds
+
+            val hasNewMedias = selectedMedias.any { it.id == null }
+
+            return isTextChanged || isMediaChanged || hasNewMedias
+        }
+
     val isSubmittable: Boolean
-        get() = textContent.isNotBlank() || selectedMedias.isNotEmpty()
+        get() = (textContent.isNotBlank() || selectedMedias.isNotEmpty()) && !isUploading && isContentChanged
 }

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/guestbook/InvitationGuestBookUiState.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/guestbook/InvitationGuestBookUiState.kt
@@ -18,6 +18,7 @@ data class InvitationGuestBookUiState(
     val isAudioPlaying: Boolean = false,
     val editingGuestBookId: Long? = null,
     val isLoadingGuestBooks: Boolean = false,
+    val deleteTargetId: Long? = null,
     val guestBooksErrorMessage: String? = null,
 ) : BaseUiState {
 

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/guestbook/InvitationGuestBookUiState.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/guestbook/InvitationGuestBookUiState.kt
@@ -1,11 +1,9 @@
 package com.andlife.invitation.model.guestbook
 
-import com.andlife.domain.model.guestbook.GuestBook
 import com.andlife.ui.base.BaseUiState
 import com.andlife.ui.component.invitation.SelectedMedia
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
-import kotlin.collections.sorted
 
 data class InvitationGuestBookUiState(
     val selectedMedias: ImmutableList<SelectedMedia> = persistentListOf(),

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/guestbook/InvitationGuestBookUiState.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/guestbook/InvitationGuestBookUiState.kt
@@ -13,6 +13,7 @@ data class InvitationGuestBookUiState(
     val errorMessage: String? = null,
     val playingAudioUrl: String? = null,
     val isAudioPlaying: Boolean = false,
+    val editingGuestBookId: Long? = null,
     val isLoadingGuestBooks: Boolean = false,
     val guestBooksErrorMessage: String? = null,
 ) : BaseUiState

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
@@ -287,6 +287,8 @@ private fun InvitationGuestBookScreen(
                                 isAudioPlaying = uiState.isAudioPlaying &&
                                     guestBook.audioMedias.any { it.url == uiState.playingAudioUrl },
                                 playingAudioUrl = uiState.playingAudioUrl,
+                                isEditing = uiState.editingGuestBookId == guestBook.id,
+                                onEditClick = { onEvent(InvitationGuestBookUiEvent.ClickEditMenu(guestBook)) },
                                 onVisualMediaClick = { onEvent(InvitationGuestBookUiEvent.ClickVisualMedia(it.url)) },
                                 onAudioMediaClick = { onEvent(InvitationGuestBookUiEvent.ClickAudioMedia(it.url)) },
                                 onMenuClick = { onEvent(InvitationGuestBookUiEvent.ClickGuestBookMenu(guestBook.id)) },

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
@@ -347,9 +347,7 @@ private fun InvitationGuestBookScreen(
                 LazyColumn(
                     state = lazyListState,
                     modifier = Modifier.fillMaxSize(),
-                    verticalArrangement = Arrangement.spacedBy(NachoSpacing.large),
                     contentPadding = PaddingValues(
-                        top = NachoSpacing.large,
                         bottom = innerPadding.calculateBottomPadding()
                     )
                 ) {
@@ -360,7 +358,6 @@ private fun InvitationGuestBookScreen(
                         guestBooks[index]?.let { guestBook ->
                             GuestBookItem(
                                 modifier = Modifier
-                                    .fillMaxWidth()
                                     .animateItem(),
                                 guestBook = guestBook,
                                 videoPlayerPool = videoPlayerPool,

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
@@ -441,6 +441,7 @@ private fun GuestBookFormSection(
         textContent = uiState.textContent,
         isUploading = uiState.isUploading,
         isSubmittable = uiState.isSubmittable,
+        editingGuestBookId = uiState.editingGuestBookId,
         onMediasSelected = { medias ->
             onEvent(InvitationGuestBookUiEvent.UpdateSelectedMedias(medias))
         },

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.imePadding
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
@@ -83,9 +84,11 @@ fun InvitationGuestBookRoute(
     val guestBooks = viewModel.guestBooksPagingFlow.collectAsLazyPagingItems()
 
     val lifecycleOwner = LocalLifecycleOwner.current
+    val lazyListState = rememberLazyListState()
 
     val snackbarHostState = remember { SnackbarHostState() }
     var showDeleteDialog by remember { mutableStateOf<Long?>(null) }
+    var scrollToTop by remember { mutableStateOf(false) }
 
     viewModel.effectFlow.collectWithLifecycle { effect ->
         when (effect) {
@@ -97,16 +100,26 @@ fun InvitationGuestBookRoute(
             }
 
             is InvitationGuestBookSideEffect.CreateGuestBookSuccess -> {
-                guestBooks.refresh()
+                scrollToTop = true
+                viewModel.invalidateGuestBooks()
             }
 
             is InvitationGuestBookSideEffect.UpdateGuestBookSuccess -> {
-                guestBooks.refresh() // TODO: 이거 부분만 업데이트하도록 변경하기. 지금은 전체 새로고침
+                viewModel.invalidateGuestBooks()
             }
 
             is InvitationGuestBookSideEffect.DeleteGuestBookSuccess -> {
-                guestBooks.refresh() // TODO: 이거 부분만 업데이트하도록 변경하기. 지금은 전체 새로고침
+                viewModel.invalidateGuestBooks()
             }
+        }
+    }
+
+    LaunchedEffect(guestBooks.loadState.refresh, scrollToTop) {
+        if (scrollToTop && guestBooks.loadState.refresh is LoadState.NotLoading) {
+            if (guestBooks.itemCount > 0) {
+                lazyListState.animateScrollToItem(0)
+            }
+            scrollToTop = false
         }
     }
 
@@ -199,6 +212,7 @@ fun InvitationGuestBookRoute(
         onEvent = viewModel::onEvent,
         onNavigateBack = onNavigateBack,
         snackbarHostState = snackbarHostState,
+        lazyListState = lazyListState,
         videoPlayerPool = viewModel.videoPlayerPool,
         onDeleteMenuClick = { guestBookId -> showDeleteDialog = guestBookId },
         modifier = modifier,
@@ -211,15 +225,14 @@ private fun InvitationGuestBookScreen(
     guestBooks: LazyPagingItems<GuestBookUiModel>,
     onEvent: (InvitationGuestBookUiEvent) -> Unit,
     snackbarHostState: SnackbarHostState,
+    lazyListState: LazyListState,
     videoPlayerPool: AutoVideoPlayerPool,
     onNavigateBack: () -> Unit,
     onDeleteMenuClick: (Long) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val lazyListState = rememberLazyListState()
     val coroutineScope = rememberCoroutineScope()
     var playVideoIndex by remember { mutableStateOf(-1) }
-
     var isMediaActive by remember { mutableStateOf(true) }
 
     val navigateBackWithCleanup: () -> Unit = {
@@ -300,15 +313,6 @@ private fun InvitationGuestBookScreen(
                     }
                 }
             }
-    }
-
-    LaunchedEffect(guestBooks.loadState.refresh) {
-        if (guestBooks.loadState.refresh is LoadState.NotLoading) {
-            if (guestBooks.itemCount > 0) {
-                lazyListState.animateScrollToItem(0)
-            }
-            playVideoIndex = -1
-        }
     }
 
     Scaffold(
@@ -430,6 +434,7 @@ private fun InvitationGuestBookEmptyPreview() {
             onNavigateBack = {},
             videoPlayerPool = FakeVideoPlayerPool(),
             snackbarHostState = SnackbarHostState(),
+            lazyListState = rememberLazyListState(),
             onDeleteMenuClick = {},
         )
     }

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
@@ -3,7 +3,10 @@ package com.andlife.invitation.screen.guestbook
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
@@ -16,6 +19,8 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -27,6 +32,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -37,10 +43,12 @@ import androidx.paging.PagingData
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemKey
+import com.andlife.designsystem.component.dialog.NachoDialog
 import com.andlife.designsystem.preview.PreviewTheme
 import com.andlife.designsystem.theme.NachoElevation
 import com.andlife.designsystem.theme.NachoSpacing
 import com.andlife.designsystem.theme.NachoTheme
+import com.andlife.invitation.R
 import com.andlife.invitation.model.guestbook.InvitationGuestBookSideEffect
 import com.andlife.invitation.model.guestbook.InvitationGuestBookUiEvent
 import com.andlife.invitation.model.guestbook.InvitationGuestBookUiState
@@ -73,8 +81,11 @@ fun InvitationGuestBookRoute(
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val guestBooks = viewModel.guestBooksPagingFlow.collectAsLazyPagingItems()
-    val snackbarHostState = remember { SnackbarHostState() }
+
     val lifecycleOwner = LocalLifecycleOwner.current
+
+    val snackbarHostState = remember { SnackbarHostState() }
+    var showDeleteDialog by remember { mutableStateOf<Long?>(null) }
 
     viewModel.effectFlow.collectWithLifecycle { effect ->
         when (effect) {
@@ -87,6 +98,14 @@ fun InvitationGuestBookRoute(
 
             is InvitationGuestBookSideEffect.CreateGuestBookSuccess -> {
                 guestBooks.refresh()
+            }
+
+            is InvitationGuestBookSideEffect.UpdateGuestBookSuccess -> {
+                guestBooks.refresh() // TODO: 이거 부분만 업데이트하도록 변경하기. 지금은 전체 새로고침
+            }
+
+            is InvitationGuestBookSideEffect.DeleteGuestBookSuccess -> {
+                guestBooks.refresh() // TODO: 이거 부분만 업데이트하도록 변경하기. 지금은 전체 새로고침
             }
         }
     }
@@ -123,6 +142,57 @@ fun InvitationGuestBookRoute(
         onDispose { lifecycleOwner.lifecycle.removeObserver(observer) }
     }
 
+    if (showDeleteDialog != null) {
+        NachoDialog(
+            onDismiss = { showDeleteDialog = null }
+        ) {
+            Column(
+                modifier = Modifier.padding(NachoSpacing.xLarge),
+                verticalArrangement = Arrangement.spacedBy(NachoSpacing.medium)
+            ) {
+                Text(
+                    text = stringResource(R.string.txt_delete_dialog_title),
+                    color = NachoTheme.colorScheme.textPrimary,
+                    style = NachoTheme.typography.headingSmallSemiBold,
+                )
+                Spacer(modifier = Modifier.padding(NachoSpacing.xSmall))
+                Text(
+                    text = stringResource(R.string.txt_delete_dialog_message),
+                    color = NachoTheme.colorScheme.textSecondary,
+                    style = NachoTheme.typography.bodyMediumRegular,
+                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    TextButton(
+                        onClick = { showDeleteDialog = null }
+                    ) {
+                        Text(
+                            text = stringResource(R.string.btn_label_cancel),
+                            color = NachoTheme.colorScheme.textPrimary,
+                            style = NachoTheme.typography.bodyMediumSemiBold,
+                        )
+                    }
+                    TextButton(
+                        onClick = {
+                            showDeleteDialog?.let { guestBookId ->
+                                viewModel.onEvent(InvitationGuestBookUiEvent.ClickDeleteMenu(guestBookId))
+                            }
+                            showDeleteDialog = null
+                        }
+                    ) {
+                        Text(
+                            text = stringResource(R.string.btn_label_delete),
+                            color = NachoTheme.colorScheme.brandDark,
+                            style = NachoTheme.typography.bodyMediumSemiBold,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
     InvitationGuestBookScreen(
         uiState = uiState,
         guestBooks = guestBooks,
@@ -130,6 +200,7 @@ fun InvitationGuestBookRoute(
         onNavigateBack = onNavigateBack,
         snackbarHostState = snackbarHostState,
         videoPlayerPool = viewModel.videoPlayerPool,
+        onDeleteMenuClick = { guestBookId -> showDeleteDialog = guestBookId },
         modifier = modifier,
     )
 }
@@ -142,6 +213,7 @@ private fun InvitationGuestBookScreen(
     snackbarHostState: SnackbarHostState,
     videoPlayerPool: AutoVideoPlayerPool,
     onNavigateBack: () -> Unit,
+    onDeleteMenuClick: (Long) -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val lazyListState = rememberLazyListState()
@@ -289,6 +361,7 @@ private fun InvitationGuestBookScreen(
                                 playingAudioUrl = uiState.playingAudioUrl,
                                 isEditing = uiState.editingGuestBookId == guestBook.id,
                                 onEditClick = { onEvent(InvitationGuestBookUiEvent.ClickEditMenu(guestBook)) },
+                                onDeleteClick = { onDeleteMenuClick(guestBook.id) },
                                 onVisualMediaClick = { onEvent(InvitationGuestBookUiEvent.ClickVisualMedia(it.url)) },
                                 onAudioMediaClick = { onEvent(InvitationGuestBookUiEvent.ClickAudioMedia(it.url)) },
                                 onMenuClick = { onEvent(InvitationGuestBookUiEvent.ClickGuestBookMenu(guestBook.id)) },
@@ -357,6 +430,7 @@ private fun InvitationGuestBookEmptyPreview() {
             onNavigateBack = {},
             videoPlayerPool = FakeVideoPlayerPool(),
             snackbarHostState = SnackbarHostState(),
+            onDeleteMenuClick = {},
         )
     }
 }

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
@@ -29,6 +29,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
@@ -240,7 +241,7 @@ private fun InvitationGuestBookScreen(
     val focusManager = LocalFocusManager.current
     val isImVisible = WindowInsets.isImeVisible
 
-    var playVideoIndex by remember { mutableStateOf(-1) }
+    var playVideoIndex by remember { mutableIntStateOf(-1) }
     var isMediaActive by remember { mutableStateOf(true) }
     var isTextFieldFocused by remember { mutableStateOf(false) }
 

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
@@ -4,12 +4,15 @@ import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.isImeVisible
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -33,6 +36,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
@@ -219,6 +223,7 @@ fun InvitationGuestBookRoute(
     )
 }
 
+@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun InvitationGuestBookScreen(
     uiState: InvitationGuestBookUiState,
@@ -232,8 +237,12 @@ private fun InvitationGuestBookScreen(
     modifier: Modifier = Modifier,
 ) {
     val coroutineScope = rememberCoroutineScope()
+    val focusManager = LocalFocusManager.current
+    val isImVisible = WindowInsets.isImeVisible
+
     var playVideoIndex by remember { mutableStateOf(-1) }
     var isMediaActive by remember { mutableStateOf(true) }
+    var isTextFieldFocused by remember { mutableStateOf(false) }
 
     val navigateBackWithCleanup: () -> Unit = {
         isMediaActive = false
@@ -246,7 +255,20 @@ private fun InvitationGuestBookScreen(
         }
     }
 
-    BackHandler(onBack = navigateBackWithCleanup)
+    BackHandler(enabled = !isImVisible) {
+        when {
+            uiState.editingGuestBookId != null -> {
+                focusManager.clearFocus()
+                onEvent(InvitationGuestBookUiEvent.CancelEdit)
+            }
+            isTextFieldFocused -> {
+                focusManager.clearFocus()
+            }
+            else -> {
+                navigateBackWithCleanup()
+            }
+        }
+    }
 
     LaunchedEffect(lazyListState, guestBooks.itemCount, isMediaActive, uiState.isAudioPlaying) {
         var pendingIndex = -1
@@ -329,7 +351,13 @@ private fun InvitationGuestBookScreen(
                         .navigationBarsPadding()
                         .imePadding()
                 ) {
-                    GuestBookFormSection(uiState = uiState, onEvent = onEvent)
+                    GuestBookFormSection(
+                        uiState = uiState,
+                        onEvent = onEvent,
+                        onFocusChanged = { focused ->
+                            isTextFieldFocused = focused
+                        }
+                    )
                 }
             }
         }
@@ -400,6 +428,7 @@ private fun InvitationGuestBookScreen(
 private fun GuestBookFormSection(
     uiState: InvitationGuestBookUiState,
     onEvent: (InvitationGuestBookUiEvent) -> Unit,
+    onFocusChanged: (Boolean) -> Unit,
 ) {
     InvitationGuestBookForm(
         modifier = Modifier
@@ -424,6 +453,7 @@ private fun GuestBookFormSection(
         onUploadClick = {
             onEvent(InvitationGuestBookUiEvent.UploadMedias)
         },
+        onFocusChanged = onFocusChanged,
     )
 }
 

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
@@ -329,6 +329,7 @@ private fun GuestBookFormSection(
         selectedMedias = uiState.selectedMedias,
         textContent = uiState.textContent,
         isUploading = uiState.isUploading,
+        isSubmittable = uiState.isSubmittable,
         onMediasSelected = { medias ->
             onEvent(InvitationGuestBookUiEvent.UpdateSelectedMedias(medias))
         },

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
@@ -335,12 +335,15 @@ private fun InvitationGuestBookScreen(
         }
     ) { innerPadding ->
         if (isMediaActive) {
-            PagingStateContent(
-                loadState = guestBooks.loadState.refresh,
-                itemCount = guestBooks.itemCount,
-                onRetry = { guestBooks.retry() },
-                modifier = Modifier.padding(horizontal = NachoSpacing.large)
-            ) {
+            val isInitialLoading = guestBooks.loadState.refresh is LoadState.Loading && guestBooks.itemCount == 0
+
+            if (isInitialLoading) {
+                PagingStateContent(
+                    loadState = guestBooks.loadState.refresh,
+                    itemCount = guestBooks.itemCount,
+                    onRetry = { guestBooks.retry() },
+                ) {}
+            } else {
                 LazyColumn(
                     state = lazyListState,
                     modifier = Modifier.fillMaxSize(),
@@ -356,7 +359,9 @@ private fun InvitationGuestBookScreen(
                     ) { index ->
                         guestBooks[index]?.let { guestBook ->
                             GuestBookItem(
-                                modifier = Modifier.animateItem(),
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .animateItem(),
                                 guestBook = guestBook,
                                 videoPlayerPool = videoPlayerPool,
                                 shouldPlayVideo = isMediaActive && (index == playVideoIndex),

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
@@ -337,11 +337,14 @@ private fun InvitationGuestBookScreen(
         if (isMediaActive) {
             val isInitialLoading = guestBooks.loadState.refresh is LoadState.Loading && guestBooks.itemCount == 0
 
-            if (isInitialLoading) {
+            if (isInitialLoading || guestBooks.itemCount == 0) {
                 PagingStateContent(
                     loadState = guestBooks.loadState.refresh,
                     itemCount = guestBooks.itemCount,
-                    onRetry = { guestBooks.retry() },
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .padding(bottom = innerPadding.calculateBottomPadding()),
+                    onRetry = { guestBooks.retry() }
                 ) {}
             } else {
                 LazyColumn(

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationGuestBookViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationGuestBookViewModel.kt
@@ -301,5 +301,4 @@ constructor(
             is Result.Error -> sendEffect(InvitationGuestBookSideEffect.ShowSnackbar("실패: ${result.message}"))
         }
     }
-
 }

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationGuestBookViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationGuestBookViewModel.kt
@@ -1,5 +1,6 @@
 package com.andlife.invitation.viewmodel
 
+import android.net.Uri
 import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
@@ -20,6 +21,7 @@ import com.andlife.invitation.model.guestbook.InvitationGuestBookUiState
 import com.andlife.media.audio.AudioPlayerManager
 import com.andlife.media.video.AutoVideoPlayerPool
 import com.andlife.model.guestbook.GuestBookUiModel
+import com.andlife.model.guestbook.MediaUiType
 import com.andlife.model.guestbook.toUiModel
 import com.andlife.ui.base.BaseViewModel
 import com.andlife.ui.component.invitation.SelectedMedia
@@ -42,6 +44,7 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
+import okhttp3.internal.toImmutableList
 import javax.inject.Inject
 
 @HiltViewModel
@@ -115,6 +118,9 @@ constructor(
             is InvitationGuestBookUiEvent.ClickVisualMedia -> sendEffect(
                 InvitationGuestBookSideEffect.ShowSnackbar("비주얼 미디어 클릭됨: ${event.url}"),
             )
+
+            is InvitationGuestBookUiEvent.ClickEditMenu -> startEditing(event.guestBook)
+            is InvitationGuestBookUiEvent.CancelEdit -> {}
         }
     }
 
@@ -277,6 +283,33 @@ constructor(
         } catch (e: Exception) {
             updateState { copy(isUploading = false) }
             sendEffect(InvitationGuestBookSideEffect.ShowSnackbar("방명록 생성 중 오류 발생: ${e.message}"))
+        }
+    }
+
+    private fun startEditing(guestBook: GuestBookUiModel) {
+        val existingMedias = (guestBook.visualMedias + guestBook.audioMedias)
+            .sortedBy { it.displayOrder }
+            .map { media ->
+            SelectedMedia(
+                id = media.id,
+                uri = when (media.type) {
+                    MediaUiType.VIDEO -> media.thumbnailUrl ?: media.url
+                    MediaUiType.IMAGE, MediaUiType.AUDIO -> media.url
+                },
+                type = when (media.type) {
+                    MediaUiType.IMAGE -> UiMediaType.IMAGE
+                    MediaUiType.VIDEO -> UiMediaType.VIDEO
+                    MediaUiType.AUDIO -> UiMediaType.AUDIO
+                },
+                duration = media.durationSeconds
+            )
+        }
+        updateState {
+            copy(
+                editingGuestBookId = guestBook.id,
+                textContent = guestBook.textContent,
+                selectedMedias = existingMedias.toPersistentList()
+            )
         }
     }
 }

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationGuestBookViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationGuestBookViewModel.kt
@@ -322,6 +322,15 @@ constructor(
         viewModelScope.launch {
             guestBookRepository.deleteGuestBook(guestBookId)
                 .onSuccess { deletedId ->
+                    updateState {
+                        copy(
+                            editingGuestBookId = if (editingGuestBookId == deletedId) null else editingGuestBookId,
+                            selectedMedias = if (editingGuestBookId == deletedId) persistentListOf() else selectedMedias,
+                            textContent = if (editingGuestBookId == deletedId) "" else textContent,
+                            originalTextContent = if (editingGuestBookId == deletedId) "" else originalTextContent,
+                            originalMediaIds = if (editingGuestBookId == deletedId) setOf() else originalMediaIds,
+                        )
+                    }
                     sendEffect(InvitationGuestBookSideEffect.DeleteGuestBookSuccess)
                 }
                 .onFailure {

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationGuestBookViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationGuestBookViewModel.kt
@@ -15,6 +15,8 @@ import com.andlife.domain.repository.guestbook.GuestBookRepository
 import com.andlife.domain.util.MediaFileProvider
 import com.andlife.domain.util.MediaUploader
 import com.andlife.domain.util.Result
+import com.andlife.domain.util.onFailure
+import com.andlife.domain.util.onSuccess
 import com.andlife.invitation.InvitationDetail
 import com.andlife.invitation.model.guestbook.InvitationGuestBookSideEffect
 import com.andlife.invitation.model.guestbook.InvitationGuestBookUiEvent
@@ -116,6 +118,8 @@ constructor(
 
             is InvitationGuestBookUiEvent.ClickEditMenu -> startEditing(event.guestBook)
             is InvitationGuestBookUiEvent.CancelEdit -> {}
+
+            is InvitationGuestBookUiEvent.ClickDeleteMenu -> deleteGuestBook(event.guestBookId)
         }
     }
 
@@ -302,5 +306,15 @@ constructor(
 
             is Result.Error -> sendEffect(InvitationGuestBookSideEffect.ShowSnackbar("실패: ${result.message}"))
         }
+    }
+
+    private fun deleteGuestBook(guestBookId: Long) = viewModelScope.launch {
+        guestBookRepository.deleteGuestBook(guestBookId)
+            .onSuccess { deletedId ->
+                sendEffect(InvitationGuestBookSideEffect.DeleteGuestBookSuccess)
+            }
+            .onFailure {
+                sendEffect(InvitationGuestBookSideEffect.ShowSnackbar("방명록 삭제를 실패하였습니다."))
+            }
     }
 }

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationGuestBookViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationGuestBookViewModel.kt
@@ -290,20 +290,18 @@ constructor(
         val existingMedias = (guestBook.visualMedias + guestBook.audioMedias)
             .sortedBy { it.displayOrder }
             .map { media ->
-            SelectedMedia(
-                id = media.id,
-                uri = when (media.type) {
-                    MediaUiType.VIDEO -> media.thumbnailUrl ?: media.url
-                    MediaUiType.IMAGE, MediaUiType.AUDIO -> media.url
-                },
-                type = when (media.type) {
-                    MediaUiType.IMAGE -> UiMediaType.IMAGE
-                    MediaUiType.VIDEO -> UiMediaType.VIDEO
-                    MediaUiType.AUDIO -> UiMediaType.AUDIO
-                },
-                duration = media.durationSeconds
-            )
-        }
+                SelectedMedia(
+                    id = media.id,
+                    uri = media.url, // 서버 원본 URL
+                    type = when (media.type) {
+                        MediaUiType.IMAGE -> UiMediaType.IMAGE
+                        MediaUiType.VIDEO -> UiMediaType.VIDEO
+                        MediaUiType.AUDIO -> UiMediaType.AUDIO
+                    },
+                    duration = media.durationSeconds,
+                    thumbnailUrl = media.thumbnailUrl
+                )
+            }
         updateState {
             copy(
                 editingGuestBookId = guestBook.id,

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationGuestBookViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationGuestBookViewModel.kt
@@ -170,7 +170,9 @@ constructor(
             copy(
                 editingGuestBookId = guestBook.id,
                 textContent = guestBook.textContent,
-                selectedMedias = existingMedias.toPersistentList()
+                selectedMedias = existingMedias.toPersistentList(),
+                originalTextContent = guestBook.textContent,
+                originalMediaIds = existingMedias.mapNotNull { it.id }.toSet(),
             )
         }
     }

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationGuestBookViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationGuestBookViewModel.kt
@@ -34,7 +34,6 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -123,7 +122,7 @@ constructor(
             )
 
             is InvitationGuestBookUiEvent.ClickEditMenu -> startEditing(event.guestBook)
-            is InvitationGuestBookUiEvent.CancelEdit -> {}
+            is InvitationGuestBookUiEvent.CancelEdit -> cancelEdit()
 
             is InvitationGuestBookUiEvent.ClickDeleteMenu -> deleteGuestBook(event.guestBookId)
         }
@@ -342,5 +341,17 @@ constructor(
     fun invalidateGuestBooks() {
         Log.d("qqqqq", "방명록 목록 무효화")
         refreshFlow.value += 1
+    }
+
+    private fun cancelEdit() {
+        updateState {
+            copy(
+                editingGuestBookId = null,
+                selectedMedias = persistentListOf(),
+                textContent = "",
+                originalTextContent = "",
+                originalMediaIds = emptySet(),
+            )
+        }
     }
 }

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationGuestBookViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationGuestBookViewModel.kt
@@ -1,6 +1,5 @@
 package com.andlife.invitation.viewmodel
 
-import android.net.Uri
 import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
@@ -8,6 +7,8 @@ import androidx.navigation.toRoute
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import androidx.paging.map
+import com.andlife.domain.error.DataError
+import com.andlife.domain.model.guestbook.GuestBook
 import com.andlife.domain.model.guestbook.GuestBookMedia
 import com.andlife.domain.model.guestbook.MediaType
 import com.andlife.domain.repository.guestbook.GuestBookRepository
@@ -22,29 +23,23 @@ import com.andlife.media.audio.AudioPlayerManager
 import com.andlife.media.video.AutoVideoPlayerPool
 import com.andlife.model.guestbook.GuestBookUiModel
 import com.andlife.model.guestbook.MediaUiType
+import com.andlife.model.guestbook.UiMediaType
 import com.andlife.model.guestbook.toUiModel
 import com.andlife.ui.base.BaseViewModel
 import com.andlife.ui.component.invitation.SelectedMedia
-import com.andlife.model.guestbook.UiMediaType
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.flow.flatMapLatest
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
-import okhttp3.internal.toImmutableList
 import javax.inject.Inject
 
 @HiltViewModel
@@ -103,7 +98,7 @@ constructor(
             is InvitationGuestBookUiEvent.UpdateSelectedMedias -> updateSelectedMedias(event.medias)
             is InvitationGuestBookUiEvent.UpdateTextContent -> updateTextContent(event.textContent)
             is InvitationGuestBookUiEvent.RemoveMedia -> removeMedia(event.media)
-            is InvitationGuestBookUiEvent.UploadMedias -> uploadMedias()
+            is InvitationGuestBookUiEvent.UploadMedias -> handleUploadMedias()
             is InvitationGuestBookUiEvent.ClearError -> clearError()
             is InvitationGuestBookUiEvent.ClickAudioMedia -> clickAudioMedia(event.url)
 
@@ -151,139 +146,8 @@ constructor(
         }
     }
 
-    // 등록 버튼 누를 시 호출
-    private fun uploadMedias() {
-        val medias = mutableUiState.value.selectedMedias
-        val textContent = mutableUiState.value.textContent
-
-        viewModelScope.launch {
-            when {
-                medias.isEmpty() && textContent.isBlank() -> {
-                    // 아무 것도 없음
-                    return@launch
-                }
-
-                medias.isEmpty() -> {
-                    // 텍스트만 있는 경우
-                    updateState { copy(isUploading = true) }
-                    createGuestBook(emptyList(), emptyList())
-                }
-
-                else -> {
-                    // 미디어가 있는 경우
-                    updateState { copy(isUploading = true) }
-
-                    try {
-                        val mediaFiles =
-                            mediaFileProvider.createFromUris(
-                                medias.map { it.uri },
-                            )
-
-                        when {
-                            mediaFiles.isEmpty() -> {
-                                updateState { copy(isUploading = false) }
-                                sendEffect(
-                                    InvitationGuestBookSideEffect.ShowSnackbar(
-                                        "유효하지 않은 미디어 파일입니다",
-                                    ),
-                                )
-                            }
-
-                            else -> {
-                                when (val result = mediaUploader.uploadMedias(mediaFiles)) {
-                                    is Result.Success -> {
-                                        // 업로드된 미디어 URL 리스트: 업로드 실패한 미디어는 null 가능
-                                        createGuestBook(result.data, medias)
-                                    }
-
-                                    is Result.Error -> {
-                                        updateState { copy(isUploading = false) }
-                                        sendEffect(
-                                            InvitationGuestBookSideEffect.ShowSnackbar(
-                                                "업로드 실패: ${result.message}",
-                                            ),
-                                        )
-                                    }
-                                }
-                            }
-                        }
-                    } catch (e: Exception) {
-                        updateState { copy(isUploading = false) }
-                        sendEffect(
-                            InvitationGuestBookSideEffect.ShowSnackbar(
-                                "업로드 중 오류 발생: ${e.message}",
-                            ),
-                        )
-                    }
-                }
-            }
-        }
-    }
-
-
     private fun clearError() {
         updateState { copy(errorMessage = null) }
-    }
-
-    private suspend fun createGuestBook(
-        uploadedUrls: List<String?>,
-        selectedMedias: List<SelectedMedia>,
-    ) {
-        try {
-            val guestBookMedias =
-                uploadedUrls
-                    .mapIndexed { index, url ->
-                        if (url == null) return@mapIndexed null // 업로드 실패한 미디어는 건너뜀
-                        val selectedMedia = selectedMedias.getOrNull(index)
-                        val thumbnailUrl =
-                            if (selectedMedia?.type == UiMediaType.VIDEO) "https://thumbnailurl.com" else null // TODO: 썸네일 URL 처리
-                        GuestBookMedia(
-                            id = 0L,
-                            type =
-                                when (selectedMedia?.type) {
-                                    UiMediaType.IMAGE -> MediaType.IMAGE
-                                    UiMediaType.VIDEO -> MediaType.VIDEO
-                                    UiMediaType.AUDIO -> MediaType.AUDIO
-                                    else -> MediaType.IMAGE
-                                },
-                            url = url,
-                            thumbnailUrl = thumbnailUrl,
-                            durationSeconds = selectedMedia?.duration,
-                            displayOrder = index,
-                        )
-                    }.filterNotNull()
-
-            val result =
-                guestBookRepository.createGuestBook(
-                    invitationId = 1, // 임시
-                    userId = 1, // 임시
-                    textContent = mutableUiState.value.textContent,
-                    medias = guestBookMedias,
-                )
-
-            when (result) {
-                is Result.Success -> {
-                    updateState {
-                        copy(
-                            isUploading = false,
-                            selectedMedias = persistentListOf(),
-                            textContent = "",
-                            errorMessage = null,
-                        )
-                    }
-                    sendEffect(InvitationGuestBookSideEffect.CreateGuestBookSuccess)
-                }
-
-                is Result.Error -> {
-                    Log.e("InvitationDetailViewModel", "GuestBook creation failed: ${result.message}")
-                    updateState { copy(isUploading = false) }
-                    sendEffect(InvitationGuestBookSideEffect.ShowSnackbar("방명록 생성 실패: ${result.message}"))
-                }
-            }
-        } catch (e: Exception) {
-            updateState { copy(isUploading = false) }
-            sendEffect(InvitationGuestBookSideEffect.ShowSnackbar("방명록 생성 중 오류 발생: ${e.message}"))
-        }
     }
 
     private fun startEditing(guestBook: GuestBookUiModel) {
@@ -292,7 +156,7 @@ constructor(
             .map { media ->
                 SelectedMedia(
                     id = media.id,
-                    uri = media.url, // 서버 원본 URL
+                    uri = media.url,
                     type = when (media.type) {
                         MediaUiType.IMAGE -> UiMediaType.IMAGE
                         MediaUiType.VIDEO -> UiMediaType.VIDEO
@@ -310,4 +174,132 @@ constructor(
             )
         }
     }
+
+    private fun handleUploadMedias() {
+        val state = uiState.value
+        if (!state.isSubmittable) return
+
+        viewModelScope.launch {
+            updateState { copy(isUploading = true) }
+
+            val newMedias = state.selectedMedias.filter { it.id == null }
+
+            try {
+                val uploadedUrls = if (newMedias.isNotEmpty()) {
+                    val mediaFiles = mediaFileProvider.createFromUris(newMedias.map { it.uri })
+                    when (val uploadResult = mediaUploader.uploadMedias(mediaFiles)) {
+                        is Result.Success -> uploadResult.data
+                        is Result.Error -> {
+                            updateState { copy(isUploading = false) }
+                            sendEffect(InvitationGuestBookSideEffect.ShowSnackbar("업로드 실패: ${uploadResult.message}"))
+                            return@launch
+                        }
+                    }
+                } else {
+                    emptyList()
+                }
+
+                if (state.editingGuestBookId == null) {
+                    Log.d("qqqqq", "방명록 생성")
+                    createGuestBook(uploadedUrls, newMedias)
+                } else {
+                    Log.d("qqqqq", "방명록 수정: ${state.editingGuestBookId}")
+                    updateGuestBook(state.editingGuestBookId, uploadedUrls, state.selectedMedias)
+                }
+            } catch (e: Exception) {
+                updateState { copy(isUploading = false) }
+                sendEffect(InvitationGuestBookSideEffect.ShowSnackbar("업로드 중 오류 발생: ${e.message}"))
+                return@launch
+            }
+        }
+    }
+
+    private suspend fun createGuestBook(uploadedUrls: List<String?>, newSelectedMedias: List<SelectedMedia>) {
+        val guestBookMedias = uploadedUrls
+            .mapIndexedNotNull { index, url ->
+                val urlValue = url ?: return@mapIndexedNotNull null
+                val selectedMedia = newSelectedMedias.getOrNull(index) ?: return@mapIndexedNotNull null
+
+                GuestBookMedia(
+                    id = 0L,
+                    type = when (selectedMedia.type) {
+                        UiMediaType.IMAGE -> MediaType.IMAGE
+                        UiMediaType.VIDEO -> MediaType.VIDEO
+                        UiMediaType.AUDIO -> MediaType.AUDIO
+                    },
+                    url = urlValue,
+                    thumbnailUrl = null,
+                    durationSeconds = selectedMedia.duration,
+                    displayOrder = index,
+                )
+            }
+
+        val result = guestBookRepository.createGuestBook(
+            invitationId = invitationId,
+            userId = 1,
+            textContent = uiState.value.textContent,
+            medias = guestBookMedias,
+        )
+        handleResult(result)
+    }
+
+    private fun updateGuestBook(
+        guestBookId: Long,
+        uploadedUrls: List<String?>,
+        allSelectedMedias: List<SelectedMedia>
+    ) = viewModelScope.launch {
+        val existingImageIds = allSelectedMedias.filter { it.id != null && it.type == UiMediaType.IMAGE }.mapNotNull { it.id }
+        val existingAudioIds = allSelectedMedias.filter { it.id != null && it.type == UiMediaType.AUDIO }.mapNotNull { it.id }
+        val existingVideoIds = allSelectedMedias.filter { it.id != null && it.type == UiMediaType.VIDEO }.mapNotNull { it.id }
+
+        val onlyNewMedias = allSelectedMedias.filter { it.id == null }
+
+        val newMedias = uploadedUrls
+            .mapIndexedNotNull { index, url ->
+                val urlValue = url ?: return@mapIndexedNotNull null
+                val selectedMedia = onlyNewMedias.getOrNull(index) ?: return@mapIndexedNotNull null
+
+                GuestBookMedia(
+                    id = 0L,
+                    type = when (selectedMedia.type) {
+                        UiMediaType.IMAGE -> MediaType.IMAGE
+                        UiMediaType.VIDEO -> MediaType.VIDEO
+                        UiMediaType.AUDIO -> MediaType.AUDIO
+                    },
+                    url = urlValue,
+                    thumbnailUrl = null,
+                    durationSeconds = selectedMedia.duration,
+                    displayOrder = allSelectedMedias.indexOf(selectedMedia)
+                )
+            }
+
+        val result = guestBookRepository.updateGuestBook(
+            guestBookId = guestBookId,
+            textContent = uiState.value.textContent,
+            existingImageIds = existingImageIds,
+            existingVideoIds = existingVideoIds,
+            existingAudioIds = existingAudioIds,
+            newMedias = newMedias
+        )
+        handleResult(result)
+    }
+
+    private fun handleResult(result: Result<GuestBook, DataError>) {
+        updateState { copy(isUploading = false) }
+        when (result) {
+            is Result.Success -> {
+                updateState {
+                    copy(
+                        editingGuestBookId = null,
+                        selectedMedias = persistentListOf(),
+                        textContent = ""
+                    )
+                }
+                sendEffect(InvitationGuestBookSideEffect.CreateGuestBookSuccess)
+            }
+
+            is Result.Error -> sendEffect(InvitationGuestBookSideEffect.ShowSnackbar("실패: ${result.message}"))
+        }
+    }
+
 }

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationGuestBookViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationGuestBookViewModel.kt
@@ -34,10 +34,13 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
@@ -61,13 +64,16 @@ constructor(
 
     override val uiState: StateFlow<InvitationGuestBookUiState> = mutableUiState.asStateFlow()
 
+    private val refreshFlow = MutableStateFlow(0)
+
     @OptIn(ExperimentalCoroutinesApi::class)
     val guestBooksPagingFlow: Flow<PagingData<GuestBookUiModel>> =
-        guestBookRepository.getGuestBooksByInvitationId(invitationId)
-            .map { pagingData ->
-                pagingData.map { it.toUiModel() }
-            }
-            .cachedIn(viewModelScope)
+        refreshFlow.flatMapLatest {
+            guestBookRepository.getGuestBooksByInvitationId(invitationId)
+                .map { pagingData ->
+                    pagingData.map { it.toUiModel() }
+                }
+        }.cachedIn(viewModelScope)
 
     init {
         observeAudioPlayerState()
@@ -249,11 +255,11 @@ constructor(
         handleResult(result)
     }
 
-    private fun updateGuestBook(
+    private suspend fun updateGuestBook(
         guestBookId: Long,
         uploadedUrls: List<String?>,
         allSelectedMedias: List<SelectedMedia>
-    ) = viewModelScope.launch {
+    ) {
         val existingImageIds = allSelectedMedias.filter { it.id != null && it.type == UiMediaType.IMAGE }.mapNotNull { it.id }
         val existingAudioIds = allSelectedMedias.filter { it.id != null && it.type == UiMediaType.AUDIO }.mapNotNull { it.id }
         val existingVideoIds = allSelectedMedias.filter { it.id != null && it.type == UiMediaType.VIDEO }.mapNotNull { it.id }
@@ -287,10 +293,10 @@ constructor(
             existingAudioIds = existingAudioIds,
             newMedias = newMedias
         )
-        handleResult(result)
+        handleResult(result, true)
     }
 
-    private fun handleResult(result: Result<GuestBook, DataError>) {
+    private fun handleResult(result: Result<GuestBook, DataError>, isUpdate: Boolean = false) = viewModelScope.launch {
         updateState { copy(isUploading = false) }
         when (result) {
             is Result.Success -> {
@@ -301,20 +307,31 @@ constructor(
                         textContent = ""
                     )
                 }
-                sendEffect(InvitationGuestBookSideEffect.CreateGuestBookSuccess)
+                if (isUpdate) {
+                    sendEffect(InvitationGuestBookSideEffect.UpdateGuestBookSuccess)
+                } else {
+                    sendEffect(InvitationGuestBookSideEffect.CreateGuestBookSuccess)
+                }
             }
 
             is Result.Error -> sendEffect(InvitationGuestBookSideEffect.ShowSnackbar("실패: ${result.message}"))
         }
     }
 
-    private fun deleteGuestBook(guestBookId: Long) = viewModelScope.launch {
-        guestBookRepository.deleteGuestBook(guestBookId)
-            .onSuccess { deletedId ->
-                sendEffect(InvitationGuestBookSideEffect.DeleteGuestBookSuccess)
-            }
-            .onFailure {
-                sendEffect(InvitationGuestBookSideEffect.ShowSnackbar("방명록 삭제를 실패하였습니다."))
-            }
+    private fun deleteGuestBook(guestBookId: Long) {
+        viewModelScope.launch {
+            guestBookRepository.deleteGuestBook(guestBookId)
+                .onSuccess { deletedId ->
+                    sendEffect(InvitationGuestBookSideEffect.DeleteGuestBookSuccess)
+                }
+                .onFailure {
+                    sendEffect(InvitationGuestBookSideEffect.ShowSnackbar("방명록 삭제를 실패하였습니다."))
+                }
+        }
+    }
+
+    fun invalidateGuestBooks() {
+        Log.d("qqqqq", "방명록 목록 무효화")
+        refreshFlow.value += 1
     }
 }

--- a/android/feature/invitation/src/main/res/values/strings.xml
+++ b/android/feature/invitation/src/main/res/values/strings.xml
@@ -15,5 +15,9 @@
     </string-array>
 
     <string name="snack_load_error_map">설치된 지도 앱이 없습니다.</string>
+    <string name="txt_delete_dialog_title">정말로 이 방명록을\n삭제하시겠습니까?</string>
+    <string name="txt_delete_dialog_message">삭제된 방명록은 복구할 수 없습니다.</string>
+    <string name="btn_label_cancel">취소</string>
+    <string name="btn_label_delete">삭제</string>
 </resources>
 

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/controller/MediaController.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/controller/MediaController.kt
@@ -254,29 +254,6 @@ class MediaController(
         }
     }
 
-    @DeleteMapping("/{mediaKey}")
-    fun deleteMedia(
-        @PathVariable mediaKey: String
-    ): BaseResponse<DeleteMediaResponse> {
-        return try {
-            r2Client.deleteObject { builder ->
-                builder.bucket(bucketName)
-                    .key(mediaKey)
-            }
-
-            BaseResponse.success(DeleteMediaResponse(success = true))
-
-        } catch (e: Exception) {
-            BaseResponse.success(
-                DeleteMediaResponse(
-                    success = false,
-                    message = "Media deletion failed: ${e.message}"
-                ),
-                responseCode = CommonResponseCode.INTERNAL_SERVER_ERROR
-            )
-        }
-    }
-
     private fun createSimpleUploadInfo(
         key: String,
         mediaType: MediaType,

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/controller/guestbook/GuestBookController.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/controller/guestbook/GuestBookController.kt
@@ -4,6 +4,7 @@ import com.andlife.InvitationServer.request.invitation.guestbook.UpdateGuestBook
 import com.andlife.InvitationServer.response.BaseResponse
 import com.andlife.InvitationServer.response.invitation.guestbook.GuestBookResponse
 import com.andlife.InvitationServer.service.invitation.guestbook.GuestBookService
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -22,5 +23,13 @@ class GuestBookController(
     ): BaseResponse<GuestBookResponse> {
         val result = guestBookService.updateGuestBook(guestBookId, request)
         return BaseResponse.success(result)
+    }
+
+    @DeleteMapping("/{guestBookId}")
+    fun deleteGuestBook(
+        @PathVariable guestBookId: Long
+    ): BaseResponse<Long> {
+        guestBookService.deleteGuestBook(guestBookId)
+        return BaseResponse.success(guestBookId)
     }
 }

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/controller/guestbook/GuestBookController.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/controller/guestbook/GuestBookController.kt
@@ -1,5 +1,6 @@
 package com.andlife.InvitationServer.controller.guestbook
 
+import com.andlife.InvitationServer.auth.AuthContext
 import com.andlife.InvitationServer.request.invitation.guestbook.UpdateGuestBookRequest
 import com.andlife.InvitationServer.response.BaseResponse
 import com.andlife.InvitationServer.response.invitation.guestbook.GuestBookResponse
@@ -19,17 +20,19 @@ class GuestBookController(
     @PutMapping("/{guestBookId}")
     fun updateGuestBook(
         @PathVariable guestBookId: Long,
+        authContext: AuthContext,
         @RequestBody request: UpdateGuestBookRequest
     ): BaseResponse<GuestBookResponse> {
-        val result = guestBookService.updateGuestBook(guestBookId, request)
+        val result = guestBookService.updateGuestBook(guestBookId, request, authContext)
         return BaseResponse.success(result)
     }
 
     @DeleteMapping("/{guestBookId}")
     fun deleteGuestBook(
-        @PathVariable guestBookId: Long
+        @PathVariable guestBookId: Long,
+        authContext: AuthContext,
     ): BaseResponse<Long> {
-        guestBookService.deleteGuestBook(guestBookId)
+        guestBookService.deleteGuestBook(guestBookId, authContext)
         return BaseResponse.success(guestBookId)
     }
 }

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/controller/guestbook/GuestBookController.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/controller/guestbook/GuestBookController.kt
@@ -1,0 +1,26 @@
+package com.andlife.InvitationServer.controller.guestbook
+
+import com.andlife.InvitationServer.request.invitation.guestbook.UpdateGuestBookRequest
+import com.andlife.InvitationServer.response.BaseResponse
+import com.andlife.InvitationServer.response.invitation.guestbook.GuestBookResponse
+import com.andlife.InvitationServer.service.invitation.guestbook.GuestBookService
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PutMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/guestbooks")
+class GuestBookController(
+    private val guestBookService: GuestBookService,
+) {
+    @PutMapping("/{guestBookId}")
+    fun updateGuestBook(
+        @PathVariable guestBookId: Long,
+        @RequestBody request: UpdateGuestBookRequest
+    ): BaseResponse<GuestBookResponse> {
+        val result = guestBookService.updateGuestBook(guestBookId, request)
+        return BaseResponse.success(result)
+    }
+}

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/controller/invitation/InvitationController.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/controller/invitation/InvitationController.kt
@@ -97,14 +97,4 @@ class InvitationController(
             BaseResponse.error(responseCode = CommonResponseCode.INTERNAL_SERVER_ERROR)
         }
     }
-
-    @PutMapping("/{invitationId}/guestbooks/{guestBookId}")
-    fun updateGuestBook(
-        @PathVariable invitationId: Long,
-        @PathVariable guestBookId: Long,
-        @RequestBody request: GuestBookUpdateRequest
-    ): BaseResponse<GuestBookResponse> {
-        val result = guestBookService.updateGuestBook(guestBookId, request)
-        return BaseResponse.success(result)
-    }
 }

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/controller/invitation/InvitationController.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/controller/invitation/InvitationController.kt
@@ -2,7 +2,6 @@ package com.andlife.InvitationServer.controller.invitation
 
 import com.andlife.InvitationServer.request.invitation.CreateInvitationRequest
 import com.andlife.InvitationServer.request.invitation.guestbook.GuestBookRequest
-import com.andlife.InvitationServer.request.invitation.guestbook.GuestBookUpdateRequest
 import com.andlife.InvitationServer.response.BaseResponse
 import com.andlife.InvitationServer.response.CommonResponseCode
 import com.andlife.InvitationServer.response.PagingResponse
@@ -14,13 +13,7 @@ import com.andlife.InvitationServer.service.invitation.guestbook.GuestBookServic
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.web.PageableDefault
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/api/invitations")

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/controller/invitation/InvitationController.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/controller/invitation/InvitationController.kt
@@ -2,6 +2,7 @@ package com.andlife.InvitationServer.controller.invitation
 
 import com.andlife.InvitationServer.request.invitation.CreateInvitationRequest
 import com.andlife.InvitationServer.request.invitation.guestbook.GuestBookRequest
+import com.andlife.InvitationServer.request.invitation.guestbook.GuestBookUpdateRequest
 import com.andlife.InvitationServer.response.BaseResponse
 import com.andlife.InvitationServer.response.CommonResponseCode
 import com.andlife.InvitationServer.response.PagingResponse
@@ -16,6 +17,7 @@ import org.springframework.data.web.PageableDefault
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.PutMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RestController
@@ -94,5 +96,15 @@ class InvitationController(
             println(e.message)
             BaseResponse.error(responseCode = CommonResponseCode.INTERNAL_SERVER_ERROR)
         }
+    }
+
+    @PutMapping("/{invitationId}/guestbooks/{guestBookId}")
+    fun updateGuestBook(
+        @PathVariable invitationId: Long,
+        @PathVariable guestBookId: Long,
+        @RequestBody request: GuestBookUpdateRequest
+    ): BaseResponse<GuestBookResponse> {
+        val result = guestBookService.updateGuestBook(guestBookId, request)
+        return BaseResponse.success(result)
     }
 }

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/controller/invitation/InvitationController.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/controller/invitation/InvitationController.kt
@@ -61,9 +61,10 @@ class InvitationController(
     @GetMapping("/{invitationId}/guestbooks")
     fun getGuestBooks(
         @PathVariable invitationId: Long,
+        authContext: AuthContext,
         @PageableDefault(size = 10, sort = ["createdAt"], direction = Sort.Direction.DESC) pageable: Pageable
     ): BaseResponse<PagingResponse<GuestBookResponse>> {
-        val result = guestBookService.getGuestBooks(invitationId, pageable)
+        val result = guestBookService.getGuestBooks(invitationId, pageable, authContext)
         return BaseResponse.success(result)
     }
 

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/request/invitation/guestbook/GuestBookUpdateRequest.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/request/invitation/guestbook/GuestBookUpdateRequest.kt
@@ -1,0 +1,9 @@
+package com.andlife.InvitationServer.request.invitation.guestbook
+
+data class GuestBookUpdateRequest(
+    val textContent: String,
+    val existingImageIds: List<Long> = emptyList(),
+    val existingVideoIds: List<Long> = emptyList(),
+    val existingAudioIds: List<Long> = emptyList(),
+    val newMedias: List<GuestBookMediaRequest> = emptyList()
+)

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/request/invitation/guestbook/UpdateGuestBookRequest.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/request/invitation/guestbook/UpdateGuestBookRequest.kt
@@ -1,6 +1,6 @@
 package com.andlife.InvitationServer.request.invitation.guestbook
 
-data class GuestBookUpdateRequest(
+data class UpdateGuestBookRequest(
     val textContent: String,
     val existingImageIds: List<Long> = emptyList(),
     val existingVideoIds: List<Long> = emptyList(),

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/response/ResponseCode.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/response/ResponseCode.kt
@@ -16,7 +16,8 @@ enum class CommonResponseCode(
     OK(HttpStatus.OK, "성공적으로 처리되었습니다."),
 
     // 4xx 클라이언트 에러
-    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증 정보가 유효하지 않습니다."),
+    UNAUTHORIZED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    FORBIDDEN(HttpStatus.FORBIDDEN, "권한이 없습니다."),
     NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 정보를 찾을 수 없습니다."),
     BAD_REQUEST(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
 

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/service/invitation/guestbook/GuestBookService.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/service/invitation/guestbook/GuestBookService.kt
@@ -1,5 +1,6 @@
 package com.andlife.InvitationServer.service.invitation.guestbook
 
+import com.andlife.InvitationServer.auth.AuthContext
 import com.andlife.InvitationServer.constant.MediaType
 import com.andlife.InvitationServer.entity.GuestBook
 import com.andlife.InvitationServer.entity.GuestBookAudio
@@ -91,10 +92,19 @@ class GuestBookService(
         return collection.sortedByDescending { it.createdAt }
     }
 
-    fun getGuestBooks(invitationId: Long, pageable: Pageable): PagingResponse<GuestBookResponse> {
+    fun getGuestBooks(
+        invitationId: Long,
+        pageable: Pageable,
+        authContext: AuthContext
+    ): PagingResponse<GuestBookResponse> {
         val guestBooksPage = guestBookRepository.findAllByInvitationId(invitationId, pageable)
 
         val responsePage = guestBooksPage.map { guestBook ->
+            val isOwner = when (authContext) {
+                is AuthContext.Member -> authContext.userId == guestBook.user.id
+                is AuthContext.Guest -> false
+            }
+
             val allMedia = mutableListOf<GuestBookMediaResponse>()
 
             guestBook.images.forEach {
@@ -141,7 +151,7 @@ class GuestBookService(
                 visualMedias = visualMedias,
                 audioMedias = audioMedias,
                 totalVisualCount = visualMedias.size,
-                isOwner = true,
+                isOwner = isOwner,
                 createdAt = guestBook.createdAt,
                 updatedAt = guestBook.updatedAt
             )
@@ -201,7 +211,7 @@ class GuestBookService(
                         durationSeconds = mediaReq.durationSeconds ?: 0,
                         displayOrder = mediaReq.displayOrder
                     )
-                    
+
                     // 썸네일이 있는 경우 VideoPreviewThumbnail에도 추가
                     if (!mediaReq.thumbnailUrl.isNullOrEmpty()) {
                         val previewThumbnail = VideoPreviewThumbnail(
@@ -211,7 +221,7 @@ class GuestBookService(
                         )
                         video.previewThumbnails.add(previewThumbnail)
                     }
-                    
+
                     guestBook.videos.add(video)
                 }
 
@@ -237,13 +247,30 @@ class GuestBookService(
         request.newMedias.forEach { mediaReq ->
             when (mediaReq.mediaType) {
                 "IMAGE" -> guestBook.images.add(
-                    GuestBookImage(guestBook = guestBook, imageUrl = mediaReq.mediaUrl, displayOrder = mediaReq.displayOrder)
+                    GuestBookImage(
+                        guestBook = guestBook,
+                        imageUrl = mediaReq.mediaUrl,
+                        displayOrder = mediaReq.displayOrder
+                    )
                 )
+
                 "AUDIO" -> guestBook.audios.add(
-                    GuestBookAudio(guestBook = guestBook, audioUrl = mediaReq.mediaUrl, durationSeconds = mediaReq.durationSeconds ?: 0, displayOrder = mediaReq.displayOrder)
+                    GuestBookAudio(
+                        guestBook = guestBook,
+                        audioUrl = mediaReq.mediaUrl,
+                        durationSeconds = mediaReq.durationSeconds ?: 0,
+                        displayOrder = mediaReq.displayOrder
+                    )
                 )
+
                 "VIDEO" -> guestBook.videos.add(
-                    GuestBookVideo(guestBook = guestBook, videoUrl = mediaReq.mediaUrl, thumbnailUrl = mediaReq.thumbnailUrl ?: "", durationSeconds = mediaReq.durationSeconds ?: 0, displayOrder = mediaReq.displayOrder)
+                    GuestBookVideo(
+                        guestBook = guestBook,
+                        videoUrl = mediaReq.mediaUrl,
+                        thumbnailUrl = mediaReq.thumbnailUrl ?: "",
+                        durationSeconds = mediaReq.durationSeconds ?: 0,
+                        displayOrder = mediaReq.displayOrder
+                    )
                 )
             }
         }

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/service/invitation/guestbook/GuestBookService.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/service/invitation/guestbook/GuestBookService.kt
@@ -17,6 +17,7 @@ import com.andlife.InvitationServer.response.invitation.guestbook.CollectionResp
 import com.andlife.InvitationServer.response.invitation.guestbook.GuestBookMediaResponse
 import com.andlife.InvitationServer.response.invitation.guestbook.GuestBookResponse
 import com.andlife.InvitationServer.response.invitation.guestbook.toGuestBookResponse
+import com.andlife.InvitationServer.service.media.MediaService
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.data.domain.Pageable
 import org.springframework.data.repository.findByIdOrNull
@@ -28,7 +29,8 @@ import org.springframework.transaction.annotation.Transactional
 class GuestBookService(
     private val guestBookRepository: GuestBookRepository,
     private val userRepository: UserRepository,
-    private val invitationRepository: InvitationRepository
+    private val invitationRepository: InvitationRepository,
+    private val mediaService: MediaService
 ) {
 
     fun getCollectionByInvitation(invitationId: Long): List<CollectionResponse> {
@@ -242,6 +244,19 @@ class GuestBookService(
 
         validateOwner(guestBook.user.id, authContext)
 
+        val mediaKeysToDelete = mutableListOf<String>()
+
+        guestBook.images.filter { it.id !in request.existingImageIds }
+            .forEach { mediaKeysToDelete.add(mediaService.extractKey(it.imageUrl)) }
+        guestBook.audios.filter { it.id !in request.existingAudioIds }
+            .forEach { mediaKeysToDelete.add(mediaService.extractKey(it.audioUrl)) }
+        guestBook.videos.filter { it.id !in request.existingVideoIds }
+            .forEach {
+                mediaKeysToDelete.add(mediaService.extractKey(it.videoUrl))
+                mediaKeysToDelete.add(mediaService.extractKey(it.thumbnailUrl))
+            }
+
+
         guestBook.textContent = request.textContent
 
         guestBook.images.removeIf { !request.existingImageIds.contains(it.id) }
@@ -279,6 +294,10 @@ class GuestBookService(
             }
         }
 
+        mediaKeysToDelete.forEach { mediaKey ->
+            mediaService.deleteMedia(mediaKey)
+        }
+
         return guestBook.toGuestBookResponse()
     }
 
@@ -289,7 +308,12 @@ class GuestBookService(
 
         validateOwner(guestBook.user.id, authContext)
 
+        val mediaKeys = getAllMediaKeys(guestBook)
         guestBookRepository.delete(guestBook)
+
+        mediaKeys.forEach { mediaKey ->
+            mediaService.deleteMedia(mediaKey)
+        }
     }
 
     private fun validateOwner(guestBookUserId: Long, authContext: AuthContext) {
@@ -299,9 +323,21 @@ class GuestBookService(
                     throw BusinessException(CommonResponseCode.FORBIDDEN)
                 }
             }
+
             is AuthContext.Guest -> {
                 throw BusinessException(CommonResponseCode.FORBIDDEN)
             }
         }
+    }
+
+    private fun getAllMediaKeys(guestBook: GuestBook): List<String> {
+        val keys = mutableListOf<String>()
+        guestBook.images.forEach { keys.add(mediaService.extractKey(it.imageUrl)) }
+        guestBook.audios.forEach { keys.add(mediaService.extractKey(it.audioUrl)) }
+        guestBook.videos.forEach {
+            keys.add(mediaService.extractKey(it.videoUrl))
+            keys.add(mediaService.extractKey(it.thumbnailUrl))
+        }
+        return keys
     }
 }

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/service/invitation/guestbook/GuestBookService.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/service/invitation/guestbook/GuestBookService.kt
@@ -17,7 +17,9 @@ import com.andlife.InvitationServer.response.invitation.guestbook.CollectionResp
 import com.andlife.InvitationServer.response.invitation.guestbook.GuestBookMediaResponse
 import com.andlife.InvitationServer.response.invitation.guestbook.GuestBookResponse
 import com.andlife.InvitationServer.response.invitation.guestbook.toGuestBookResponse
+import jakarta.persistence.EntityNotFoundException
 import org.springframework.data.domain.Pageable
+import org.springframework.data.repository.findByIdOrNull
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -235,5 +237,15 @@ class GuestBookService(
         }
 
         return guestBook.toGuestBookResponse()
+    }
+
+    @Transactional
+    fun deleteGuestBook(guestBookId: Long) {
+        val guestBook = guestBookRepository.findByIdOrNull(guestBookId)
+            ?: throw EntityNotFoundException("방명록을 찾을 수 없습니다. id: $guestBookId")
+
+        // TODO: 추후 권한 체크 로직 추가해야 하나?
+
+        guestBookRepository.delete(guestBook)
     }
 }

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/service/invitation/guestbook/GuestBookService.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/service/invitation/guestbook/GuestBookService.kt
@@ -139,7 +139,7 @@ class GuestBookService(
                 visualMedias = visualMedias,
                 audioMedias = audioMedias,
                 totalVisualCount = visualMedias.size,
-                isOwner = false,
+                isOwner = true,
                 createdAt = guestBook.createdAt,
                 updatedAt = guestBook.updatedAt
             )

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/service/invitation/guestbook/GuestBookService.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/service/invitation/guestbook/GuestBookService.kt
@@ -9,12 +9,11 @@ import com.andlife.InvitationServer.repository.invitation.InvitationRepository
 import com.andlife.InvitationServer.repository.invitation.guestbook.GuestBookRepository
 import com.andlife.InvitationServer.repository.user.UserRepository
 import com.andlife.InvitationServer.request.invitation.guestbook.GuestBookRequest
-import com.andlife.InvitationServer.request.invitation.guestbook.GuestBookUpdateRequest
+import com.andlife.InvitationServer.request.invitation.guestbook.UpdateGuestBookRequest
 import com.andlife.InvitationServer.response.AuthorResponse
 import com.andlife.InvitationServer.response.PagingMetaResponse
 import com.andlife.InvitationServer.response.PagingResponse
 import com.andlife.InvitationServer.response.invitation.guestbook.CollectionResponse
-import com.andlife.InvitationServer.response.invitation.guestbook.GuestBookInvitationResponse
 import com.andlife.InvitationServer.response.invitation.guestbook.GuestBookMediaResponse
 import com.andlife.InvitationServer.response.invitation.guestbook.GuestBookResponse
 import com.andlife.InvitationServer.response.invitation.guestbook.toGuestBookResponse
@@ -211,7 +210,7 @@ class GuestBookService(
     }
 
     @Transactional
-    fun updateGuestBook(guestBookId: Long, request: GuestBookUpdateRequest): GuestBookResponse {
+    fun updateGuestBook(guestBookId: Long, request: UpdateGuestBookRequest): GuestBookResponse {
         val guestBook = guestBookRepository.findById(guestBookId)
             .orElseThrow { IllegalArgumentException("방명록을 찾을 수 없습니다. id: $guestBookId") }
 

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/service/invitation/guestbook/GuestBookService.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/service/invitation/guestbook/GuestBookService.kt
@@ -2,17 +2,15 @@ package com.andlife.InvitationServer.service.invitation.guestbook
 
 import com.andlife.InvitationServer.auth.AuthContext
 import com.andlife.InvitationServer.constant.MediaType
-import com.andlife.InvitationServer.entity.GuestBook
-import com.andlife.InvitationServer.entity.GuestBookAudio
-import com.andlife.InvitationServer.entity.GuestBookImage
-import com.andlife.InvitationServer.entity.GuestBookVideo
-import com.andlife.InvitationServer.entity.VideoPreviewThumbnail
+import com.andlife.InvitationServer.entity.*
+import com.andlife.InvitationServer.error.BusinessException
 import com.andlife.InvitationServer.repository.invitation.InvitationRepository
 import com.andlife.InvitationServer.repository.invitation.guestbook.GuestBookRepository
 import com.andlife.InvitationServer.repository.user.UserRepository
 import com.andlife.InvitationServer.request.invitation.guestbook.GuestBookRequest
 import com.andlife.InvitationServer.request.invitation.guestbook.UpdateGuestBookRequest
 import com.andlife.InvitationServer.response.AuthorResponse
+import com.andlife.InvitationServer.response.CommonResponseCode
 import com.andlife.InvitationServer.response.PagingMetaResponse
 import com.andlife.InvitationServer.response.PagingResponse
 import com.andlife.InvitationServer.response.invitation.guestbook.CollectionResponse
@@ -234,9 +232,15 @@ class GuestBookService(
     }
 
     @Transactional
-    fun updateGuestBook(guestBookId: Long, request: UpdateGuestBookRequest): GuestBookResponse {
+    fun updateGuestBook(
+        guestBookId: Long,
+        request: UpdateGuestBookRequest,
+        authContext: AuthContext
+    ): GuestBookResponse {
         val guestBook = guestBookRepository.findById(guestBookId)
             .orElseThrow { IllegalArgumentException("방명록을 찾을 수 없습니다. id: $guestBookId") }
+
+        validateOwner(guestBook.user.id, authContext)
 
         guestBook.textContent = request.textContent
 
@@ -279,12 +283,25 @@ class GuestBookService(
     }
 
     @Transactional
-    fun deleteGuestBook(guestBookId: Long) {
+    fun deleteGuestBook(guestBookId: Long, authContext: AuthContext) {
         val guestBook = guestBookRepository.findByIdOrNull(guestBookId)
             ?: throw EntityNotFoundException("방명록을 찾을 수 없습니다. id: $guestBookId")
 
-        // TODO: 추후 권한 체크 로직 추가해야 하나?
+        validateOwner(guestBook.user.id, authContext)
 
         guestBookRepository.delete(guestBook)
+    }
+
+    private fun validateOwner(guestBookUserId: Long, authContext: AuthContext) {
+        when (authContext) {
+            is AuthContext.Member -> {
+                if (guestBookUserId != authContext.userId) {
+                    throw BusinessException(CommonResponseCode.FORBIDDEN)
+                }
+            }
+            is AuthContext.Guest -> {
+                throw BusinessException(CommonResponseCode.FORBIDDEN)
+            }
+        }
     }
 }

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/service/invitation/guestbook/GuestBookService.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/service/invitation/guestbook/GuestBookService.kt
@@ -244,21 +244,9 @@ class GuestBookService(
 
         validateOwner(guestBook.user.id, authContext)
 
-        val mediaKeysToDelete = mutableListOf<String>()
-
-        guestBook.images.filter { it.id !in request.existingImageIds }
-            .forEach { mediaKeysToDelete.add(mediaService.extractKey(it.imageUrl)) }
-        guestBook.audios.filter { it.id !in request.existingAudioIds }
-            .forEach { mediaKeysToDelete.add(mediaService.extractKey(it.audioUrl)) }
-        guestBook.videos.filter { it.id !in request.existingVideoIds }
-            .forEach {
-                mediaKeysToDelete.add(mediaService.extractKey(it.videoUrl))
-                mediaKeysToDelete.add(mediaService.extractKey(it.thumbnailUrl))
-            }
-
+        val mediaKeysToDelete = getAllMediaKeys(guestBook).toMutableList()
 
         guestBook.textContent = request.textContent
-
         guestBook.images.removeIf { !request.existingImageIds.contains(it.id) }
         guestBook.audios.removeIf { !request.existingAudioIds.contains(it.id) }
         guestBook.videos.removeIf { !request.existingVideoIds.contains(it.id) }

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/service/invitation/guestbook/GuestBookService.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/service/invitation/guestbook/GuestBookService.kt
@@ -9,6 +9,7 @@ import com.andlife.InvitationServer.repository.invitation.InvitationRepository
 import com.andlife.InvitationServer.repository.invitation.guestbook.GuestBookRepository
 import com.andlife.InvitationServer.repository.user.UserRepository
 import com.andlife.InvitationServer.request.invitation.guestbook.GuestBookRequest
+import com.andlife.InvitationServer.request.invitation.guestbook.GuestBookUpdateRequest
 import com.andlife.InvitationServer.response.AuthorResponse
 import com.andlife.InvitationServer.response.PagingMetaResponse
 import com.andlife.InvitationServer.response.PagingResponse
@@ -207,5 +208,33 @@ class GuestBookService(
 
         val savedGuestBook = guestBookRepository.save(guestBook)
         return savedGuestBook.toGuestBookResponse()
+    }
+
+    @Transactional
+    fun updateGuestBook(guestBookId: Long, request: GuestBookUpdateRequest): GuestBookResponse {
+        val guestBook = guestBookRepository.findById(guestBookId)
+            .orElseThrow { IllegalArgumentException("방명록을 찾을 수 없습니다. id: $guestBookId") }
+
+        guestBook.textContent = request.textContent
+
+        guestBook.images.removeIf { !request.existingImageIds.contains(it.id) }
+        guestBook.audios.removeIf { !request.existingAudioIds.contains(it.id) }
+        guestBook.videos.removeIf { !request.existingVideoIds.contains(it.id) }
+
+        request.newMedias.forEach { mediaReq ->
+            when (mediaReq.mediaType) {
+                "IMAGE" -> guestBook.images.add(
+                    GuestBookImage(guestBook = guestBook, imageUrl = mediaReq.mediaUrl, displayOrder = mediaReq.displayOrder)
+                )
+                "AUDIO" -> guestBook.audios.add(
+                    GuestBookAudio(guestBook = guestBook, audioUrl = mediaReq.mediaUrl, durationSeconds = mediaReq.durationSeconds ?: 0, displayOrder = mediaReq.displayOrder)
+                )
+                "VIDEO" -> guestBook.videos.add(
+                    GuestBookVideo(guestBook = guestBook, videoUrl = mediaReq.mediaUrl, thumbnailUrl = mediaReq.thumbnailUrl ?: "", durationSeconds = mediaReq.durationSeconds ?: 0, displayOrder = mediaReq.displayOrder)
+                )
+            }
+        }
+
+        return guestBook.toGuestBookResponse()
     }
 }

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/service/media/MediaService.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/service/media/MediaService.kt
@@ -1,0 +1,27 @@
+package com.andlife.InvitationServer.service.media
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import software.amazon.awssdk.services.s3.S3Client
+
+@Service
+class MediaService(
+    private val r2Client: S3Client,
+    @Value($$"${r2.bucket-name}") private val bucketName: String,
+    @Value($$"${r2.public-url}") private val publicUrl: String
+) {
+    fun deleteMedia(mediaKey: String) {
+        if (mediaKey.isBlank()) return
+        try {
+            r2Client.deleteObject { it.bucket(bucketName).key(mediaKey) }
+        } catch (e: Exception) {
+            println("미디어 삭제 실패: $mediaKey, 오류: ${e.message}")
+        }
+    }
+
+    fun extractKey(url: String?): String {
+        if (url.isNullOrBlank()) return ""
+        val baseUrl = publicUrl.removeSuffix("/")
+        return url.substringAfter("$baseUrl/").removePrefix("/")
+    }
+}

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/util/GlobalExceptionHandler.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/util/GlobalExceptionHandler.kt
@@ -1,5 +1,6 @@
 package com.andlife.InvitationServer.util
 
+import com.andlife.InvitationServer.error.BusinessException
 import com.andlife.InvitationServer.response.BaseResponse
 import com.andlife.InvitationServer.response.CommonResponseCode
 import jakarta.persistence.EntityNotFoundException
@@ -22,6 +23,14 @@ class GlobalExceptionHandler {
         return BaseResponse.error(
             responseCode = CommonResponseCode.INTERNAL_SERVER_ERROR,
             customMessage = "서버 내부 오류가 발생했습니다."
+        )
+    }
+
+    @ExceptionHandler(BusinessException::class)
+    fun handleBusinessException(e: BusinessException): BaseResponse<Nothing> {
+        return BaseResponse.error(
+            responseCode = e.responseCode,
+            customMessage = e.message
         )
     }
 }

--- a/backend/src/main/kotlin/com/andlife/InvitationServer/util/GlobalExceptionHandler.kt
+++ b/backend/src/main/kotlin/com/andlife/InvitationServer/util/GlobalExceptionHandler.kt
@@ -1,0 +1,27 @@
+package com.andlife.InvitationServer.util
+
+import com.andlife.InvitationServer.response.BaseResponse
+import com.andlife.InvitationServer.response.CommonResponseCode
+import jakarta.persistence.EntityNotFoundException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+
+    @ExceptionHandler(EntityNotFoundException::class)
+    fun handleNotFound(e: EntityNotFoundException): BaseResponse<Nothing> {
+        return BaseResponse.error(
+            responseCode = CommonResponseCode.NOT_FOUND,
+            customMessage = e.message ?: "리소스를 찾을 수 없습니다."
+        )
+    }
+
+    @ExceptionHandler(Exception::class)
+    fun handleGeneral(e: Exception): BaseResponse<Nothing> {
+        return BaseResponse.error(
+            responseCode = CommonResponseCode.INTERNAL_SERVER_ERROR,
+            customMessage = "서버 내부 오류가 발생했습니다."
+        )
+    }
+}


### PR DESCRIPTION
## 🔍 변경 사항

- 방명록 수정, 삭제 구현
- 로딩 때는 그냥 리스트 보이게 하고 데이터 새로 불러온 후 바꾸는 방식으로 했습니다.(처음 로딩 제외)

## 리뷰 요청사항
- 수정 시 커서 뒤쪽으로 가지 않는 이유는 TextFieldValue 타입을 써야한다는데 저희 NachTextField가 String이라 충돌이 많이 일어날 것 같아서 일단은 그냥 두었습니다.

## 📸 스크린샷 


https://github.com/user-attachments/assets/1cc83897-3676-41b4-bf27-c528f3743a73


https://github.com/user-attachments/assets/4d82b245-c11d-4e0e-86e6-62b7e48634f7


### 개선 후


https://github.com/user-attachments/assets/025775a4-0d24-4cd0-ae95-d1b653b366b7





## 🔗 관련 이슈

- Close #75 

## ✅ 체크리스트
- [x] 팀 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 import는 삭제했나요?
