### PR TITLE
Feature/#112 나의 초대장 카메라/마이크 적용

### DIFF
--- a/android/core/designsystem/src/main/kotlin/com/andlife/designsystem/theme/Dimen.kt
+++ b/android/core/designsystem/src/main/kotlin/com/andlife/designsystem/theme/Dimen.kt
@@ -18,6 +18,7 @@ object NachoIconSize {
     val xSmall = 16.dp
     val small = 20.dp
     val medium = 24.dp
+    val semiLarge = 28.dp
     val large = 32.dp
     val xLarge = 48.dp
     val twoXLarge = 64.dp

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/InvitationGuestBookForm.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/InvitationGuestBookForm.kt
@@ -143,14 +143,14 @@ fun InvitationGuestBookForm(
                 } else {
                     NachoTheme.colorScheme.iconDisabled
                 }
-            Row(horizontalArrangement = Arrangement.spacedBy(NachoSpacing.small)) {
+            Row(horizontalArrangement = Arrangement.spacedBy(NachoSpacing.medium)) {
                 Icon(
                     painter = painterResource(R.drawable.ic_image_16),
                     contentDescription = null,
                     tint = iconColor,
                     modifier =
                         Modifier
-                            .size(NachoIconSize.medium)
+                            .size(NachoIconSize.semiLarge)
                             .let {
                                 if (isMediaAddEnabled) {
                                     it.clickable {
@@ -167,7 +167,7 @@ fun InvitationGuestBookForm(
                     tint = iconColor,
                     modifier =
                         Modifier
-                            .size(NachoIconSize.medium)
+                            .size(NachoIconSize.semiLarge)
                             .let {
                                 if (isMediaAddEnabled) {
                                     it.clickable {
@@ -184,7 +184,7 @@ fun InvitationGuestBookForm(
                     tint = iconColor,
                     modifier =
                         Modifier
-                            .size(NachoIconSize.medium)
+                            .size(NachoIconSize.semiLarge)
                             .let {
                                 if (isMediaAddEnabled) {
                                     it.clickable {
@@ -201,7 +201,7 @@ fun InvitationGuestBookForm(
                     tint = if (isAudioRecording) Color.Green else iconColor,
                     modifier =
                         Modifier
-                            .size(NachoIconSize.medium)
+                            .size(NachoIconSize.semiLarge)
                             .let {
                                 if (isMediaAddEnabled) {
                                     it.clickable {

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
@@ -6,8 +6,10 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.FileProvider
 import android.Manifest
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
+import android.provider.Settings
 import androidx.activity.result.ActivityResultLauncher
 import java.io.File
 import androidx.compose.foundation.layout.Arrangement
@@ -50,6 +52,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.core.content.ContextCompat
+import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -109,6 +112,7 @@ fun InvitationGuestBookRoute(
 
     val snackbarHostState = remember { SnackbarHostState() }
     var showDeleteDialog by remember { mutableStateOf<Long?>(null) }
+    var showPermissionDialog by remember { mutableStateOf<String?>(null) }
     var scrollToTop by remember { mutableStateOf(false) }
 
     var cameraImageUri by remember { mutableStateOf<Uri?>(null) }
@@ -124,6 +128,8 @@ fun InvitationGuestBookRoute(
     ) { isGranted ->
         if (isGranted) {
             viewModel.onEvent(InvitationGuestBookUiEvent.ClickCamera)
+        } else {
+            showPermissionDialog = Manifest.permission.CAMERA
         }
     }
 
@@ -148,6 +154,8 @@ fun InvitationGuestBookRoute(
     ) { isGranted ->
         if (isGranted) {
             viewModel.onEvent(InvitationGuestBookUiEvent.ClickMicrophone)
+        } else {
+            showPermissionDialog = Manifest.permission.RECORD_AUDIO
         }
     }
 
@@ -320,6 +328,54 @@ fun InvitationGuestBookRoute(
         }
     }
 
+    if (showPermissionDialog != null) {
+        NachoDialog(
+            onDismiss = { showPermissionDialog = null }
+        ) {
+            Column(
+                modifier = Modifier.padding(NachoSpacing.xLarge),
+                verticalArrangement = Arrangement.spacedBy(NachoSpacing.medium)
+            ) {
+                Text(
+                    text = when (showPermissionDialog) {
+                        Manifest.permission.CAMERA -> stringResource(R.string.txt_permission_camera)
+                        Manifest.permission.RECORD_AUDIO -> stringResource(R.string.txt_permission_audio)
+                        else -> stringResource(R.string.txt_permission_etc)
+                    },
+                    color = NachoTheme.colorScheme.textSecondary,
+                    style = NachoTheme.typography.bodyMediumRegular,
+                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    TextButton(
+                        onClick = { showPermissionDialog = null }
+                    ) {
+                        Text(
+                            text = stringResource(R.string.btn_label_cancel),
+                            color = NachoTheme.colorScheme.textPrimary,
+                            style = NachoTheme.typography.bodyMediumSemiBold,
+                        )
+                    }
+                    TextButton(
+                        onClick = {
+                            showPermissionDialog = null
+                            val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                            intent.data = "package:${context.packageName}".toUri()
+                            context.startActivity(intent)
+                        }
+                    ) {
+                        Text(
+                            text = stringResource(R.string.btn_label_to_setting),                            color = NachoTheme.colorScheme.brandPrimary,
+                            style = NachoTheme.typography.bodyMediumSemiBold,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
     InvitationGuestBookScreen(
         uiState = uiState,
         guestBooks = guestBooks,
@@ -380,6 +436,7 @@ private fun InvitationGuestBookScreen(
             isImVisible -> {
                 focusManager.clearFocus()
             }
+
             uiState.editingGuestBookId != null -> {
                 focusManager.clearFocus()
                 onEvent(InvitationGuestBookUiEvent.CancelEdit)

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
@@ -197,6 +197,7 @@ fun InvitationGuestBookRoute(
                     "${context.packageName}.provider",
                     photoFile
                 )
+                cameraImageUri = photoUri
                 cameraLauncher.launch(photoUri)
             }
 

--- a/android/feature/invitation/src/main/res/values/strings.xml
+++ b/android/feature/invitation/src/main/res/values/strings.xml
@@ -19,5 +19,10 @@
     <string name="txt_delete_dialog_message">삭제된 방명록은 복구할 수 없습니다.</string>
     <string name="btn_label_cancel">취소</string>
     <string name="btn_label_delete">삭제</string>
+
+    <string name="txt_permission_camera">사진을 촬영하려면 카메라 권한이 필요합니다.</string>
+    <string name="txt_permission_audio">음성을 녹음하려면 마이크 권한이 필요합니다.</string>
+    <string name="txt_permission_etc">권한이 필요합니다.</string>
+    <string name="btn_label_to_setting">설정으로 이동</string>
 </resources>
 

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/model/guestbook/MyInvitationGuestBookSideEffect.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/model/guestbook/MyInvitationGuestBookSideEffect.kt
@@ -12,4 +12,10 @@ sealed interface MyInvitationGuestBookSideEffect : BaseSideEffect {
     data object UpdateGuestBookSuccess : MyInvitationGuestBookSideEffect
 
     data object DeleteGuestBookSuccess : MyInvitationGuestBookSideEffect
+
+    data object LaunchCamera : MyInvitationGuestBookSideEffect
+
+    data object StartAudioRecording : MyInvitationGuestBookSideEffect
+
+    data object StopAudioRecording : MyInvitationGuestBookSideEffect
 }

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/model/guestbook/MyInvitationGuestBookUiEvent.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/model/guestbook/MyInvitationGuestBookUiEvent.kt
@@ -19,6 +19,14 @@ sealed interface MyInvitationGuestBookUiEvent : BaseUiEvent {
 
     data object UploadMedias : MyInvitationGuestBookUiEvent
 
+    data object ClickCamera : MyInvitationGuestBookUiEvent
+
+    data object ClickMicrophone : MyInvitationGuestBookUiEvent
+
+    data object StartAudioRecording : MyInvitationGuestBookUiEvent
+
+    data object StopAudioRecording : MyInvitationGuestBookUiEvent
+
     data object ClearError : MyInvitationGuestBookUiEvent
 
     data class ClickInvitationTitle(

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/model/guestbook/MyInvitationGuestBookUiState.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/model/guestbook/MyInvitationGuestBookUiState.kt
@@ -18,6 +18,8 @@ data class MyInvitationGuestBookUiState(
     val isLoadingGuestBooks: Boolean = false,
     val deleteTargetId: Long? = null,
     val guestBooksErrorMessage: String? = null,
+    val isAudioRecording: Boolean = false,
+    val audioRecordingDuration: Int = 0,
 ) : BaseUiState {
 
     val isContentChanged: Boolean

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
@@ -197,6 +197,7 @@ fun MyInvitationGuestBookRoute(
                     "${context.packageName}.provider",
                     photoFile
                 )
+                cameraImageUri = photoUri
                 cameraLauncher.launch(photoUri)
             }
 

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
@@ -1,6 +1,13 @@
 package com.andlife.myinvitation.screen.guestbook
 
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.net.Uri
 import androidx.activity.compose.BackHandler
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -37,8 +44,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
+import androidx.core.content.ContextCompat
+import androidx.core.content.FileProvider
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -70,14 +80,21 @@ import com.andlife.myinvitation.viewmodel.MyInvitationGuestBookViewModel
 import com.andlife.ui.component.guestbook.GuestBookItem
 import com.andlife.ui.component.invitation.InvitationGuestBookForm
 import com.andlife.ui.component.paging.PagingStateContent
+import com.andlife.ui.util.audio.AudioRecorder
 import com.andlife.ui.util.collectWithLifecycle
+import com.andlife.ui.util.media.uriToSelectedMedia
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDateTime
+import java.io.File
 import kotlin.math.max
 import kotlin.math.min
+import kotlin.toString
+
+private const val CAMERA_IMAGES_DIR = "camera_images"
+private const val AUDIO_RECORDINGS_DIR = "audio_recordings"
 
 @Composable
 fun MyInvitationGuestBookRoute(
@@ -94,6 +111,45 @@ fun MyInvitationGuestBookRoute(
     val snackbarHostState = remember { SnackbarHostState() }
     var showDeleteDialog by remember { mutableStateOf<Long?>(null) }
     var scrollToTop by remember { mutableStateOf(false) }
+
+
+    val context = LocalContext.current
+
+    var cameraImageUri by remember { mutableStateOf<Uri?>(null) }
+    val audioRecorder = remember { AudioRecorder(context) }
+
+    // 카메라 권한 요청 launcher
+    val cameraPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            viewModel.onEvent(MyInvitationGuestBookUiEvent.ClickCamera)
+        }
+    }
+
+    // 카메라 촬영을 위한 launcher
+    val cameraLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.TakePicture()
+    ) { success ->
+        if (success && cameraImageUri != null) {
+            val currentMedias = uiState.selectedMedias
+            if (currentMedias.size < 5) {
+                // 촬영한 사진을 SelectedMedia로 변환하여 추가
+                val newMedia = uriToSelectedMedia(context, cameraImageUri.toString())
+                val updatedMedias = (currentMedias + newMedia).toImmutableList()
+                viewModel.onEvent(MyInvitationGuestBookUiEvent.UpdateSelectedMedias(updatedMedias))
+            }
+        }
+    }
+
+    // 오디오 권한 요청 launcher
+    val audioPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+            viewModel.onEvent(MyInvitationGuestBookUiEvent.ClickMicrophone)
+        }
+    }
 
     viewModel.effectFlow.collectWithLifecycle { effect ->
         when (effect) {
@@ -116,6 +172,56 @@ fun MyInvitationGuestBookRoute(
             is MyInvitationGuestBookSideEffect.DeleteGuestBookSuccess -> {
                 viewModel.videoPlayerPool.clearCacheById(uiState.editingGuestBookId)
                 viewModel.invalidateGuestBooks()
+            }
+
+            is MyInvitationGuestBookSideEffect.LaunchCamera -> {
+                // 임시 파일 생성
+                val cameraImagesDir = File(context.cacheDir, CAMERA_IMAGES_DIR)
+                if (!cameraImagesDir.exists()) {
+                    cameraImagesDir.mkdirs()
+                }
+                val photoFile = File(
+                    cameraImagesDir,
+                    "camera_photo_${System.currentTimeMillis()}.jpg"
+                )
+                val photoUri = FileProvider.getUriForFile(
+                    context,
+                    "${context.packageName}.provider",
+                    photoFile
+                )
+                cameraLauncher.launch(photoUri)
+            }
+
+            is MyInvitationGuestBookSideEffect.StartAudioRecording -> {
+                // 오디오 녹음 시작
+                val audioRecordingsDir = File(context.cacheDir, AUDIO_RECORDINGS_DIR)
+                if (!audioRecordingsDir.exists()) {
+                    audioRecordingsDir.mkdirs()
+                }
+                val audioFile = File(
+                    audioRecordingsDir,
+                    "audio_${System.currentTimeMillis()}.m4a"
+                )
+
+                audioRecorder.startRecording(audioFile) { e ->
+                    viewModel.onEvent(MyInvitationGuestBookUiEvent.StopAudioRecording)
+                    // exception 표시
+                }
+            }
+
+            is MyInvitationGuestBookSideEffect.StopAudioRecording -> {
+                // 오디오 녹음 중지
+                audioRecorder.stopRecording { recordedFile ->
+                    if (recordedFile != null) {
+                        // 녹음된 오디오 파일을 SelectedMedia로 변환
+                        val currentMedias = uiState.selectedMedias
+                        if (currentMedias.size < 5) {
+                            val audioMedia = uriToSelectedMedia(context, recordedFile.toURI().toString())
+                            val updatedMedias = (currentMedias + audioMedia).toImmutableList()
+                            viewModel.onEvent(MyInvitationGuestBookUiEvent.UpdateSelectedMedias(updatedMedias))
+                        }
+                    }
+                }
             }
         }
     }
@@ -221,6 +327,9 @@ fun MyInvitationGuestBookRoute(
         lazyListState = lazyListState,
         videoPlayerPool = viewModel.videoPlayerPool,
         onDeleteMenuClick = { guestBookId -> showDeleteDialog = guestBookId },
+        context = context,
+        cameraPermissionLauncher = cameraPermissionLauncher,
+        audioPermissionLauncher = audioPermissionLauncher,
         modifier = modifier,
     )
 }
@@ -236,6 +345,9 @@ private fun InvitationGuestBookScreen(
     videoPlayerPool: AutoVideoPlayerPool,
     onNavigateBack: () -> Unit,
     onDeleteMenuClick: (Long) -> Unit,
+    context: Context,
+    cameraPermissionLauncher: ActivityResultLauncher<String>,
+    audioPermissionLauncher: ActivityResultLauncher<String>,
     modifier: Modifier = Modifier,
 ) {
     val coroutineScope = rememberCoroutineScope()
@@ -360,7 +472,10 @@ private fun InvitationGuestBookScreen(
                         onEvent = onEvent,
                         onFocusChanged = { focused ->
                             isTextFieldFocused = focused
-                        }
+                        },
+                        context = context,
+                        cameraPermissionLauncher = cameraPermissionLauncher,
+                        audioPermissionLauncher = audioPermissionLauncher
                     )
                 }
             }
@@ -433,6 +548,9 @@ private fun GuestBookFormSection(
     uiState: MyInvitationGuestBookUiState,
     onEvent: (MyInvitationGuestBookUiEvent) -> Unit,
     onFocusChanged: (Boolean) -> Unit,
+    context: Context,
+    cameraPermissionLauncher: ActivityResultLauncher<String>,
+    audioPermissionLauncher: ActivityResultLauncher<String>,
 ) {
     InvitationGuestBookForm(
         modifier = Modifier
@@ -458,11 +576,40 @@ private fun GuestBookFormSection(
         onUploadClick = {
             onEvent(MyInvitationGuestBookUiEvent.UploadMedias)
         },
-        onCameraClick = {},
-        onMicrophoneClick = {},
-
         onFocusChanged = onFocusChanged,
-    )
+        onCameraClick = {
+            // 카메라 권한 체크
+            val hasPermission = ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.CAMERA
+            ) == PackageManager.PERMISSION_GRANTED
+
+            if (hasPermission) {
+                onEvent(MyInvitationGuestBookUiEvent.ClickCamera)
+            } else {
+                cameraPermissionLauncher.launch(Manifest.permission.CAMERA)
+            }
+        },
+        onMicrophoneClick = {
+            // 오디오 권한 체크
+            val hasPermission = ContextCompat.checkSelfPermission(
+                context,
+                Manifest.permission.RECORD_AUDIO
+            ) == PackageManager.PERMISSION_GRANTED
+
+            if (hasPermission) {
+                if (uiState.isAudioRecording) {
+                    onEvent(MyInvitationGuestBookUiEvent.StopAudioRecording)
+                } else {
+                    onEvent(MyInvitationGuestBookUiEvent.StartAudioRecording)
+                }
+            } else {
+                audioPermissionLauncher.launch(Manifest.permission.RECORD_AUDIO)
+            }
+        },
+
+
+        )
 }
 
 @PreviewTheme
@@ -479,6 +626,13 @@ private fun InvitationGuestBookEmptyPreview() {
             snackbarHostState = SnackbarHostState(),
             lazyListState = rememberLazyListState(),
             onDeleteMenuClick = {},
+            context = LocalContext.current,
+            cameraPermissionLauncher = rememberLauncherForActivityResult(
+                contract = ActivityResultContracts.RequestPermission()
+            ) {},
+            audioPermissionLauncher = rememberLauncherForActivityResult(
+                contract = ActivityResultContracts.RequestPermission()
+            ) {},
         )
     }
 }

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
@@ -2,8 +2,10 @@ package com.andlife.myinvitation.screen.guestbook
 
 import android.Manifest
 import android.content.Context
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
+import android.provider.Settings
 import androidx.activity.compose.BackHandler
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResultLauncher
@@ -49,6 +51,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.stringResource
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
+import androidx.core.net.toUri
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
@@ -110,6 +113,7 @@ fun MyInvitationGuestBookRoute(
 
     val snackbarHostState = remember { SnackbarHostState() }
     var showDeleteDialog by remember { mutableStateOf<Long?>(null) }
+    var showPermissionDialog by remember { mutableStateOf<String?>(null) }
     var scrollToTop by remember { mutableStateOf(false) }
 
 
@@ -124,6 +128,8 @@ fun MyInvitationGuestBookRoute(
     ) { isGranted ->
         if (isGranted) {
             viewModel.onEvent(MyInvitationGuestBookUiEvent.ClickCamera)
+        } else {
+            showPermissionDialog = Manifest.permission.CAMERA
         }
     }
 
@@ -148,6 +154,8 @@ fun MyInvitationGuestBookRoute(
     ) { isGranted ->
         if (isGranted) {
             viewModel.onEvent(MyInvitationGuestBookUiEvent.ClickMicrophone)
+        } else {
+            showPermissionDialog = Manifest.permission.RECORD_AUDIO
         }
     }
 
@@ -310,6 +318,55 @@ fun MyInvitationGuestBookRoute(
                         Text(
                             text = stringResource(R.string.btn_label_delete),
                             color = NachoTheme.colorScheme.brandDark,
+                            style = NachoTheme.typography.bodyMediumSemiBold,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    if (showPermissionDialog != null) {
+        NachoDialog(
+            onDismiss = { showPermissionDialog = null }
+        ) {
+            Column(
+                modifier = Modifier.padding(NachoSpacing.xLarge),
+                verticalArrangement = Arrangement.spacedBy(NachoSpacing.medium)
+            ) {
+                Text(
+                    text = when (showPermissionDialog) {
+                        Manifest.permission.CAMERA -> "사진을 촬영하려면 카메라 권한이 필요합니다."
+                        Manifest.permission.RECORD_AUDIO -> "음성을 녹음하려면 마이크 권한이 필요합니다."
+                        else -> "권한이 필요합니다."
+                    },
+                    color = NachoTheme.colorScheme.textSecondary,
+                    style = NachoTheme.typography.bodyMediumRegular,
+                )
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                ) {
+                    TextButton(
+                        onClick = { showPermissionDialog = null }
+                    ) {
+                        Text(
+                            text = "취소",
+                            color = NachoTheme.colorScheme.textPrimary,
+                            style = NachoTheme.typography.bodyMediumSemiBold,
+                        )
+                    }
+                    TextButton(
+                        onClick = {
+                            showPermissionDialog = null
+                            val intent = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS)
+                            intent.data = "package:${context.packageName}".toUri()
+                            context.startActivity(intent)
+                        }
+                    ) {
+                        Text(
+                            text = "설정으로 이동",
+                            color = NachoTheme.colorScheme.brandPrimary,
                             style = NachoTheme.typography.bodyMediumSemiBold,
                         )
                     }

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
@@ -336,9 +336,9 @@ fun MyInvitationGuestBookRoute(
             ) {
                 Text(
                     text = when (showPermissionDialog) {
-                        Manifest.permission.CAMERA -> "사진을 촬영하려면 카메라 권한이 필요합니다."
-                        Manifest.permission.RECORD_AUDIO -> "음성을 녹음하려면 마이크 권한이 필요합니다."
-                        else -> "권한이 필요합니다."
+                        Manifest.permission.CAMERA -> stringResource(R.string.txt_permission_camera)
+                        Manifest.permission.RECORD_AUDIO -> stringResource(R.string.txt_permission_audio)
+                        else -> stringResource(R.string.txt_permission_etc)
                     },
                     color = NachoTheme.colorScheme.textSecondary,
                     style = NachoTheme.typography.bodyMediumRegular,
@@ -351,7 +351,7 @@ fun MyInvitationGuestBookRoute(
                         onClick = { showPermissionDialog = null }
                     ) {
                         Text(
-                            text = "취소",
+                            text = stringResource(R.string.btn_label_cancel),
                             color = NachoTheme.colorScheme.textPrimary,
                             style = NachoTheme.typography.bodyMediumSemiBold,
                         )
@@ -365,7 +365,7 @@ fun MyInvitationGuestBookRoute(
                         }
                     ) {
                         Text(
-                            text = "설정으로 이동",
+                            text = stringResource(R.string.btn_label_to_setting),
                             color = NachoTheme.colorScheme.brandPrimary,
                             style = NachoTheme.typography.bodyMediumSemiBold,
                         )

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
@@ -564,6 +564,7 @@ private fun GuestBookFormSection(
         isUploading = uiState.isUploading,
         isSubmittable = uiState.isSubmittable,
         editingGuestBookId = uiState.editingGuestBookId,
+        isAudioRecording = uiState.isAudioRecording,
         onMediasSelected = { medias ->
             onEvent(MyInvitationGuestBookUiEvent.UpdateSelectedMedias(medias))
         },

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationGuestBookViewModel.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationGuestBookViewModel.kt
@@ -107,6 +107,10 @@ constructor(
             is MyInvitationGuestBookUiEvent.UpdateTextContent -> updateTextContent(event.textContent)
             is MyInvitationGuestBookUiEvent.RemoveMedia -> removeMedia(event.media)
             is MyInvitationGuestBookUiEvent.UploadMedias -> handleUploadMedias()
+            is MyInvitationGuestBookUiEvent.ClickCamera -> handleCameraClick()
+            is MyInvitationGuestBookUiEvent.ClickMicrophone -> handleMicrophoneClick()
+            is MyInvitationGuestBookUiEvent.StartAudioRecording -> handleStartAudioRecording()
+            is MyInvitationGuestBookUiEvent.StopAudioRecording -> handleStopAudioRecording()
             is MyInvitationGuestBookUiEvent.ClearError -> clearError()
             is MyInvitationGuestBookUiEvent.ClickAudioMedia -> clickAudioMedia(event.url)
 
@@ -203,6 +207,7 @@ constructor(
                             val thumbnails = generateAndUploadThumbnails(newMedias)
                             uploadResult.data to thumbnails
                         }
+
                         is Result.Error -> {
                             updateState { copy(isUploading = false) }
                             sendEffect(MyInvitationGuestBookSideEffect.ShowSnackbar("업로드 실패: ${uploadResult.message}"))
@@ -290,9 +295,12 @@ constructor(
         thumbnailUrls: List<String?>,
         allSelectedMedias: List<SelectedMedia>
     ) {
-        val existingImageIds = allSelectedMedias.filter { it.id != null && it.type == UiMediaType.IMAGE }.mapNotNull { it.id }
-        val existingAudioIds = allSelectedMedias.filter { it.id != null && it.type == UiMediaType.AUDIO }.mapNotNull { it.id }
-        val existingVideoIds = allSelectedMedias.filter { it.id != null && it.type == UiMediaType.VIDEO }.mapNotNull { it.id }
+        val existingImageIds =
+            allSelectedMedias.filter { it.id != null && it.type == UiMediaType.IMAGE }.mapNotNull { it.id }
+        val existingAudioIds =
+            allSelectedMedias.filter { it.id != null && it.type == UiMediaType.AUDIO }.mapNotNull { it.id }
+        val existingVideoIds =
+            allSelectedMedias.filter { it.id != null && it.type == UiMediaType.VIDEO }.mapNotNull { it.id }
 
         val onlyNewMedias = allSelectedMedias.filter { it.id == null }
 
@@ -380,5 +388,38 @@ constructor(
                 originalMediaIds = emptySet(),
             )
         }
+    }
+
+    private fun handleCameraClick() {
+        val state = uiState.value
+        if (state.selectedMedias.size >= 5) {
+            sendEffect(MyInvitationGuestBookSideEffect.ShowSnackbar("최대 5개까지 미디어를 추가할 수 있습니다."))
+            return
+        }
+        sendEffect(MyInvitationGuestBookSideEffect.LaunchCamera)
+    }
+
+    private fun handleMicrophoneClick() {
+        val state = uiState.value
+
+        if (state.isAudioRecording) {
+            onEvent(MyInvitationGuestBookUiEvent.StopAudioRecording)
+        } else {
+            if (state.selectedMedias.size >= 5) {
+                sendEffect(MyInvitationGuestBookSideEffect.ShowSnackbar("최대 5개까지 미디어를 추가할 수 있습니다."))
+                return
+            }
+            onEvent(MyInvitationGuestBookUiEvent.StartAudioRecording)
+        }
+    }
+
+    private fun handleStartAudioRecording() {
+        updateState { copy(isAudioRecording = true, audioRecordingDuration = 0) }
+        sendEffect(MyInvitationGuestBookSideEffect.StartAudioRecording)
+    }
+
+    private fun handleStopAudioRecording() {
+        updateState { copy(isAudioRecording = false, audioRecordingDuration = 0) }
+        sendEffect(MyInvitationGuestBookSideEffect.StopAudioRecording)
     }
 }

--- a/android/feature/myinvitation/src/main/res/values/strings.xml
+++ b/android/feature/myinvitation/src/main/res/values/strings.xml
@@ -26,4 +26,9 @@
     <string name="txt_delete_dialog_message">삭제된 방명록은 복구할 수 없습니다.</string>
     <string name="btn_label_cancel">취소</string>
     <string name="btn_label_delete">삭제</string>
+
+    <string name="txt_permission_camera">사진을 촬영하려면 카메라 권한이 필요합니다.</string>
+    <string name="txt_permission_audio">음성을 녹음하려면 마이크 권한이 필요합니다.</string>
+    <string name="txt_permission_etc">권한이 필요합니다.</string>
+    <string name="btn_label_to_setting">설정으로 이동</string>
 </resources>


### PR DESCRIPTION
## 🔍 변경 사항
- [x] 나의 초대장에도 카메라/마이크 적용
- [x] 일부 피드백 및 qa 반영
	- [x] 권한이 거부되었을 경우 다이얼로그를 통해 설정 화면으로 유도
	- [x] 미디어 아이콘 크기 조정

[지난 PR](https://github.com/boostcampwm2025/and02-boostcamp/pull/99)의 invitation feature에서 있었던 변경사항을 my-invitation에도 코드 복사만 진행했습니다. 지금 카메라 기능이 안되고 있고 음성녹음 구현도 문서화와 함께 수정중이라서, 이 부분은 완료되면 다음 QA PR로 올리도록 하겠습니다.

## 📸 스크린샷 (선택)

<img src="https://github.com/user-attachments/assets/a1e18d9e-b5b5-4af0-b349-1472c40cbf9f" width="540" height="277"/>

## 🔗 관련 이슈
- Close #112

## ✅ 체크리스트
- [x] 팀 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 import는 삭제했나요?
