### PR TITLE
Feature/#74 내 초대장 상세 화면 방명록 탭 추가 및 자잘한 UI/UX 수정

### DIFF
--- a/android/core/designsystem/src/main/kotlin/com/andlife/designsystem/component/NachoTextField.kt
+++ b/android/core/designsystem/src/main/kotlin/com/andlife/designsystem/component/NachoTextField.kt
@@ -29,6 +29,7 @@ fun NachoTextField(
     isError: Boolean = false,
     singleLine: Boolean = true,
     minLines: Int = 1,
+    maxLines: Int = Int.MAX_VALUE,
     keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
     leadingIcon: @Composable (() -> Unit)? = null,
@@ -50,6 +51,7 @@ fun NachoTextField(
         readOnly = readOnly,
         singleLine = singleLine,
         minLines = if (singleLine) 1 else minLines,
+        maxLines = if (singleLine) 1 else maxLines,
         textStyle = NachoTheme.typography.bodyMediumSemiBold,
         shape = NachoTheme.shapes.extraSmall,
         colors =

--- a/android/core/media/src/main/kotlin/com/andlife/media/video/AutoVideoPlayerPool.kt
+++ b/android/core/media/src/main/kotlin/com/andlife/media/video/AutoVideoPlayerPool.kt
@@ -16,6 +16,8 @@ interface AutoVideoPlayerPool {
 
     fun resumeLastPlayed()
 
+    fun clearCacheById(itemId: Long?)
+
     fun resetPool()
 
     fun releaseAllPlayers()
@@ -31,6 +33,7 @@ class FakeVideoPlayerPool : AutoVideoPlayerPool {
     override fun pausePlayer(url: String) {}
     override fun pauseAllPlayers() {}
     override fun resumeLastPlayed() {}
+    override fun clearCacheById(itemId: Long?) {}
     override fun resetPool() {}
     override fun releaseAllPlayers() {}
 }

--- a/android/core/media/src/main/kotlin/com/andlife/media/video/AutoVideoPlayerPool.kt
+++ b/android/core/media/src/main/kotlin/com/andlife/media/video/AutoVideoPlayerPool.kt
@@ -20,3 +20,17 @@ interface AutoVideoPlayerPool {
 
     fun releaseAllPlayers()
 }
+
+class FakeVideoPlayerPool : AutoVideoPlayerPool {
+    override fun preparePlayers() {}
+    override fun getPlayer(url: String): AutoVideoPlayer {
+        throw NotImplementedError()
+    }
+
+    override fun playPlayer(url: String, itemId: Long) {}
+    override fun pausePlayer(url: String) {}
+    override fun pauseAllPlayers() {}
+    override fun resumeLastPlayed() {}
+    override fun resetPool() {}
+    override fun releaseAllPlayers() {}
+}

--- a/android/core/media/src/main/kotlin/com/andlife/media/video/AutoVideoPlayerPoolImpl.kt
+++ b/android/core/media/src/main/kotlin/com/andlife/media/video/AutoVideoPlayerPoolImpl.kt
@@ -116,6 +116,18 @@ class AutoVideoPlayerPoolImpl @UnstableApi @Inject constructor(
         currentPlayingUrl?.let { activePlayers[it]?.play() }
     }
 
+    override fun clearCacheById(itemId: Long?) {
+        if (itemId == null) return
+        val oldUrl = lastPlayedUrlByGuestBookId[itemId]
+        if (oldUrl != null) {
+            activePlayers[oldUrl]?.stop()
+            activePlayers.remove(oldUrl)
+            if (currentPlayingUrl == oldUrl) currentPlayingUrl = null
+        }
+
+        lastPlayedUrlByGuestBookId.remove(itemId)
+    }
+
     override fun resetPool() {
         activePlayers.values.forEach { it.stop() }
         activePlayers.clear()

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/guestbook/GuestBookItem.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/guestbook/GuestBookItem.kt
@@ -268,11 +268,13 @@ private fun GuestBookItemTextSection(
             modifier =
                 Modifier
                     .fillMaxWidth()
-                    .clickable {
+                    .then(
                         if (isOverflowed) {
-                            isExpanded = !isExpanded
+                            Modifier.clickable { isExpanded = !isExpanded }
+                        } else {
+                            Modifier
                         }
-                    },
+                    ),
             verticalArrangement = Arrangement.spacedBy(NachoSpacing.small),
         ) {
             Text(

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/guestbook/GuestBookItem.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/guestbook/GuestBookItem.kt
@@ -113,30 +113,20 @@ fun GuestBookItem(
             textContent = guestBook.textContent,
             onInvitationTitleClick = onInvitationTitleClick,
         )
-        if (guestBook.visualMedias.isNotEmpty()) {
-            GuestBookItemVisualMediaSection(
-                guestBookId = guestBook.id,
-                visualMediaUrls = guestBook.visualMedias,
-                totalVisualCount = guestBook.totalVisualCount,
-                shouldPlayVideo = shouldPlayVideo,
-                videoPlayerPool = videoPlayerPool,
-                onVisualMediaClick = onVisualMediaClick,
-            )
-        }
-        if (guestBook.audioMedias.isNotEmpty()) {
-            Column(
-                modifier = Modifier,
-                verticalArrangement = Arrangement.spacedBy(NachoSpacing.small),
-            ) {
-                guestBook.audioMedias.forEach { audio ->
-                    GuestBookAudioItem(
-                        audio = audio,
-                        isAudioPlaying = isAudioPlaying && (audio.url == playingAudioUrl),
-                        onAudioMediaClick = onAudioMediaClick,
-                    )
-                }
-            }
-        }
+        GuestBookItemVisualMediaSection(
+            guestBookId = guestBook.id,
+            visualMediaUrls = guestBook.visualMedias,
+            totalVisualCount = guestBook.totalVisualCount,
+            shouldPlayVideo = shouldPlayVideo,
+            videoPlayerPool = videoPlayerPool,
+            onVisualMediaClick = onVisualMediaClick,
+        )
+        GuestBookItemAudioSection(
+            audioMedias = guestBook.audioMedias,
+            isAudioPlaying = isAudioPlaying,
+            playingAudioUrl = playingAudioUrl,
+            onAudioMediaClick = onAudioMediaClick,
+        )
         HorizontalDivider(
             modifier = Modifier.padding(top = NachoSpacing.xSmall),
             color = NachoTheme.colorScheme.backgroundBorder,
@@ -244,6 +234,8 @@ private fun GuestBookItemTextSection(
     onInvitationTitleClick: (Long) -> Unit?,
     modifier: Modifier = Modifier,
 ) {
+    if (textContent.isBlank()) return
+
     var isExpanded by remember { mutableStateOf(false) }
     var isOverflowed by remember { mutableStateOf(false) }
 
@@ -323,6 +315,8 @@ private fun GuestBookItemVisualMediaSection(
     onVisualMediaClick: (GuestBookMediaUiModel) -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    if (visualMediaUrls.isEmpty()) return
+
     val pagerState = rememberPagerState(pageCount = { visualMediaUrls.size })
     var beyondViewportPageCount by remember { mutableStateOf(0) }
 
@@ -545,6 +539,30 @@ private fun ThumbnailWrapper(
                 contentDescription = stringResource(R.string.desc_play_video),
                 tint = NachoTheme.colorScheme.iconTertiary,
                 modifier = Modifier.size(24.dp),
+            )
+        }
+    }
+}
+
+@Composable
+private fun GuestBookItemAudioSection(
+    audioMedias: ImmutableList<GuestBookMediaUiModel>,
+    isAudioPlaying: Boolean,
+    playingAudioUrl: String?,
+    onAudioMediaClick: (GuestBookMediaUiModel) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    if (audioMedias.isEmpty()) return
+
+    Column(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(NachoSpacing.small),
+    ) {
+        audioMedias.forEach { audio ->
+            GuestBookAudioItem(
+                audio = audio,
+                isAudioPlaying = isAudioPlaying && (audio.url == playingAudioUrl),
+                onAudioMediaClick = onAudioMediaClick,
             )
         }
     }

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/guestbook/GuestBookItem.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/guestbook/GuestBookItem.kt
@@ -525,6 +525,11 @@ private fun VideoPlayerView(
                 this.player = player
             }
         },
+        update = { playerView ->
+            if (playerView.player != player) {
+                playerView.player = player
+            }
+        },
         modifier = modifier,
     )
 }
@@ -806,6 +811,7 @@ class FakeAutoVideoPlayerPool : AutoVideoPlayerPool {
     override fun pausePlayer(url: String) {}
     override fun pauseAllPlayers() {}
     override fun resumeLastPlayed() {}
+    override fun clearCacheById(itemId: Long?) {}
     override fun resetPool() {}
     override fun releaseAllPlayers() {}
 }

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/guestbook/GuestBookItem.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/guestbook/GuestBookItem.kt
@@ -63,6 +63,7 @@ import com.andlife.model.guestbook.GuestBookMediaUiModel
 import com.andlife.model.guestbook.GuestBookUiModel
 import com.andlife.model.guestbook.MediaUiType
 import com.andlife.ui.R
+import com.andlife.ui.component.icon.PlayerThumbnailIcon
 import com.andlife.ui.component.media.MediaOverlay
 import com.andlife.ui.util.toFormatDuration
 import com.andlife.ui.util.toRelativeTimeString
@@ -542,23 +543,7 @@ private fun ThumbnailWrapper(
             modifier = Modifier.fillMaxSize(),
             contentScale = ContentScale.Fit,
         )
-        Box(
-            modifier = Modifier
-                .align(Alignment.Center)
-                .size(48.dp)
-                .background(
-                    color = NachoTheme.colorScheme.iconSecondary.copy(alpha = 0.6f),
-                    shape = CircleShape,
-                ),
-            contentAlignment = Alignment.Center,
-        ) {
-            Icon(
-                painter = painterResource(R.drawable.ic_play_arrow_24),
-                contentDescription = stringResource(R.string.desc_play_video),
-                tint = NachoTheme.colorScheme.iconTertiary,
-                modifier = Modifier.size(24.dp),
-            )
-        }
+        PlayerThumbnailIcon(modifier = Modifier.align(Alignment.Center))
     }
 }
 

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/guestbook/GuestBookItem.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/guestbook/GuestBookItem.kt
@@ -102,8 +102,7 @@ fun GuestBookItem(
     Column(
         modifier = modifier
             .fillMaxWidth()
-            .background(backgroundColor)
-            .padding(horizontal = NachoSpacing.large),
+            .background(backgroundColor),
         verticalArrangement = Arrangement.spacedBy(NachoSpacing.medium),
     ) {
         GuestBookItemHeader(
@@ -135,7 +134,9 @@ fun GuestBookItem(
             onAudioMediaClick = onAudioMediaClick,
         )
         HorizontalDivider(
-            modifier = Modifier.padding(top = NachoSpacing.xSmall),
+            modifier = Modifier
+                .padding(horizontal = NachoSpacing.large)
+                .padding(top = NachoSpacing.xSmall),
             color = NachoTheme.colorScheme.backgroundBorder,
         )
     }
@@ -156,7 +157,11 @@ private fun GuestBookItemHeader(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .padding(top = NachoSpacing.large),
+            .padding(
+                top = NachoSpacing.large,
+                start = NachoSpacing.large,
+                end = NachoSpacing.xSmall
+            ),
         horizontalArrangement = Arrangement.spacedBy(NachoSpacing.small),
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -248,7 +253,9 @@ private fun GuestBookItemTextSection(
     var isOverflowed by remember { mutableStateOf(false) }
 
     Column(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = NachoSpacing.large),
         verticalArrangement = Arrangement.spacedBy(NachoSpacing.medium),
     ) {
         invitation?.let {
@@ -344,6 +351,7 @@ private fun GuestBookItemVisualMediaSection(
         modifier =
             modifier
                 .fillMaxWidth()
+                .padding(horizontal = NachoSpacing.large)
                 .aspectRatio(1f) // TODO: 추후 미디어 비율에 맞게 조정 필요, 일단 정사각형으로 고정
                 .clip(NachoTheme.shapes.small),
     ) {
@@ -565,7 +573,9 @@ private fun GuestBookItemAudioSection(
     if (audioMedias.isEmpty()) return
 
     Column(
-        modifier = modifier,
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = NachoSpacing.large),
         verticalArrangement = Arrangement.spacedBy(NachoSpacing.small),
     ) {
         audioMedias.forEach { audio ->

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/guestbook/GuestBookItem.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/guestbook/GuestBookItem.kt
@@ -93,6 +93,12 @@ fun GuestBookItem(
         NachoTheme.colorScheme.backgroundPrimary
     }
 
+    val maxTextLines = when {
+        guestBook.visualMedias.isNotEmpty() -> 2
+        guestBook.audioMedias.isNotEmpty() -> 4
+        else -> 6
+    }
+
     Column(
         modifier = modifier
             .fillMaxWidth()
@@ -111,6 +117,7 @@ fun GuestBookItem(
         GuestBookItemTextSection(
             invitation = guestBook.invitation,
             textContent = guestBook.textContent,
+            maxLines = maxTextLines,
             onInvitationTitleClick = onInvitationTitleClick,
         )
         GuestBookItemVisualMediaSection(
@@ -231,6 +238,7 @@ private fun GuestBookItemHeader(
 private fun GuestBookItemTextSection(
     invitation: GuestBookInvitationUiModel?,
     textContent: String,
+    maxLines: Int,
     onInvitationTitleClick: (Long) -> Unit?,
     modifier: Modifier = Modifier,
 ) {
@@ -281,7 +289,7 @@ private fun GuestBookItemTextSection(
                 text = textContent,
                 style = NachoTheme.typography.bodyMediumRegular,
                 color = NachoTheme.colorScheme.textPrimary,
-                maxLines = if (isExpanded) Int.MAX_VALUE else 2,
+                maxLines = if (isExpanded) Int.MAX_VALUE else maxLines,
                 overflow = TextOverflow.Ellipsis,
                 onTextLayout = { textLayoutResult ->
                     if (!isExpanded) {

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/icon/PlayerThumbnailIcon.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/icon/PlayerThumbnailIcon.kt
@@ -1,0 +1,50 @@
+package com.andlife.ui.component.icon
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Icon
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.andlife.designsystem.preview.PreviewTheme
+import com.andlife.designsystem.theme.NachoIconSize
+import com.andlife.designsystem.theme.NachoTheme
+import com.andlife.ui.R
+
+@Composable
+fun PlayerThumbnailIcon(
+    modifier: Modifier = Modifier,
+    boxSize: Dp = NachoIconSize.xLarge,
+    iconSize: Dp = NachoIconSize.medium
+) {
+    Box(
+        modifier = modifier
+            .size(boxSize)
+            .background(
+                color = NachoTheme.colorScheme.iconSecondary.copy(alpha = 0.6f),
+                shape = CircleShape,
+            ),
+        contentAlignment = Alignment.Center,
+    ) {
+        Icon(
+            painter = painterResource(R.drawable.ic_play_arrow_24),
+            contentDescription = stringResource(R.string.desc_play_video),
+            tint = NachoTheme.colorScheme.iconTertiary,
+            modifier = Modifier.size(iconSize),
+        )
+    }
+}
+
+@PreviewTheme
+@Composable
+private fun PlayerThumbnailIconPreview() {
+    NachoTheme {
+        PlayerThumbnailIcon()
+    }
+}

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/InvitationGuestBookForm.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/InvitationGuestBookForm.kt
@@ -15,7 +15,10 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
@@ -55,6 +58,7 @@ fun InvitationGuestBookForm(
     editingGuestBookId: Long? = null,
 ) {
     val context = LocalContext.current
+    var isFocused by remember { mutableStateOf(false) }
     val focusRequester = remember { FocusRequester() }
 
     LaunchedEffect(editingGuestBookId) {
@@ -104,10 +108,12 @@ fun InvitationGuestBookForm(
                     .fillMaxWidth()
                     .focusRequester(focusRequester)
                     .onFocusChanged { focusState ->
+                        isFocused = focusState.isFocused
                         onFocusChanged(focusState.isFocused)
                     },
                 singleLine = false,
                 minLines = 3,
+                maxLines = if (isFocused) Int.MAX_VALUE else 3,
             )
 
             Text(

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/collection/NachoMediaGridView.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/collection/NachoMediaGridView.kt
@@ -34,8 +34,8 @@ fun NachoMediaGridView(
             columns = GridCells.Fixed(3),
             modifier = modifier,
             contentPadding = PaddingValues(NachoSpacing.small),
-            horizontalArrangement = Arrangement.spacedBy(NachoSpacing.small),
-            verticalArrangement = Arrangement.spacedBy(NachoSpacing.small),
+            horizontalArrangement = Arrangement.spacedBy(NachoSpacing.twoXSmall),
+            verticalArrangement = Arrangement.spacedBy(NachoSpacing.twoXSmall),
         ) {
             itemsIndexed(
                 items = items,

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/media/MediaItem.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/media/MediaItem.kt
@@ -46,7 +46,6 @@ fun MediaItem(
         modifier =
             modifier
                 .aspectRatio(1f)
-                .clip(RoundedCornerShape(NachoSpacing.small))
                 .clickable { onClick() },
     ) {
         when (mediaType) {

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/media/MediaItem.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/media/MediaItem.kt
@@ -26,8 +26,9 @@ import com.andlife.designsystem.preview.PreviewTheme
 import com.andlife.designsystem.theme.NachoIconSize
 import com.andlife.designsystem.theme.NachoSpacing
 import com.andlife.designsystem.theme.NachoTheme
-import com.andlife.ui.R
 import com.andlife.model.guestbook.UiMediaType
+import com.andlife.ui.R
+import com.andlife.ui.component.icon.PlayerThumbnailIcon
 import com.andlife.ui.util.toFormatDuration
 
 @Composable
@@ -78,9 +79,12 @@ fun MediaItem(
                     }
                 )
             }
+
             UiMediaType.AUDIO -> {
                 Box(
-                    modifier = Modifier.fillMaxSize().background(NachoTheme.colorScheme.backgroundSecondary),
+                    modifier = Modifier
+                        .fillMaxSize()
+                        .background(NachoTheme.colorScheme.backgroundSecondary),
                     contentAlignment = Alignment.Center,
                 ) {
                     Icon(
@@ -91,6 +95,7 @@ fun MediaItem(
                     )
                 }
             }
+
             UiMediaType.VIDEO -> {
                 Box(modifier = Modifier.fillMaxSize()) {
                     SubcomposeAsyncImage(
@@ -120,11 +125,9 @@ fun MediaItem(
                             )
                         }
                     )
-                    Icon(
-                        painter = painterResource(id = R.drawable.ic_play_circle_24),
-                        contentDescription = stringResource(R.string.desc_ic_play),
-                        modifier = Modifier.align(Alignment.Center).size(NachoIconSize.xLarge),
-                        tint = NachoTheme.colorScheme.iconTertiary.copy(alpha = 0.8f),
+                    PlayerThumbnailIcon(
+                        modifier = Modifier.align(Alignment.Center),
+                        boxSize = NachoIconSize.large
                     )
                 }
             }
@@ -133,7 +136,9 @@ fun MediaItem(
         if (duration != null && duration > 0) {
             MediaOverlay(
                 text = duration.toFormatDuration(),
-                modifier = Modifier.align(Alignment.BottomEnd).padding(NachoSpacing.small),
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(NachoSpacing.small),
             )
         }
 
@@ -144,7 +149,8 @@ fun MediaItem(
                     Modifier
                         .align(
                             Alignment.TopEnd,
-                        ).size(NachoIconSize.medium)
+                        )
+                        .size(NachoIconSize.medium)
                         .padding(NachoSpacing.xSmall),
             ) {
                 Icon(

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/detail/InvitationDetailScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/detail/InvitationDetailScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringArrayResource
@@ -201,8 +202,10 @@ private fun InvitationDetailTopBar(
     showActions: Boolean = true,
     hasThanksCard: Boolean = false,
 ) {
+    val alpha = 1f - scrollBehavior.state.collapsedFraction
+
     TopAppBar(
-        modifier = modifier,
+        modifier = modifier.graphicsLayer { this.alpha = alpha },
         title = {
             Text(
                 text = title,

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/detail/InvitationDetailScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/detail/InvitationDetailScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -26,6 +27,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
@@ -50,6 +52,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import com.andlife.designsystem.R as designR
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun InvitationDetailRoute(
     onNavigateBack: () -> Unit,
@@ -59,6 +62,8 @@ fun InvitationDetailRoute(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+
     val mapErrorMessage = stringResource(R.string.snack_load_error_map)
 
     viewModel.effectFlow.collectWithLifecycle { effect ->
@@ -80,16 +85,19 @@ fun InvitationDetailRoute(
     InvitationDetailScreen(
         uiState = uiState,
         snackbarHostState = snackbarHostState,
+        scrollBehavior = scrollBehavior,
         onEvent = viewModel::onEvent,
         onNavigateBack = onNavigateBack,
         modifier = modifier,
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun InvitationDetailScreen(
     uiState: InvitationDetailUiState,
     snackbarHostState: SnackbarHostState,
+    scrollBehavior: TopAppBarScrollBehavior,
     onEvent: (InvitationDetailUiEvent) -> Unit,
     onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier,
@@ -109,12 +117,15 @@ private fun InvitationDetailScreen(
     BackHandler(onBack = navigateBackWithMapCleanup)
 
     Scaffold(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .nestedScroll(scrollBehavior.nestedScrollConnection),
         snackbarHost = {
             SnackbarHost(snackbarHostState)
         },
         topBar = {
             InvitationDetailTopBar(
+                scrollBehavior = scrollBehavior,
                 title = uiState.invitationContentsUiModel.title,
                 hasThanksCard = uiState.hasThanksCard,
                 showActions = !uiState.isLoading && !uiState.isError,
@@ -181,6 +192,7 @@ private fun InvitationDetailScreen(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun InvitationDetailTopBar(
+    scrollBehavior: TopAppBarScrollBehavior,
     title: String,
     onBack: () -> Unit,
     onClickThanksCard: () -> Unit,
@@ -227,7 +239,9 @@ private fun InvitationDetailTopBar(
         },
         colors = TopAppBarDefaults.topAppBarColors(
             containerColor = NachoTheme.colorScheme.backgroundPrimary,
+            scrolledContainerColor = NachoTheme.colorScheme.backgroundPrimary,
         ),
+        scrollBehavior = scrollBehavior,
     )
 }
 

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
@@ -110,6 +110,7 @@ fun InvitationGuestBookRoute(
             }
 
             is InvitationGuestBookSideEffect.UpdateGuestBookSuccess -> {
+                viewModel.videoPlayerPool.clearCacheById(uiState.editingGuestBookId)
                 viewModel.invalidateGuestBooks()
             }
 

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
@@ -256,14 +256,18 @@ private fun InvitationGuestBookScreen(
         }
     }
 
-    BackHandler(enabled = !isImVisible) {
+    LaunchedEffect(isImVisible) {
+        if (!isImVisible) focusManager.clearFocus()
+    }
+
+    BackHandler(enabled = true) {
         when {
+            isImVisible -> {
+                focusManager.clearFocus()
+            }
             uiState.editingGuestBookId != null -> {
                 focusManager.clearFocus()
                 onEvent(InvitationGuestBookUiEvent.CancelEdit)
-            }
-            isTextFieldFocused -> {
-                focusManager.clearFocus()
             }
             else -> {
                 navigateBackWithCleanup()

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
@@ -352,11 +352,7 @@ private fun InvitationGuestBookScreen(
                 shadowElevation = NachoElevation.large,
                 color = NachoTheme.colorScheme.backgroundPrimary
             ) {
-                Box(
-                    modifier = Modifier
-                        .navigationBarsPadding()
-                        .imePadding()
-                ) {
+                Box(modifier = Modifier.imePadding()) {
                     GuestBookFormSection(
                         uiState = uiState,
                         onEvent = onEvent,

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationGuestBookViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationGuestBookViewModel.kt
@@ -343,13 +343,7 @@ constructor(
         updateState { copy(isUploading = false) }
         when (result) {
             is Result.Success -> {
-                updateState {
-                    copy(
-                        editingGuestBookId = null,
-                        selectedMedias = persistentListOf(),
-                        textContent = ""
-                    )
-                }
+                clearFormInput()
                 if (isUpdate) {
                     sendEffect(InvitationGuestBookSideEffect.UpdateGuestBookSuccess)
                 } else {
@@ -387,12 +381,14 @@ constructor(
         refreshFlow.value += 1
     }
 
-    private fun cancelEdit() {
+    private fun cancelEdit() = clearFormInput()
+
+    private fun clearFormInput() {
         updateState {
             copy(
-                editingGuestBookId = null,
-                selectedMedias = persistentListOf(),
                 textContent = "",
+                selectedMedias = persistentListOf(),
+                editingGuestBookId = null,
                 originalTextContent = "",
                 originalMediaIds = emptySet(),
             )

--- a/android/feature/myinvitation/build.gradle.kts
+++ b/android/feature/myinvitation/build.gradle.kts
@@ -8,6 +8,8 @@ android {
 
 dependencies {
     implementation(projects.feature.editor)
+    implementation(projects.core.media)
+
     implementation(libs.androidx.compose.material.icons.extended)
 
     // kakao 공유
@@ -24,6 +26,9 @@ dependencies {
 
     // ExoPlayer
     implementation(libs.bundles.media3)
+
+    // Paging
+    implementation(libs.androidx.paging.compose)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/model/guestbook/MyInvitationGuestBookSideEffect.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/model/guestbook/MyInvitationGuestBookSideEffect.kt
@@ -1,0 +1,15 @@
+package com.andlife.myinvitation.model.guestbook
+
+import com.andlife.ui.base.BaseSideEffect
+
+sealed interface MyInvitationGuestBookSideEffect : BaseSideEffect {
+    data class ShowSnackbar(
+        val message: String,
+    ) : MyInvitationGuestBookSideEffect
+
+    data object CreateGuestBookSuccess : MyInvitationGuestBookSideEffect
+
+    data object UpdateGuestBookSuccess : MyInvitationGuestBookSideEffect
+
+    data object DeleteGuestBookSuccess : MyInvitationGuestBookSideEffect
+}

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/model/guestbook/MyInvitationGuestBookUiEvent.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/model/guestbook/MyInvitationGuestBookUiEvent.kt
@@ -1,0 +1,49 @@
+package com.andlife.myinvitation.model.guestbook
+
+import com.andlife.model.guestbook.GuestBookUiModel
+import com.andlife.ui.base.BaseUiEvent
+import com.andlife.ui.component.invitation.SelectedMedia
+
+sealed interface MyInvitationGuestBookUiEvent : BaseUiEvent {
+    data class UpdateSelectedMedias(
+        val medias: List<SelectedMedia>,
+    ) : MyInvitationGuestBookUiEvent
+
+    data class UpdateTextContent(
+        val textContent: String,
+    ) : MyInvitationGuestBookUiEvent
+
+    data class RemoveMedia(
+        val media: SelectedMedia,
+    ) : MyInvitationGuestBookUiEvent
+
+    data object UploadMedias : MyInvitationGuestBookUiEvent
+
+    data object ClearError : MyInvitationGuestBookUiEvent
+
+    data class ClickInvitationTitle(
+        val invitationId: Long,
+    ) : MyInvitationGuestBookUiEvent
+
+    data class ClickGuestBookMenu(
+        val guestBookId: Long,
+    ) : MyInvitationGuestBookUiEvent
+
+    data class ClickVisualMedia(
+        val url: String,
+    ) : MyInvitationGuestBookUiEvent
+
+    data class ClickAudioMedia(
+        val url: String,
+    ) : MyInvitationGuestBookUiEvent
+
+    data class ClickEditMenu(
+        val guestBook: GuestBookUiModel,
+    ) : MyInvitationGuestBookUiEvent
+
+    data object CancelEdit : MyInvitationGuestBookUiEvent
+
+    data class ClickDeleteMenu(
+        val guestBookId: Long,
+    ) : MyInvitationGuestBookUiEvent
+}

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/model/guestbook/MyInvitationGuestBookUiState.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/model/guestbook/MyInvitationGuestBookUiState.kt
@@ -1,0 +1,37 @@
+package com.andlife.myinvitation.model.guestbook
+
+import com.andlife.ui.base.BaseUiState
+import com.andlife.ui.component.invitation.SelectedMedia
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+
+data class MyInvitationGuestBookUiState(
+    val selectedMedias: ImmutableList<SelectedMedia> = persistentListOf(),
+    val textContent: String = "",
+    val isUploading: Boolean = false,
+    val originalTextContent: String = "",
+    val originalMediaIds: Set<Long> = emptySet(),
+    val errorMessage: String? = null,
+    val playingAudioUrl: String? = null,
+    val isAudioPlaying: Boolean = false,
+    val editingGuestBookId: Long? = null,
+    val isLoadingGuestBooks: Boolean = false,
+    val deleteTargetId: Long? = null,
+    val guestBooksErrorMessage: String? = null,
+) : BaseUiState {
+
+    val isContentChanged: Boolean
+        get() {
+            if (editingGuestBookId == null) return true
+            val isTextChanged = textContent != originalTextContent
+            val currentMediaIds = selectedMedias.mapNotNull { it.id }.toSet()
+            val isMediaChanged = currentMediaIds != originalMediaIds
+
+            val hasNewMedias = selectedMedias.any { it.id == null }
+
+            return isTextChanged || isMediaChanged || hasNewMedias
+        }
+
+    val isSubmittable: Boolean
+        get() = (textContent.isNotBlank() || selectedMedias.isNotEmpty()) && !isUploading && isContentChanged
+}

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationDetailScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationDetailScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -26,6 +27,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
@@ -61,6 +64,7 @@ import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDate
 import com.andlife.designsystem.R as designR
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MyInvitationDetailRoute(
     onNavigateBack: () -> Unit,
@@ -71,6 +75,8 @@ fun MyInvitationDetailRoute(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
+    val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
+
     val mapErrorMessage = stringResource(R.string.snack_load_error_map)
 
     viewModel.effectFlow.collectWithLifecycle { effect ->
@@ -96,16 +102,19 @@ fun MyInvitationDetailRoute(
     MyInvitationDetailScreen(
         uiState = uiState,
         snackbarHostState = snackbarHostState,
+        scrollBehavior = scrollBehavior,
         onEvent = viewModel::onEvent,
         onNavigateBack = onNavigateBack,
         modifier = modifier,
     )
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun MyInvitationDetailScreen(
     uiState: MyInvitationDetailUiState,
     snackbarHostState: SnackbarHostState,
+    scrollBehavior: TopAppBarScrollBehavior,
     onEvent: (MyInvitationDetailUiEvent) -> Unit,
     onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier,
@@ -125,12 +134,15 @@ private fun MyInvitationDetailScreen(
     BackHandler(onBack = navigateBackWithMapCleanup)
 
     Scaffold(
-        modifier = modifier.fillMaxSize(),
+        modifier = modifier
+            .fillMaxSize()
+            .nestedScroll(scrollBehavior.nestedScrollConnection),
         snackbarHost = {
             SnackbarHost(snackbarHostState)
         },
         topBar = {
             MyInvitationDetailTopBar(
+                scrollBehavior = scrollBehavior,
                 title = uiState.invitationContentsUiModel.title,
                 hasThanksCard = uiState.hasThanksCard,
                 showActions = !uiState.isLoading && !uiState.isError,
@@ -205,6 +217,7 @@ private fun MyInvitationDetailScreen(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun MyInvitationDetailTopBar(
+    scrollBehavior: TopAppBarScrollBehavior,
     title: String,
     onBack: () -> Unit,
     onClickThanksCard: () -> Unit,
@@ -216,8 +229,10 @@ private fun MyInvitationDetailTopBar(
     showActions: Boolean = true,
     hasThanksCard: Boolean = false,
 ) {
+    val alpha = 1f - scrollBehavior.state.collapsedFraction
+
     TopAppBar(
-        modifier = modifier,
+        modifier = modifier.graphicsLayer { this.alpha = alpha },
         title = {
             Text(
                 text = title,
@@ -263,10 +278,11 @@ private fun MyInvitationDetailTopBar(
                 )
             }
         },
-        colors =
-            TopAppBarDefaults.topAppBarColors(
-                containerColor = NachoTheme.colorScheme.backgroundPrimary,
-            ),
+        colors = TopAppBarDefaults.topAppBarColors(
+            containerColor = NachoTheme.colorScheme.backgroundPrimary,
+            scrolledContainerColor = NachoTheme.colorScheme.backgroundPrimary,
+        ),
+        scrollBehavior = scrollBehavior,
     )
 }
 
@@ -349,6 +365,7 @@ private fun InvitationMoreMenu(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 @PreviewTheme
 private fun MyInvitationDetailScreenPreview() {
@@ -388,6 +405,7 @@ private fun MyInvitationDetailScreenPreview() {
                         ),
                 ),
             snackbarHostState = remember { SnackbarHostState() },
+            scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(),
             onEvent = {},
             onNavigateBack = {},
         )

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationDetailScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationDetailScreen.kt
@@ -47,6 +47,7 @@ import com.andlife.myinvitation.R
 import com.andlife.myinvitation.model.detail.MyInvitationDetailSideEffect
 import com.andlife.myinvitation.model.detail.MyInvitationDetailUiEvent
 import com.andlife.myinvitation.model.detail.MyInvitationDetailUiState
+import com.andlife.myinvitation.screen.guestbook.MyInvitationGuestBookRoute
 import com.andlife.myinvitation.screen.guestbook.collection.MyInvitationCollectionRoute
 import com.andlife.myinvitation.viewmodel.MyInvitationDetailViewModel
 import com.andlife.ui.component.GenericTabRow
@@ -96,6 +97,7 @@ fun MyInvitationDetailRoute(
         uiState = uiState,
         snackbarHostState = snackbarHostState,
         onEvent = viewModel::onEvent,
+        onNavigateBack = onNavigateBack,
         modifier = modifier,
     )
 }
@@ -105,6 +107,7 @@ private fun MyInvitationDetailScreen(
     uiState: MyInvitationDetailUiState,
     snackbarHostState: SnackbarHostState,
     onEvent: (MyInvitationDetailUiEvent) -> Unit,
+    onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
     val tabTitles = stringArrayResource(R.array.txt_tap_title).toImmutableList()
@@ -190,7 +193,7 @@ private fun MyInvitationDetailScreen(
                                 )
                             }
 
-                            1 -> {} // TODO: 방명록 조회 및 작성
+                            1 -> MyInvitationGuestBookRoute(onNavigateBack = onNavigateBack)
                             2 -> MyInvitationCollectionRoute()
                         }
                     },
@@ -386,6 +389,7 @@ private fun MyInvitationDetailScreenPreview() {
                 ),
             snackbarHostState = remember { SnackbarHostState() },
             onEvent = {},
+            onNavigateBack = {},
         )
     }
 }

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
@@ -1,4 +1,4 @@
-package com.andlife.invitation.screen.guestbook
+package com.andlife.myinvitation.screen.guestbook
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
@@ -54,11 +54,6 @@ import com.andlife.designsystem.preview.PreviewTheme
 import com.andlife.designsystem.theme.NachoElevation
 import com.andlife.designsystem.theme.NachoSpacing
 import com.andlife.designsystem.theme.NachoTheme
-import com.andlife.invitation.R
-import com.andlife.invitation.model.guestbook.InvitationGuestBookSideEffect
-import com.andlife.invitation.model.guestbook.InvitationGuestBookUiEvent
-import com.andlife.invitation.model.guestbook.InvitationGuestBookUiState
-import com.andlife.invitation.viewmodel.InvitationGuestBookViewModel
 import com.andlife.media.video.AutoVideoPlayerPool
 import com.andlife.media.video.FakeVideoPlayerPool
 import com.andlife.model.common.AuthorUiModel
@@ -67,6 +62,11 @@ import com.andlife.model.guestbook.GuestBookInvitationUiModel
 import com.andlife.model.guestbook.GuestBookMediaUiModel
 import com.andlife.model.guestbook.GuestBookUiModel
 import com.andlife.model.guestbook.MediaUiType
+import com.andlife.myinvitation.R
+import com.andlife.myinvitation.model.guestbook.MyInvitationGuestBookSideEffect
+import com.andlife.myinvitation.model.guestbook.MyInvitationGuestBookUiEvent
+import com.andlife.myinvitation.model.guestbook.MyInvitationGuestBookUiState
+import com.andlife.myinvitation.viewmodel.MyInvitationGuestBookViewModel
 import com.andlife.ui.component.guestbook.GuestBookItem
 import com.andlife.ui.component.invitation.InvitationGuestBookForm
 import com.andlife.ui.component.paging.PagingStateContent
@@ -80,10 +80,10 @@ import kotlin.math.max
 import kotlin.math.min
 
 @Composable
-fun InvitationGuestBookRoute(
+fun MyInvitationGuestBookRoute(
     onNavigateBack: () -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: InvitationGuestBookViewModel = hiltViewModel(),
+    viewModel: MyInvitationGuestBookViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val guestBooks = viewModel.guestBooksPagingFlow.collectAsLazyPagingItems()
@@ -97,23 +97,23 @@ fun InvitationGuestBookRoute(
 
     viewModel.effectFlow.collectWithLifecycle { effect ->
         when (effect) {
-            is InvitationGuestBookSideEffect.ShowSnackbar -> {
+            is MyInvitationGuestBookSideEffect.ShowSnackbar -> {
                 snackbarHostState.showSnackbar(
                     message = effect.message,
                     duration = SnackbarDuration.Short,
                 )
             }
 
-            is InvitationGuestBookSideEffect.CreateGuestBookSuccess -> {
+            is MyInvitationGuestBookSideEffect.CreateGuestBookSuccess -> {
                 scrollToTop = true
                 viewModel.invalidateGuestBooks()
             }
 
-            is InvitationGuestBookSideEffect.UpdateGuestBookSuccess -> {
+            is MyInvitationGuestBookSideEffect.UpdateGuestBookSuccess -> {
                 viewModel.invalidateGuestBooks()
             }
 
-            is InvitationGuestBookSideEffect.DeleteGuestBookSuccess -> {
+            is MyInvitationGuestBookSideEffect.DeleteGuestBookSuccess -> {
                 viewModel.invalidateGuestBooks()
             }
         }
@@ -195,7 +195,7 @@ fun InvitationGuestBookRoute(
                     TextButton(
                         onClick = {
                             showDeleteDialog?.let { guestBookId ->
-                                viewModel.onEvent(InvitationGuestBookUiEvent.ClickDeleteMenu(guestBookId))
+                                viewModel.onEvent(MyInvitationGuestBookUiEvent.ClickDeleteMenu(guestBookId))
                             }
                             showDeleteDialog = null
                         }
@@ -227,9 +227,9 @@ fun InvitationGuestBookRoute(
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun InvitationGuestBookScreen(
-    uiState: InvitationGuestBookUiState,
+    uiState: MyInvitationGuestBookUiState,
     guestBooks: LazyPagingItems<GuestBookUiModel>,
-    onEvent: (InvitationGuestBookUiEvent) -> Unit,
+    onEvent: (MyInvitationGuestBookUiEvent) -> Unit,
     snackbarHostState: SnackbarHostState,
     lazyListState: LazyListState,
     videoPlayerPool: AutoVideoPlayerPool,
@@ -249,7 +249,7 @@ private fun InvitationGuestBookScreen(
         isMediaActive = false
         coroutineScope.launch {
             videoPlayerPool.pauseAllPlayers()
-            onEvent(InvitationGuestBookUiEvent.ClickAudioMedia(""))
+            onEvent(MyInvitationGuestBookUiEvent.ClickAudioMedia(""))
 
             delay(50L)
             onNavigateBack()
@@ -260,7 +260,7 @@ private fun InvitationGuestBookScreen(
         when {
             uiState.editingGuestBookId != null -> {
                 focusManager.clearFocus()
-                onEvent(InvitationGuestBookUiEvent.CancelEdit)
+                onEvent(MyInvitationGuestBookUiEvent.CancelEdit)
             }
             isTextFieldFocused -> {
                 focusManager.clearFocus()
@@ -398,11 +398,11 @@ private fun InvitationGuestBookScreen(
                                     guestBook.audioMedias.any { it.url == uiState.playingAudioUrl },
                                 playingAudioUrl = uiState.playingAudioUrl,
                                 isEditing = uiState.editingGuestBookId == guestBook.id,
-                                onEditClick = { onEvent(InvitationGuestBookUiEvent.ClickEditMenu(guestBook)) },
+                                onEditClick = { onEvent(MyInvitationGuestBookUiEvent.ClickEditMenu(guestBook)) },
                                 onDeleteClick = { onDeleteMenuClick(guestBook.id) },
-                                onVisualMediaClick = { onEvent(InvitationGuestBookUiEvent.ClickVisualMedia(it.url)) },
-                                onAudioMediaClick = { onEvent(InvitationGuestBookUiEvent.ClickAudioMedia(it.url)) },
-                                onMenuClick = { onEvent(InvitationGuestBookUiEvent.ClickGuestBookMenu(guestBook.id)) },
+                                onVisualMediaClick = { onEvent(MyInvitationGuestBookUiEvent.ClickVisualMedia(it.url)) },
+                                onAudioMediaClick = { onEvent(MyInvitationGuestBookUiEvent.ClickAudioMedia(it.url)) },
+                                onMenuClick = { onEvent(MyInvitationGuestBookUiEvent.ClickGuestBookMenu(guestBook.id)) },
                             )
                         }
                     }
@@ -427,8 +427,8 @@ private fun InvitationGuestBookScreen(
 
 @Composable
 private fun GuestBookFormSection(
-    uiState: InvitationGuestBookUiState,
-    onEvent: (InvitationGuestBookUiEvent) -> Unit,
+    uiState: MyInvitationGuestBookUiState,
+    onEvent: (MyInvitationGuestBookUiEvent) -> Unit,
     onFocusChanged: (Boolean) -> Unit,
 ) {
     InvitationGuestBookForm(
@@ -444,16 +444,16 @@ private fun GuestBookFormSection(
         isSubmittable = uiState.isSubmittable,
         editingGuestBookId = uiState.editingGuestBookId,
         onMediasSelected = { medias ->
-            onEvent(InvitationGuestBookUiEvent.UpdateSelectedMedias(medias))
+            onEvent(MyInvitationGuestBookUiEvent.UpdateSelectedMedias(medias))
         },
         onMediaRemove = { media ->
-            onEvent(InvitationGuestBookUiEvent.RemoveMedia(media))
+            onEvent(MyInvitationGuestBookUiEvent.RemoveMedia(media))
         },
         onTextContentChange = { text ->
-            onEvent(InvitationGuestBookUiEvent.UpdateTextContent(text))
+            onEvent(MyInvitationGuestBookUiEvent.UpdateTextContent(text))
         },
         onUploadClick = {
-            onEvent(InvitationGuestBookUiEvent.UploadMedias)
+            onEvent(MyInvitationGuestBookUiEvent.UploadMedias)
         },
         onFocusChanged = onFocusChanged,
     )
@@ -465,7 +465,7 @@ private fun InvitationGuestBookEmptyPreview() {
     val emptyGuestBooks = flowOf(PagingData.empty<GuestBookUiModel>()).collectAsLazyPagingItems()
     NachoTheme {
         InvitationGuestBookScreen(
-            uiState = InvitationGuestBookUiState(isLoadingGuestBooks = false),
+            uiState = MyInvitationGuestBookUiState(isLoadingGuestBooks = false),
             guestBooks = emptyGuestBooks,
             onEvent = {},
             onNavigateBack = {},

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
@@ -256,14 +256,18 @@ private fun InvitationGuestBookScreen(
         }
     }
 
-    BackHandler(enabled = !isImVisible) {
+    LaunchedEffect(isImVisible) {
+        if (!isImVisible) focusManager.clearFocus()
+    }
+
+    BackHandler(enabled = true) {
         when {
+            isImVisible -> {
+                focusManager.clearFocus()
+            }
             uiState.editingGuestBookId != null -> {
                 focusManager.clearFocus()
                 onEvent(MyInvitationGuestBookUiEvent.CancelEdit)
-            }
-            isTextFieldFocused -> {
-                focusManager.clearFocus()
             }
             else -> {
                 navigateBackWithCleanup()

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
@@ -114,6 +114,7 @@ fun MyInvitationGuestBookRoute(
             }
 
             is MyInvitationGuestBookSideEffect.DeleteGuestBookSuccess -> {
+                viewModel.videoPlayerPool.clearCacheById(uiState.editingGuestBookId)
                 viewModel.invalidateGuestBooks()
             }
         }

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
@@ -352,11 +352,7 @@ private fun InvitationGuestBookScreen(
                 shadowElevation = NachoElevation.large,
                 color = NachoTheme.colorScheme.backgroundPrimary
             ) {
-                Box(
-                    modifier = Modifier
-                        .navigationBarsPadding()
-                        .imePadding()
-                ) {
+                Box(modifier = Modifier.imePadding()) {
                     GuestBookFormSection(
                         uiState = uiState,
                         onEvent = onEvent,

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationGuestBookViewModel.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationGuestBookViewModel.kt
@@ -331,13 +331,7 @@ constructor(
         updateState { copy(isUploading = false) }
         when (result) {
             is Result.Success -> {
-                updateState {
-                    copy(
-                        editingGuestBookId = null,
-                        selectedMedias = persistentListOf(),
-                        textContent = ""
-                    )
-                }
+                clearFormInput()
                 if (isUpdate) {
                     sendEffect(MyInvitationGuestBookSideEffect.UpdateGuestBookSuccess)
                 } else {
@@ -374,12 +368,14 @@ constructor(
         refreshFlow.value += 1
     }
 
-    private fun cancelEdit() {
+    private fun cancelEdit() = clearFormInput()
+
+    private fun clearFormInput() {
         updateState {
             copy(
-                editingGuestBookId = null,
-                selectedMedias = persistentListOf(),
                 textContent = "",
+                selectedMedias = persistentListOf(),
+                editingGuestBookId = null,
                 originalTextContent = "",
                 originalMediaIds = emptySet(),
             )

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationGuestBookViewModel.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationGuestBookViewModel.kt
@@ -1,0 +1,388 @@
+package com.andlife.myinvitation.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import androidx.navigation.toRoute
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
+import androidx.paging.map
+import com.andlife.domain.error.DataError
+import com.andlife.domain.model.guestbook.GuestBook
+import com.andlife.domain.model.guestbook.GuestBookMedia
+import com.andlife.domain.model.guestbook.MediaType
+import com.andlife.domain.repository.guestbook.GuestBookRepository
+import com.andlife.domain.util.MediaFileProvider
+import com.andlife.domain.util.MediaUploader
+import com.andlife.domain.util.Result
+import com.andlife.domain.util.ThumbnailGenerator
+import com.andlife.domain.util.onFailure
+import com.andlife.domain.util.onSuccess
+import com.andlife.media.audio.AudioPlayerManager
+import com.andlife.media.video.AutoVideoPlayerPool
+import com.andlife.model.guestbook.GuestBookUiModel
+import com.andlife.model.guestbook.MediaUiType
+import com.andlife.model.guestbook.UiMediaType
+import com.andlife.model.guestbook.toUiModel
+import com.andlife.myinvitation.MyInvitationDetail
+import com.andlife.myinvitation.model.guestbook.MyInvitationGuestBookSideEffect
+import com.andlife.myinvitation.model.guestbook.MyInvitationGuestBookUiEvent
+import com.andlife.myinvitation.model.guestbook.MyInvitationGuestBookUiState
+import com.andlife.ui.base.BaseViewModel
+import com.andlife.ui.component.invitation.SelectedMedia
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toPersistentList
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class MyInvitationGuestBookViewModel
+@Inject
+constructor(
+    private val mediaUploader: MediaUploader,
+    private val mediaFileProvider: MediaFileProvider,
+    private val thumbnailGenerator: ThumbnailGenerator,
+    private val guestBookRepository: GuestBookRepository,
+    val audioPlayerManager: AudioPlayerManager,
+    val videoPlayerPool: AutoVideoPlayerPool,
+    savedStateHandle: SavedStateHandle,
+) : BaseViewModel<MyInvitationGuestBookUiState, MyInvitationGuestBookUiEvent, MyInvitationGuestBookSideEffect>(
+    MyInvitationGuestBookUiState(),
+) {
+    private val invitationId: Long = savedStateHandle.toRoute<MyInvitationDetail>().id
+
+    override val uiState: StateFlow<MyInvitationGuestBookUiState> = mutableUiState.asStateFlow()
+
+    private val refreshFlow = MutableStateFlow(0)
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    val guestBooksPagingFlow: Flow<PagingData<GuestBookUiModel>> =
+        refreshFlow.flatMapLatest {
+            guestBookRepository.getGuestBooksByInvitationId(invitationId)
+                .map { pagingData ->
+                    pagingData.map { it.toUiModel() }
+                }
+        }.cachedIn(viewModelScope)
+
+    init {
+        observeAudioPlayerState()
+    }
+
+    private fun observeAudioPlayerState() {
+        audioPlayerManager.currentAudioUrl
+            .combine(audioPlayerManager.isPlaying) { url, isPlaying ->
+                updateState {
+                    copy(
+                        playingAudioUrl = url,
+                        isAudioPlaying = isPlaying,
+                    )
+                }
+            }
+            .launchIn(viewModelScope)
+
+        uiState.map { it.isAudioPlaying }
+            .distinctUntilChanged()
+            .onEach { isAudioPlaying ->
+                if (!isAudioPlaying) {
+                    videoPlayerPool.resumeLastPlayed()
+                }
+            }
+            .launchIn(viewModelScope)
+    }
+
+    override fun onEvent(event: MyInvitationGuestBookUiEvent) {
+        when (event) {
+            is MyInvitationGuestBookUiEvent.UpdateSelectedMedias -> updateSelectedMedias(event.medias)
+            is MyInvitationGuestBookUiEvent.UpdateTextContent -> updateTextContent(event.textContent)
+            is MyInvitationGuestBookUiEvent.RemoveMedia -> removeMedia(event.media)
+            is MyInvitationGuestBookUiEvent.UploadMedias -> handleUploadMedias()
+            is MyInvitationGuestBookUiEvent.ClearError -> clearError()
+            is MyInvitationGuestBookUiEvent.ClickAudioMedia -> clickAudioMedia(event.url)
+
+            is MyInvitationGuestBookUiEvent.ClickGuestBookMenu -> sendEffect(
+                MyInvitationGuestBookSideEffect.ShowSnackbar("방명록 메뉴 클릭됨: ${event.guestBookId}"),
+            )
+
+            is MyInvitationGuestBookUiEvent.ClickInvitationTitle -> sendEffect(
+                MyInvitationGuestBookSideEffect.ShowSnackbar("초대장 제목 클릭됨: ${event.invitationId}"),
+            )
+
+            is MyInvitationGuestBookUiEvent.ClickVisualMedia -> sendEffect(
+                MyInvitationGuestBookSideEffect.ShowSnackbar("비주얼 미디어 클릭됨: ${event.url}"),
+            )
+
+            is MyInvitationGuestBookUiEvent.ClickEditMenu -> startEditing(event.guestBook)
+            is MyInvitationGuestBookUiEvent.CancelEdit -> cancelEdit()
+            is MyInvitationGuestBookUiEvent.ClickDeleteMenu -> deleteGuestBook(event.guestBookId)
+        }
+    }
+
+    private fun clickAudioMedia(url: String) {
+        val isCurrentlyPlaying = uiState.value.isAudioPlaying
+        val currentUrl = uiState.value.playingAudioUrl
+
+        if (currentUrl == url && isCurrentlyPlaying) {
+            audioPlayerManager.togglePlay(url)
+            videoPlayerPool.resumeLastPlayed()
+        } else {
+            videoPlayerPool.pauseAllPlayers()
+            audioPlayerManager.togglePlay(url)
+        }
+    }
+
+    private fun updateSelectedMedias(medias: List<SelectedMedia>) {
+        updateState { copy(selectedMedias = medias.toPersistentList()) }
+    }
+
+    private fun updateTextContent(textContent: String) {
+        updateState { copy(textContent = textContent) }
+    }
+
+    private fun removeMedia(media: SelectedMedia) {
+        updateState {
+            copy(selectedMedias = selectedMedias.toPersistentList().remove(media))
+        }
+    }
+
+    private fun clearError() {
+        updateState { copy(errorMessage = null) }
+    }
+
+    private fun startEditing(guestBook: GuestBookUiModel) {
+        val existingMedias = (guestBook.visualMedias + guestBook.audioMedias)
+            .sortedBy { it.displayOrder }
+            .map { media ->
+                SelectedMedia(
+                    id = media.id,
+                    uri = media.url,
+                    type = when (media.type) {
+                        MediaUiType.IMAGE -> UiMediaType.IMAGE
+                        MediaUiType.VIDEO -> UiMediaType.VIDEO
+                        MediaUiType.AUDIO -> UiMediaType.AUDIO
+                    },
+                    duration = media.durationSeconds,
+                    thumbnailUrl = media.thumbnailUrl
+                )
+            }
+        updateState {
+            copy(
+                editingGuestBookId = guestBook.id,
+                textContent = guestBook.textContent,
+                selectedMedias = existingMedias.toPersistentList(),
+                originalTextContent = guestBook.textContent,
+                originalMediaIds = existingMedias.mapNotNull { it.id }.toSet(),
+            )
+        }
+    }
+
+    private fun handleUploadMedias() {
+        val state = uiState.value
+        if (!state.isSubmittable) return
+
+        viewModelScope.launch {
+            updateState { copy(isUploading = true) }
+
+            val newMedias = state.selectedMedias.filter { it.id == null }
+
+            try {
+                val (uploadedUrls, thumbnailUrls) = if (newMedias.isNotEmpty()) {
+                    val mediaFiles = mediaFileProvider.createFromUris(newMedias.map { it.uri })
+                    when (val uploadResult = mediaUploader.uploadMedias(mediaFiles)) {
+                        is Result.Success -> {
+                            val thumbnails = generateAndUploadThumbnails(newMedias)
+                            uploadResult.data to thumbnails
+                        }
+                        is Result.Error -> {
+                            updateState { copy(isUploading = false) }
+                            sendEffect(MyInvitationGuestBookSideEffect.ShowSnackbar("업로드 실패: ${uploadResult.message}"))
+                            return@launch
+                        }
+                    }
+                } else {
+                    emptyList<String?>() to emptyList()
+                }
+
+                if (state.editingGuestBookId == null) {
+                    createGuestBook(uploadedUrls, thumbnailUrls, newMedias)
+                } else {
+                    updateGuestBook(state.editingGuestBookId, uploadedUrls, thumbnailUrls, state.selectedMedias)
+                }
+            } catch (e: Exception) {
+                updateState { copy(isUploading = false) }
+                sendEffect(MyInvitationGuestBookSideEffect.ShowSnackbar("업로드 중 오류 발생: ${e.message}"))
+                return@launch
+            }
+        }
+    }
+
+    private suspend fun generateAndUploadThumbnails(
+        medias: List<SelectedMedia>
+    ): List<String?> {
+        return medias.map { media ->
+            if (media.type != UiMediaType.VIDEO) return@map null
+
+            try {
+                val thumbnailFile = thumbnailGenerator.generateVideoThumbnail(media.uri) ?: return@map null
+
+                val thumbnailMediaFile = mediaFileProvider.createFromFile(thumbnailFile)
+
+                when (val result = mediaUploader.uploadMedias(listOf(thumbnailMediaFile))) {
+                    is Result.Success -> result.data.firstOrNull()
+                    is Result.Error -> {
+                        null
+                    }
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+                null
+            }
+        }
+    }
+
+    private suspend fun createGuestBook(
+        uploadedUrls: List<String?>,
+        thumbnailUrls: List<String?>,
+        newSelectedMedias: List<SelectedMedia>
+    ) {
+        val guestBookMedias = uploadedUrls
+            .mapIndexedNotNull { index, url ->
+                val urlValue = url ?: return@mapIndexedNotNull null
+                val selectedMedia = newSelectedMedias.getOrNull(index) ?: return@mapIndexedNotNull null
+                val thumbnailUrl = thumbnailUrls.getOrNull(index)
+
+                GuestBookMedia(
+                    id = 0L,
+                    type = when (selectedMedia.type) {
+                        UiMediaType.IMAGE -> MediaType.IMAGE
+                        UiMediaType.VIDEO -> MediaType.VIDEO
+                        UiMediaType.AUDIO -> MediaType.AUDIO
+                    },
+                    url = urlValue,
+                    thumbnailUrl = thumbnailUrl,
+                    durationSeconds = selectedMedia.duration,
+                    displayOrder = index,
+                )
+            }
+
+        val result = guestBookRepository.createGuestBook(
+            invitationId = invitationId,
+            userId = 1,
+            textContent = uiState.value.textContent,
+            medias = guestBookMedias,
+        )
+        handleResult(result)
+    }
+
+    private suspend fun updateGuestBook(
+        guestBookId: Long,
+        uploadedUrls: List<String?>,
+        thumbnailUrls: List<String?>,
+        allSelectedMedias: List<SelectedMedia>
+    ) {
+        val existingImageIds = allSelectedMedias.filter { it.id != null && it.type == UiMediaType.IMAGE }.mapNotNull { it.id }
+        val existingAudioIds = allSelectedMedias.filter { it.id != null && it.type == UiMediaType.AUDIO }.mapNotNull { it.id }
+        val existingVideoIds = allSelectedMedias.filter { it.id != null && it.type == UiMediaType.VIDEO }.mapNotNull { it.id }
+
+        val onlyNewMedias = allSelectedMedias.filter { it.id == null }
+
+        val newMedias = uploadedUrls
+            .mapIndexedNotNull { index, url ->
+                val urlValue = url ?: return@mapIndexedNotNull null
+                val selectedMedia = onlyNewMedias.getOrNull(index) ?: return@mapIndexedNotNull null
+                val thumbnailUrl = thumbnailUrls.getOrNull(index)
+
+                GuestBookMedia(
+                    id = 0L,
+                    type = when (selectedMedia.type) {
+                        UiMediaType.IMAGE -> MediaType.IMAGE
+                        UiMediaType.VIDEO -> MediaType.VIDEO
+                        UiMediaType.AUDIO -> MediaType.AUDIO
+                    },
+                    url = urlValue,
+                    thumbnailUrl = thumbnailUrl,
+                    durationSeconds = selectedMedia.duration,
+                    displayOrder = allSelectedMedias.indexOf(selectedMedia)
+                )
+            }
+
+        val result = guestBookRepository.updateGuestBook(
+            guestBookId = guestBookId,
+            textContent = uiState.value.textContent,
+            existingImageIds = existingImageIds,
+            existingVideoIds = existingVideoIds,
+            existingAudioIds = existingAudioIds,
+            newMedias = newMedias
+        )
+        handleResult(result, true)
+    }
+
+    private fun handleResult(result: Result<GuestBook, DataError>, isUpdate: Boolean = false) = viewModelScope.launch {
+        updateState { copy(isUploading = false) }
+        when (result) {
+            is Result.Success -> {
+                updateState {
+                    copy(
+                        editingGuestBookId = null,
+                        selectedMedias = persistentListOf(),
+                        textContent = ""
+                    )
+                }
+                if (isUpdate) {
+                    sendEffect(MyInvitationGuestBookSideEffect.UpdateGuestBookSuccess)
+                } else {
+                    sendEffect(MyInvitationGuestBookSideEffect.CreateGuestBookSuccess)
+                }
+            }
+
+            is Result.Error -> sendEffect(MyInvitationGuestBookSideEffect.ShowSnackbar("실패: ${result.message}"))
+        }
+    }
+
+    private fun deleteGuestBook(guestBookId: Long) {
+        viewModelScope.launch {
+            guestBookRepository.deleteGuestBook(guestBookId)
+                .onSuccess { deletedId ->
+                    updateState {
+                        copy(
+                            editingGuestBookId = if (editingGuestBookId == deletedId) null else editingGuestBookId,
+                            selectedMedias = if (editingGuestBookId == deletedId) persistentListOf() else selectedMedias,
+                            textContent = if (editingGuestBookId == deletedId) "" else textContent,
+                            originalTextContent = if (editingGuestBookId == deletedId) "" else originalTextContent,
+                            originalMediaIds = if (editingGuestBookId == deletedId) setOf() else originalMediaIds,
+                        )
+                    }
+                    sendEffect(MyInvitationGuestBookSideEffect.DeleteGuestBookSuccess)
+                }
+                .onFailure {
+                    sendEffect(MyInvitationGuestBookSideEffect.ShowSnackbar("방명록 삭제를 실패하였습니다."))
+                }
+        }
+    }
+
+    fun invalidateGuestBooks() {
+        refreshFlow.value += 1
+    }
+
+    private fun cancelEdit() {
+        updateState {
+            copy(
+                editingGuestBookId = null,
+                selectedMedias = persistentListOf(),
+                textContent = "",
+                originalTextContent = "",
+                originalMediaIds = emptySet(),
+            )
+        }
+    }
+}

--- a/android/feature/myinvitation/src/main/res/values/strings.xml
+++ b/android/feature/myinvitation/src/main/res/values/strings.xml
@@ -21,4 +21,9 @@
     <string name="snack_load_error_map">설치된 지도 앱이 없습니다.</string>
 
     <string name="btn_invitation_click">초대장 확인하기</string>
+
+    <string name="txt_delete_dialog_title">정말로 이 방명록을\n삭제하시겠습니까?</string>
+    <string name="txt_delete_dialog_message">삭제된 방명록은 복구할 수 없습니다.</string>
+    <string name="btn_label_cancel">취소</string>
+    <string name="btn_label_delete">삭제</string>
 </resources>


### PR DESCRIPTION
## 🔍 변경 사항

- 내 초대장 상세 화면 방명록 탭 구현
- 방명록 작성/수정 시 키보드 및 TextField 포커스 처리 강화
- TopAppbar scrollBehavior 적용(스크롤 시 사라지고 맨 위로 다시 올려야 나옴 with.fade효과)
- 더보기 버튼 분기 처리(유튜브 참고)
    - 텍스트만 있는 경우 maxLines = 6
    - 비디오/이미지 있는 경우 maxLines = 2
    - 오디오만 있는 경우 maxLines = 4
- 모아보기 탭 UI 수정(아이템간 간격, 곡률, 플레이 버튼)

## 📸 스크린샷 

https://github.com/user-attachments/assets/d0b4677a-92fa-42b2-acea-029a9537c1df




## 🔗 관련 이슈

- Close #74 

## ✅ 체크리스트
- [x] 팀 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 import는 삭제했나요?
