### PR TITLE
Feature/#92 home UI 보완

### DIFF
--- a/android/app/src/main/kotlin/com/andlife/nacho/navigation/NavHost.kt
+++ b/android/app/src/main/kotlin/com/andlife/nacho/navigation/NavHost.kt
@@ -6,8 +6,11 @@ import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -36,8 +39,13 @@ fun NachoNavHost(
     deepLinkManager: DeepLinkManager,
     modifier: Modifier = Modifier,
 ) {
+    val snackbarHostState = remember { SnackbarHostState() }
+
     Scaffold(
         containerColor = NachoTheme.colorScheme.backgroundPrimary,
+        snackbarHost = {
+            SnackbarHost(snackbarHostState)
+        },
         bottomBar = {
             AnimatedVisibility(navigator.shouldShowBottomBar()) {
                 InvitationBottomBar(
@@ -57,6 +65,7 @@ fun NachoNavHost(
         ) {
             homeNavGraph(
                 paddingValues = innerPadding,
+                snackbarHostState = snackbarHostState,
                 onNavigateToCreate = navigator::navigateToMyInvitationCreate,
                 onNavigateToInvitationDetail = navigator::navigateToInvitationDetail,
                 onNavigateToMyInvitationDetail = navigator::navigateToMyInvitationDetail,

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/guestbook/GuestBookItem.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/guestbook/GuestBookItem.kt
@@ -82,7 +82,7 @@ fun GuestBookItem(
     modifier: Modifier = Modifier,
     shouldPlayVideo: Boolean = false,
     isEditing: Boolean = false,
-    useMenuButton: Boolean= true,
+    useMenuButton: Boolean = true,
     onMenuClick: () -> Unit = {},
     onEditClick: (GuestBookUiModel) -> Unit = {},
     onDeleteClick: (GuestBookUiModel) -> Unit = {},

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/guestbook/GuestBookItem.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/guestbook/GuestBookItem.kt
@@ -82,6 +82,7 @@ fun GuestBookItem(
     modifier: Modifier = Modifier,
     shouldPlayVideo: Boolean = false,
     isEditing: Boolean = false,
+    useMenuButton: Boolean= true,
     onMenuClick: () -> Unit = {},
     onEditClick: (GuestBookUiModel) -> Unit = {},
     onDeleteClick: (GuestBookUiModel) -> Unit = {},
@@ -103,7 +104,7 @@ fun GuestBookItem(
         GuestBookItemHeader(
             author = guestBook.author,
             createdAt = guestBook.createdAt,
-            isOwner = guestBook.isOwner,
+            isOwner = useMenuButton && guestBook.isOwner,
             onMenuClick = onMenuClick,
             onEditClick = { onEditClick(guestBook) },
             onDeleteClick = { onDeleteClick(guestBook) },

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/listitem/InvitationListItem.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/listitem/InvitationListItem.kt
@@ -78,7 +78,13 @@ fun InvitationListItem(
                         model = imageUrl,
                         contentDescription = stringResource(R.string.desc_invitation_list_image),
                         contentScale = ContentScale.Crop,
-                        loading = { InvitationLoadingIndicator() },
+                        loading = {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxSize()
+                                    .background(NachoTheme.colorScheme.backgroundSecondary),
+                            )
+                        },
                         success = {
                             SubcomposeAsyncImageContent()
                         },

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/listitem/InvitationScheduleListItem.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/listitem/InvitationScheduleListItem.kt
@@ -2,7 +2,9 @@ package com.andlife.ui.component.listitem
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
@@ -27,7 +29,6 @@ import com.andlife.designsystem.theme.NachoSpacing
 import com.andlife.designsystem.theme.NachoStroke
 import com.andlife.designsystem.theme.NachoTheme
 import com.andlife.ui.R
-import com.andlife.ui.component.loading.InvitationLoadingIndicator
 
 @Composable
 fun InvitationScheduleListItem(
@@ -68,7 +69,13 @@ fun InvitationScheduleListItem(
                     model = imageUrl,
                     contentDescription = stringResource(R.string.desc_schedule_list_image),
                     contentScale = ContentScale.Crop,
-                    loading = { InvitationLoadingIndicator() },
+                    loading = {
+                        Box(
+                            modifier = Modifier
+                                .fillMaxSize()
+                                .background(NachoTheme.colorScheme.backgroundSecondary),
+                        )
+                    },
                     success = {
                         SubcomposeAsyncImageContent()
                     },

--- a/android/feature/home/src/main/kotlin/com/andlife/home/HomeNavGraph.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/HomeNavGraph.kt
@@ -2,6 +2,7 @@ package com.andlife.home
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.ui.Modifier
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
@@ -28,6 +29,7 @@ fun NavController.navigateToSetting(navOptions: NavOptions) {
 
 fun NavGraphBuilder.homeNavGraph(
     paddingValues: PaddingValues,
+    snackbarHostState: SnackbarHostState,
     onNavigateToCreate: () -> Unit,
     onNavigateToInvitationDetail: (Long) -> Unit,
     onNavigateToMyInvitationDetail: (Long) -> Unit,
@@ -35,6 +37,7 @@ fun NavGraphBuilder.homeNavGraph(
 ) {
     composable<Home> {
         HomeRoute(
+            snackbarHostState = snackbarHostState,
             onNavigateToCreate = onNavigateToCreate,
             onNavigateToInvitationDetail = onNavigateToInvitationDetail,
             onNavigateToMyInvitationDetail = onNavigateToMyInvitationDetail,

--- a/android/feature/home/src/main/kotlin/com/andlife/home/model/HomeSideEffect.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/model/HomeSideEffect.kt
@@ -21,7 +21,5 @@ sealed interface HomeSideEffect : BaseSideEffect {
 
     data object ScrollToTop : HomeSideEffect
 
-    data object RefreshSuccess : HomeSideEffect
-
     data object RefreshFailure : HomeSideEffect
 }

--- a/android/feature/home/src/main/kotlin/com/andlife/home/model/HomeUiEvent.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/model/HomeUiEvent.kt
@@ -27,6 +27,4 @@ sealed interface HomeUiEvent : BaseUiEvent {
     data object ClickCreate : HomeUiEvent
 
     data object Refresh : HomeUiEvent
-
-    data object Retry : HomeUiEvent
 }

--- a/android/feature/home/src/main/kotlin/com/andlife/home/model/HomeUiState.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/model/HomeUiState.kt
@@ -7,7 +7,6 @@ import kotlinx.collections.immutable.persistentListOf
 
 data class HomeUiState(
     val isRefreshing: Boolean = false,
-    val isRetry: Boolean = false,
     val upcomingInvitations: ImmutableList<UpcomingInvitationUiModel> = persistentListOf(),
     val playingAudioUrl: String? = null,
     val isAudioPlaying: Boolean = false,

--- a/android/feature/home/src/main/kotlin/com/andlife/home/screen/HomeScreen.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/screen/HomeScreen.kt
@@ -112,7 +112,10 @@ fun HomeRoute(
     viewModel.effectFlow.collectWithLifecycle { effect ->
         when (effect) {
             is HomeSideEffect.ShowMessage -> {
-                scope.launch { snackbarHostState.showSnackbar(effect.message) }
+                scope.launch {
+                    snackbarHostState.currentSnackbarData?.dismiss()
+                    snackbarHostState.showSnackbar(effect.message)
+                }
             }
 
             is HomeSideEffect.NavigateToInvitationDetail -> {
@@ -139,12 +142,11 @@ fun HomeRoute(
                 scope.launch { lazyListState.animateScrollToItem(0) }
             }
 
-            is HomeSideEffect.RefreshSuccess -> {
-                scope.launch { snackbarHostState.showSnackbar(context.getString(R.string.snack_refresh_success)) }
-            }
-
             is HomeSideEffect.RefreshFailure -> {
-                scope.launch { snackbarHostState.showSnackbar(context.getString(R.string.snack_refresh_failure)) }
+                scope.launch {
+                    snackbarHostState.currentSnackbarData?.dismiss()
+                    snackbarHostState.showSnackbar(context.getString(R.string.snack_refresh_failure))
+                }
             }
         }
     }
@@ -585,7 +587,10 @@ private fun LazyListScope.homeGuestBookSection(
     if (isInitialLoading || isInitialError || isEmpty) {
         item {
             GuestBookStatusContent(
-                modifier = Modifier.padding(horizontal = NachoSpacing.large),
+                modifier = Modifier.padding(
+                    vertical = NachoSpacing.threeXLarge,
+                    horizontal = NachoSpacing.large
+                ),
                 isLoading = isInitialLoading,
                 title = when {
                     isInitialError -> stringResource(R.string.error_msg_failed_load_post)

--- a/android/feature/home/src/main/kotlin/com/andlife/home/screen/HomeScreen.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/screen/HomeScreen.kt
@@ -21,7 +21,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -90,6 +89,7 @@ private const val SKELETON_ITEM_COUNT = 2
 
 @Composable
 fun HomeRoute(
+    snackbarHostState: SnackbarHostState,
     onNavigateToCreate: () -> Unit,
     onNavigateToInvitationDetail: (Long) -> Unit,
     onNavigateToMyInvitationDetail: (Long) -> Unit,
@@ -106,7 +106,6 @@ fun HomeRoute(
     val lifecycleOwner = LocalLifecycleOwner.current
     val lazyListState = rememberLazyListState()
 
-    val snackbarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
 
     viewModel.effectFlow.collectWithLifecycle { effect ->
@@ -201,7 +200,6 @@ fun HomeRoute(
         upcomingInvitations = upcomingInvitations,
         guestBooks = guestBooks,
         onEvent = viewModel::onEvent,
-        snackbarHostState = snackbarHostState,
         lazyListState = lazyListState,
         videoPlayerPool = viewModel.videoPlayerPool,
         modifier = modifier,
@@ -216,7 +214,6 @@ fun HomeScreen(
     upcomingInvitations: LazyPagingItems<UpcomingInvitationUiModel>,
     guestBooks: LazyPagingItems<GuestBookUiModel>,
     onEvent: (HomeUiEvent) -> Unit,
-    snackbarHostState: SnackbarHostState,
     lazyListState: LazyListState,
     videoPlayerPool: AutoVideoPlayerPool,
     modifier: Modifier = Modifier,
@@ -297,9 +294,6 @@ fun HomeScreen(
 
     Scaffold(
         modifier = modifier.fillMaxSize(),
-        snackbarHost = {
-            SnackbarHost(snackbarHostState)
-        },
         topBar = {
             HomeTopBar(
                 title = stringResource(R.string.txt_title_home),
@@ -711,7 +705,6 @@ private fun HomeScreenPreview() {
             upcomingInvitations = emptyUpcomingInvitations,
             guestBooks = emptyGuestBooks,
             onEvent = {},
-            snackbarHostState = SnackbarHostState(),
             videoPlayerPool = fakeVideoPlayerPool,
             lazyListState = lazyListState,
         )

--- a/android/feature/home/src/main/kotlin/com/andlife/home/screen/HomeScreen.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/screen/HomeScreen.kt
@@ -458,8 +458,6 @@ private fun LazyListScope.homeUpcomingSection(
                     UpcomingStatusContent(
                         title = stringResource(R.string.txt_error_upcoming_title),
                         description = stringResource(R.string.txt_error_upcoming_desc),
-                        buttonText = stringResource(R.string.txt_action_retry),
-                        onButtonClick = onRetryClick,
                     )
                 }
 
@@ -597,8 +595,6 @@ private fun LazyListScope.homeGuestBookSection(
                     isEmpty -> stringResource(R.string.txt_empty_new_post_desc)
                     else -> null
                 },
-                buttonText = if (isInitialError) stringResource(R.string.txt_action_retry) else null,
-                onButtonClick = if (isInitialError) onRetryClick else null
             )
         }
     } else {

--- a/android/feature/home/src/main/kotlin/com/andlife/home/screen/HomeScreen.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/screen/HomeScreen.kt
@@ -599,6 +599,7 @@ private fun LazyListScope.homeGuestBookSection(
                 GuestBookItem(
                     modifier = Modifier.animateItem(),
                     guestBook = guestBook,
+                    useMenuButton = false,
                     videoPlayerPool = videoPlayerPool,
                     shouldPlayVideo = isMediaActive && (index == playVideoIndex),
                     isAudioPlaying = uiState.isAudioPlaying &&

--- a/android/feature/home/src/main/kotlin/com/andlife/home/screen/HomeScreen.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/screen/HomeScreen.kt
@@ -334,10 +334,6 @@ fun HomeScreen(
                         onInvitationClick = { id, isOwner ->
                             onEvent(HomeUiEvent.ClickUpcomingInvitation(id, isOwner))
                         },
-                        onRetryClick = {
-                            upcomingInvitations.retry()
-                            onEvent(HomeUiEvent.Retry)
-                        },
                         onNavigateToCreate = { onEvent(HomeUiEvent.ClickCreate) },
                     )
 
@@ -347,10 +343,6 @@ fun HomeScreen(
                         uiState = uiState,
                         playVideoIndex = playVideoIndex,
                         videoPlayerPool = videoPlayerPool,
-                        onRetryClick = {
-                            guestBooks.retry()
-                            onEvent(HomeUiEvent.Retry)
-                        },
                         onInvitationTitleClick = { id, isOwner ->
                             onEvent(HomeUiEvent.ClickInvitationTitle(id, isOwner))
                         },
@@ -411,7 +403,6 @@ private fun HomeTopBar(
 private fun LazyListScope.homeUpcomingSection(
     upcomingInvitations: LazyPagingItems<UpcomingInvitationUiModel>,
     onInvitationClick: (invitationId: Long, isOwner: Boolean) -> Unit,
-    onRetryClick: () -> Unit,
     onNavigateToCreate: () -> Unit,
 ) {
     val refreshState = upcomingInvitations.loadState.refresh
@@ -561,7 +552,6 @@ private fun LazyListScope.homeGuestBookSection(
     uiState: HomeUiState,
     playVideoIndex: Int,
     videoPlayerPool: AutoVideoPlayerPool,
-    onRetryClick: () -> Unit,
     onInvitationTitleClick: (invitationId: Long, isOwner: Boolean) -> Unit,
     onVisualMediaClick: (String) -> Unit,
     onAudioMediaClick: (String) -> Unit,

--- a/android/feature/home/src/main/kotlin/com/andlife/home/viewmodel/HomeViewModel.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/viewmodel/HomeViewModel.kt
@@ -138,7 +138,6 @@ class HomeViewModel @Inject constructor(
             sendEffect(HomeSideEffect.RefreshFailure)
         } else {
             if (wasUserTriggered) {
-                sendEffect(HomeSideEffect.RefreshSuccess)
                 sendEffect(HomeSideEffect.ScrollToTop)
             }
         }

--- a/android/feature/home/src/main/kotlin/com/andlife/home/viewmodel/HomeViewModel.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/viewmodel/HomeViewModel.kt
@@ -85,7 +85,6 @@ class HomeViewModel @Inject constructor(
             is HomeUiEvent.ClickSetting -> navigateToSetting()
             is HomeUiEvent.ClickCreate -> navigateToCreate()
             is HomeUiEvent.Refresh -> refresh()
-            is HomeUiEvent.Retry -> retry()
         }
     }
 
@@ -126,13 +125,9 @@ class HomeViewModel @Inject constructor(
         updateState { copy(isRefreshing = true) }
     }
 
-    private fun retry() {
-        updateState { copy(isRetry = true) }
-    }
-
     fun onRefreshFinished(hasError: Boolean) {
-        val wasUserTriggered = uiState.value.isRefreshing || uiState.value.isRetry
-        updateState { copy(isRefreshing = false, isRetry = false) }
+        val wasUserTriggered = uiState.value.isRefreshing
+        updateState { copy(isRefreshing = false) }
 
         if (hasError) {
             sendEffect(HomeSideEffect.RefreshFailure)

--- a/android/feature/home/src/main/res/values/strings.xml
+++ b/android/feature/home/src/main/res/values/strings.xml
@@ -10,7 +10,6 @@
     <string name="txt_action_create_invitation">초대장 작성 바로가기</string>
     <string name="txt_error_upcoming_title">일정을 불러오지 못했어요</string>
     <string name="txt_error_upcoming_desc">네트워크 연결을 확인해주세요</string>
-    <string name="txt_action_retry">재시도</string>
 
     <string name="txt_title_new_post">최신 게시글</string>
     <string name="txt_empty_new_post_desc">작성된 방명록이 없습니다.\n초대에 참여하여 첫 인사를 남겨보세요!</string>

--- a/android/feature/home/src/main/res/values/strings.xml
+++ b/android/feature/home/src/main/res/values/strings.xml
@@ -19,6 +19,5 @@
     <string name="txt_title_setting">설정</string>
     <string name="desc_top_bar_back">설정 뒤로가기 아이콘 버튼</string>
 
-    <string name="snack_refresh_success">새로운 소식을 불러왔어요</string>
     <string name="snack_refresh_failure">잠시 후 다시 시도해 주세요</string>
 </resources>


### PR DESCRIPTION
## 🔍 변경 사항
- 실패 시에만 스낵바 표시
- 실패시 재시도 버튼 제거(Pull to Refresh로 통일 했습니다)
- 로딩 중 listitem 이미지 로딩바->연한 회색으로 변경(이미 화면에서 로딩바가 돌아갑니다)
- 홈화면 방명록 버튼 미표시
- 홈 스낵바 최상위 Scaffold 로 이동

## 📸 스크린샷
<table>
  <tr>
    <td align="center">
      <b>로딩 중</b><br>
      <img src="https://github.com/user-attachments/assets/6fddd8be-68a3-4274-b974-b94bbf34b898" width="200">
    </td>
    <td align="center">
      <b>success</b><br>
      <img src="https://github.com/user-attachments/assets/eaea5004-00e0-42ed-88f2-2430a4fb6c03" width="200">
    </td>
    <td align="center">
      <b>fail</b><br>
      <img src="https://github.com/user-attachments/assets/0dcd7b82-ac35-4607-8c75-4b5d6bc4d3cd" width="200">
    </td>
    <td align="center">
      <b>데이터 null</b><br>
      <img src="https://github.com/user-attachments/assets/9bc20eef-0154-4a1d-b228-49b1be77c27f" width="200">
    </td>
  </tr>
</table>


## 🔗 관련 이슈
- Close #92 

## ✅ 체크리스트
- [x] 팀 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 import는 삭제했나요?
