### PR TITLE
Feature/#125 초대장 삭제 기능 구현, QA 피드백 반영

### DIFF
--- a/android/app/src/main/kotlin/com/andlife/nacho/navigation/NavHost.kt
+++ b/android/app/src/main/kotlin/com/andlife/nacho/navigation/NavHost.kt
@@ -95,6 +95,7 @@ fun NachoNavHost(
             )
 
             myInvitationNavGraph(
+                snackbarHostState = snackbarHostState,
                 paddingValues = innerPadding,
                 onNavigateToCreate = navigator::navigateToMyInvitationCreate,
                 onNavigateToDetail = navigator::navigateToMyInvitationDetail,

--- a/android/core/data/src/main/kotlin/com/andlife/data/datasource/remote/invitation/InvitationPagingSource.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/datasource/remote/invitation/InvitationPagingSource.kt
@@ -12,7 +12,8 @@ class InvitationPagingSource(
     private val remoteDataSource: InvitationRemoteDataSource,
     private val status: InvitationStatus,
     private val sortType: SortDirection,
-    private val isMyInvitation: Boolean = false
+    private val isMyInvitation: Boolean = false,
+    private val onTotalCountLoaded: (Int) -> Unit
 ) : PagingSource<Int, InvitationSummary>() {
 
     override suspend fun load(params: LoadParams<Int>): LoadResult<Int, InvitationSummary> {
@@ -37,6 +38,9 @@ class InvitationPagingSource(
         return when (result) {
             is Result.Success -> {
                 val pagingResponse = result.data
+
+                onTotalCountLoaded(pagingResponse.meta.totalCount)
+
                 LoadResult.Page(
                     data = pagingResponse.content.map { it.toDomain() },
                     prevKey = if (page == 0) null else page - 1,

--- a/android/core/data/src/main/kotlin/com/andlife/data/datasource/remote/invitation/InvitationRemoteDataSource.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/datasource/remote/invitation/InvitationRemoteDataSource.kt
@@ -37,4 +37,5 @@ interface InvitationRemoteDataSource {
     ): Result<PagingResponse<UpcomingInvitationResponse>, DataError>
     suspend fun createInvitationCard(invitationId: Long, request: InvitationCardRequest): Result<Long, DataError>
     suspend fun updateInvitationCard(cardId: Long, request: InvitationCardRequest): Result<Long, DataError>
+    suspend fun deleteInvitation(invitationId: Long): Result<Unit, DataError>
 }

--- a/android/core/data/src/main/kotlin/com/andlife/data/datasource/remote/invitation/InvitationRemoteDataSourceImpl.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/datasource/remote/invitation/InvitationRemoteDataSourceImpl.kt
@@ -70,5 +70,8 @@ internal class InvitationRemoteDataSourceImpl @Inject constructor(
         request: InvitationCardRequest
     ): Result<Long, DataError> =
         apiCall { invitationService.updateInvitationCard(cardId, request) }
+
+    override suspend fun deleteInvitation(invitationId: Long): Result<Unit, DataError> =
+        apiCall { invitationService.deleteInvitation(invitationId) }
 }
 

--- a/android/core/data/src/main/kotlin/com/andlife/data/repository/invitation/InvitationRepositoryImpl.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/repository/invitation/InvitationRepositoryImpl.kt
@@ -64,6 +64,9 @@ internal class InvitationRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun deleteInvitation(invitationId: Long): Result<Unit, DataError> =
+        invitationRemoteDataSource.deleteInvitation(invitationId)
+
     override suspend fun getInvitation(invitationId: Long): Result<Invitation, DataError> =
         invitationRemoteDataSource.getInvitation(invitationId).map { response ->
             response.toDomain(json)

--- a/android/core/data/src/main/kotlin/com/andlife/data/repository/invitation/InvitationRepositoryImpl.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/repository/invitation/InvitationRepositoryImpl.kt
@@ -75,7 +75,8 @@ internal class InvitationRepositoryImpl @Inject constructor(
     override fun getParticipantInvitations(
         status: InvitationStatus,
         sortType: SortDirection,
-        isMyInvitation: Boolean
+        isMyInvitation: Boolean,
+        onTotalCountLoaded: (Int) -> Unit
     ): Flow<PagingData<InvitationSummary>> {
         return Pager(
             config = PagingConfig(
@@ -83,14 +84,15 @@ internal class InvitationRepositoryImpl @Inject constructor(
                 enablePlaceholders = false,
                 initialLoadSize = PAGE_SIZE
             ),
-            pagingSourceFactory = { InvitationPagingSource(invitationRemoteDataSource, status, sortType, isMyInvitation) }
+            pagingSourceFactory = { InvitationPagingSource(invitationRemoteDataSource, status, sortType, isMyInvitation, onTotalCountLoaded) }
         ).flow
     }
 
     override fun getMyInvitations(
         status: InvitationStatus,
         sortType: SortDirection,
-        isMyInvitation: Boolean
+        isMyInvitation: Boolean,
+        onTotalCountLoaded: (Int) -> Unit
     ): Flow<PagingData<InvitationSummary>> {
         return Pager(
             config = PagingConfig(
@@ -98,7 +100,7 @@ internal class InvitationRepositoryImpl @Inject constructor(
                 enablePlaceholders = false,
                 initialLoadSize = PAGE_SIZE
             ),
-            pagingSourceFactory = { InvitationPagingSource(invitationRemoteDataSource, status, sortType, isMyInvitation) }
+            pagingSourceFactory = { InvitationPagingSource(invitationRemoteDataSource, status, sortType, isMyInvitation, onTotalCountLoaded) }
         ).flow
     }
 

--- a/android/core/network/src/main/kotlin/com/andlife/network/api/invitation/InvitationService.kt
+++ b/android/core/network/src/main/kotlin/com/andlife/network/api/invitation/InvitationService.kt
@@ -9,6 +9,7 @@ import retrofit2.http.Body
 import com.andlife.network.model.invitation.InvitationSummaryResponse
 import com.andlife.network.model.invitation.JoinResponse
 import com.andlife.network.model.invitation.UpcomingInvitationResponse
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.POST
 import retrofit2.http.PUT
@@ -58,6 +59,11 @@ interface InvitationService {
         @Path("invitationId") invitationId: Long,
         @Body request: InvitationSaveRequest,
     ): BaseResponse<InvitationResponse>
+
+    @DELETE("/api/invitations/{invitationId}")
+    suspend fun deleteInvitation(
+        @Path("invitationId") invitationId: Long,
+    ): BaseResponse<Unit>
 
     @GET("/api/invitations/upcoming")
     suspend fun getUpcomingInvitations(

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/collection/NachoMediaGridView.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/collection/NachoMediaGridView.kt
@@ -1,13 +1,18 @@
 package com.andlife.ui.component.collection
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import com.andlife.designsystem.preview.PreviewTheme
 import com.andlife.designsystem.theme.NachoSpacing
 import com.andlife.designsystem.theme.NachoTheme
@@ -19,6 +24,7 @@ import kotlinx.collections.immutable.persistentListOf
 import kotlinx.datetime.Clock
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+import com.andlife.ui.R
 
 @Composable
 fun NachoMediaGridView(
@@ -30,24 +36,35 @@ fun NachoMediaGridView(
         modifier = modifier,
         color = NachoTheme.colorScheme.backgroundPrimary,
     ) {
-        LazyVerticalGrid(
-            columns = GridCells.Fixed(3),
-            modifier = modifier,
-            contentPadding = PaddingValues(NachoSpacing.small),
-            horizontalArrangement = Arrangement.spacedBy(NachoSpacing.twoXSmall),
-            verticalArrangement = Arrangement.spacedBy(NachoSpacing.twoXSmall),
-        ) {
-            itemsIndexed(
-                items = items,
-                key = { index, item -> "${item.type}_${item.id}" },
-            ) { index, item ->
-                MediaItem(
-                    mediaUrl = item.mediaUrl,
-                    thumbnailUrl = item.thumbnailUrl,
-                    mediaType = item.type,
-                    duration = item.durationSeconds,
-                    onClick = { onItemClick(index) },
+        if (items.isEmpty()) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(
+                    text = stringResource(R.string.txt_collection_empty)
                 )
+            }
+        } else {
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(3),
+                modifier = modifier,
+                contentPadding = PaddingValues(NachoSpacing.small),
+                horizontalArrangement = Arrangement.spacedBy(NachoSpacing.twoXSmall),
+                verticalArrangement = Arrangement.spacedBy(NachoSpacing.twoXSmall),
+            ) {
+                itemsIndexed(
+                    items = items,
+                    key = { index, item -> "${item.type}_${item.id}" },
+                ) { index, item ->
+                    MediaItem(
+                        mediaUrl = item.mediaUrl,
+                        thumbnailUrl = item.thumbnailUrl,
+                        mediaType = item.type,
+                        duration = item.durationSeconds,
+                        onClick = { onItemClick(index) },
+                    )
+                }
             }
         }
     }

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/collection/NachoMediaGridView.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/collection/NachoMediaGridView.kt
@@ -25,10 +25,12 @@ import kotlinx.datetime.Clock
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import com.andlife.ui.R
+import com.andlife.ui.component.media.MediaItemSkeleton
 
 @Composable
 fun NachoMediaGridView(
     items: ImmutableList<CollectionUiModel>,
+    isLoading: Boolean,
     onItemClick: (Int) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -36,14 +38,25 @@ fun NachoMediaGridView(
         modifier = modifier,
         color = NachoTheme.colorScheme.backgroundPrimary,
     ) {
-        if (items.isEmpty()) {
+        if (isLoading) {
+            LazyVerticalGrid(
+                columns = GridCells.Fixed(3),
+                modifier = modifier,
+                contentPadding = PaddingValues(NachoSpacing.small),
+                horizontalArrangement = Arrangement.spacedBy(NachoSpacing.twoXSmall),
+                verticalArrangement = Arrangement.spacedBy(NachoSpacing.twoXSmall),
+                userScrollEnabled = false
+            ) {
+                items(9) {
+                    MediaItemSkeleton()
+                }
+            }
+        } else if (items.isEmpty()) {
             Box(
                 modifier = Modifier.fillMaxSize(),
                 contentAlignment = Alignment.Center
             ) {
-                Text(
-                    text = stringResource(R.string.txt_collection_empty)
-                )
+                Text(text = stringResource(R.string.txt_collection_empty))
             }
         } else {
             LazyVerticalGrid(
@@ -112,6 +125,19 @@ private fun NachoMediaGridViewPreview() {
     NachoTheme {
         NachoMediaGridView(
             items = mockItems,
+            isLoading = false,
+            onItemClick = {},
+        )
+    }
+}
+
+@PreviewTheme
+@Composable
+private fun NachoMediaGridViewLoadingPreview() {
+    NachoTheme {
+        NachoMediaGridView(
+            items = persistentListOf(),
+            isLoading = true,
             onItemClick = {},
         )
     }

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/collection/StoryContent.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/collection/StoryContent.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.blur
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
@@ -23,6 +24,7 @@ import androidx.media3.common.Player
 import androidx.media3.exoplayer.ExoPlayer
 import coil3.compose.AsyncImage
 import com.andlife.designsystem.preview.PreviewTheme
+import com.andlife.designsystem.theme.NachoSpacing
 import com.andlife.designsystem.theme.NachoTheme
 import com.andlife.ui.component.media.AudioPlayer
 import com.andlife.ui.component.media.VideoPlayer
@@ -88,8 +90,16 @@ fun StoryContent(
             AsyncImage(
                 model = if (item.type == UiMediaType.IMAGE) item.mediaUrl else item.thumbnailUrl,
                 contentDescription = null,
-                modifier = Modifier.fillMaxSize(),
+                modifier = Modifier.fillMaxSize().blur(NachoSpacing.xLarge),
                 contentScale = ContentScale.Crop,
+                alpha = 0.5f
+            )
+
+            AsyncImage(
+                model = if (item.type == UiMediaType.IMAGE) item.mediaUrl else item.thumbnailUrl,
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize(),
+                contentScale = ContentScale.Fit,
             )
         }
 

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/media/MediaItemSkeleton.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/media/MediaItemSkeleton.kt
@@ -1,0 +1,18 @@
+package com.andlife.ui.component.media
+
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.andlife.designsystem.theme.NachoTheme
+
+@Composable
+fun MediaItemSkeleton(
+    modifier: Modifier = Modifier
+) {
+    Surface(
+        modifier = modifier.aspectRatio(1f),
+        color = NachoTheme.colorScheme.iconDisabled,
+        shape = NachoTheme.shapes.medium
+    ){ }
+}

--- a/android/core/ui/src/main/res/values/strings.xml
+++ b/android/core/ui/src/main/res/values/strings.xml
@@ -74,6 +74,7 @@
     <string name="desc_close">닫기</string>
     <string name="txt_delete_all">모두 지우기</string>
     <string name="txt_submit">등록</string>
+    <string name="txt_collection_empty">아직 미디어가 없습니다.</string>
 
     <!-- GuestBook -->
     <string name="desc_edit_guest_book">수정을 위한 더보기 아이콘</string>

--- a/android/core/ui/src/main/res/values/strings.xml
+++ b/android/core/ui/src/main/res/values/strings.xml
@@ -45,7 +45,9 @@
     <string name="msg_refresh_failure">새로고침에 실패했습니다.</string>
 
     <string name="txt_leave_invitation_title">초대장 나가기</string>
+    <string name="txt_delete_invitation_title">초대장 삭제</string>
     <string name="txt_leave_invitation_message">초대장에서 나가시겠습니까?\n나간 후에는 초대 링크가 있어야 다시 입장할 수 있습니다.</string>
+    <string name="txt_delete_invitation_message">초대장을 삭제하시겠습니까?\n삭제한 초대장은 복구할 수 없습니다.</string>
     <string name="txt_confirm">확인</string>
     <string name="txt_cancel">취소</string>
     <string name="msg_leave_success">초대장에서 나갔습니다.</string>

--- a/android/core/ui/src/main/res/values/strings.xml
+++ b/android/core/ui/src/main/res/values/strings.xml
@@ -50,6 +50,8 @@
     <string name="txt_cancel">취소</string>
     <string name="msg_leave_success">초대장에서 나갔습니다.</string>
     <string name="msg_leave_failure">나가기에 실패했습니다. 다시 시도해주세요.</string>
+    <string name="msg_delete_success">초대장을 삭제했습니다.</string>
+    <string name="msg_delete_failure">삭제에 실패했습니다. 다시 시도해주세요.</string>
 
     <!--  모아보기 Media  -->
     <string name="desc_media_image">방명록의 이미지</string>

--- a/android/domain/src/main/kotlin/com/andlife/domain/repository/invitation/InvitationRepository.kt
+++ b/android/domain/src/main/kotlin/com/andlife/domain/repository/invitation/InvitationRepository.kt
@@ -18,6 +18,7 @@ interface InvitationRepository {
     suspend fun leaveInvitation(invitationId: Long): Result<Unit, DataError>
     suspend fun createInvitation(params: InvitationSaveParam): Result<Long, DataError>
     suspend fun updateInvitation(invitationId: Long, params: InvitationSaveParam): Result<Long, DataError>
+    suspend fun deleteInvitation(invitationId: Long): Result<Unit, DataError>
     suspend fun getInvitation(invitationId: Long): Result<Invitation, DataError>
     fun getParticipantInvitations(
         status: InvitationStatus,

--- a/android/domain/src/main/kotlin/com/andlife/domain/repository/invitation/InvitationRepository.kt
+++ b/android/domain/src/main/kotlin/com/andlife/domain/repository/invitation/InvitationRepository.kt
@@ -23,12 +23,14 @@ interface InvitationRepository {
     fun getParticipantInvitations(
         status: InvitationStatus,
         sortType: SortDirection,
-        isMyInvitation: Boolean
+        isMyInvitation: Boolean,
+        onTotalCountLoaded: (Int) -> Unit
     ): Flow<PagingData<InvitationSummary>>
     fun getMyInvitations(
         status: InvitationStatus,
         sortType: SortDirection,
-        isMyInvitation: Boolean
+        isMyInvitation: Boolean,
+        onTotalCountLoaded: (Int) -> Unit
     ): Flow<PagingData<InvitationSummary>>
     fun getUpcomingInvitations(): Flow<PagingData<UpcomingInvitation>>
     suspend fun createInvitationCard(invitationId: Long, card: NachoCard): Result<Long, DataError>

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/InvitationUiState.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/InvitationUiState.kt
@@ -4,5 +4,7 @@ import com.andlife.ui.base.BaseUiState
 
 data class InvitationUiState(
     val isRefreshing: Boolean = false,
-    val selectedTab: Int = 0
+    val selectedTab: Int = 0,
+    val upcomingTotalCount: Int = 0,
+    val pastTotalCount: Int = 0
 ) : BaseUiState

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/InvitationScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/InvitationScreen.kt
@@ -234,7 +234,7 @@ private fun InvitationScreen(
                             if (currentItems.itemCount > 0) {
                                 item {
                                     InvitationListHeader(
-                                        totalCount = currentItems.itemCount,
+                                        totalCount = if (isUpcoming) uiState.upcomingTotalCount else uiState.pastTotalCount,
                                         currentSort = currentSortOptions[currentSortIndex],
                                         sortOptions = currentSortOptions,
                                         onSortSelected = { index ->

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/InvitationScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/InvitationScreen.kt
@@ -79,11 +79,13 @@ fun InvitationRoute(
             is InvitationSideEffect.NavigateToDetail -> onNavigateToDetail(effect.id)
             is InvitationSideEffect.RefreshFailure -> {
                 scope.launch {
+                    snackbarHostState.currentSnackbarData?.dismiss()
                     snackbarHostState.showSnackbar(refreshFailureMessage)
                 }
             }
             is InvitationSideEffect.LeaveSuccess -> {
                 scope.launch {
+                    snackbarHostState.currentSnackbarData?.dismiss()
                     snackbarHostState.showSnackbar(leaveSuccessMessage)
                 }
                 upcomingItems.refresh()
@@ -91,6 +93,7 @@ fun InvitationRoute(
             }
             is InvitationSideEffect.LeaveFailure -> {
                 scope.launch {
+                    snackbarHostState.currentSnackbarData?.dismiss()
                     snackbarHostState.showSnackbar(leaveFailureMessage)
                 }
             }

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/collection/InvitationCollectionScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/collection/InvitationCollectionScreen.kt
@@ -58,6 +58,7 @@ fun InvitationCollectionScreen(
     NachoMediaGridView(
         items = uiState.mediaItems,
         onItemClick = onOpenStory,
+        isLoading = uiState.isLoading,
         modifier = modifier,
     )
 

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationCollectionViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationCollectionViewModel.kt
@@ -46,7 +46,7 @@ class InvitationCollectionViewModel @Inject constructor(
                 }.stateIn(
                     scope = viewModelScope,
                     started = SharingStarted.WhileSubscribed(5_000),
-                    initialValue = InvitationCollectionUiState(),
+                    initialValue = InvitationCollectionUiState(isLoading = true),
                 )
 
         val exoPlayer: ExoPlayer = ExoPlayer.Builder(context).build().apply {

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationViewModel.kt
@@ -44,7 +44,10 @@ class InvitationViewModel @Inject constructor(
             invitationRepository.getParticipantInvitations(
                 status = InvitationStatus.UPCOMING,
                 sortType = sort,
-                isMyInvitation = false
+                isMyInvitation = false,
+                onTotalCountLoaded = { totalCount ->
+                    updateState { copy(upcomingTotalCount = totalCount) }
+                }
             ).map { pagingData ->
                 pagingData.map { summary ->
                     summary.toUiModel { date, time ->
@@ -60,7 +63,10 @@ class InvitationViewModel @Inject constructor(
             invitationRepository.getParticipantInvitations(
                 status = InvitationStatus.PAST,
                 sortType = sort,
-                isMyInvitation = false
+                isMyInvitation = false,
+                onTotalCountLoaded = { totalCount ->
+                    updateState { copy(pastTotalCount = totalCount) }
+                }
             ).map { pagingData ->
                 pagingData.map { summary ->
                     summary.toUiModel { date, time ->

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/MyInvitationGraph.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/MyInvitationGraph.kt
@@ -1,6 +1,5 @@
 package com.andlife.myinvitation
 
-import android.util.Log
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.SnackbarHostState

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/MyInvitationGraph.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/MyInvitationGraph.kt
@@ -3,6 +3,7 @@ package com.andlife.myinvitation
 import android.util.Log
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -41,12 +42,14 @@ fun NavController.navigateToMyInvitationDetail(
 }
 
 fun NavGraphBuilder.myInvitationNavGraph(
+    snackbarHostState: SnackbarHostState,
     paddingValues: PaddingValues,
     onNavigateToCreate: () -> Unit,
     onNavigateToDetail: (Long) -> Unit,
 ) {
     composable<MyInvitation> {
         MyInvitationRoute(
+            snackbarHostState = snackbarHostState,
             onNavigateToCreate = onNavigateToCreate,
             onNavigateToDetail = onNavigateToDetail,
             modifier = Modifier.padding(paddingValues),

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/model/MyInvitationSideEffect.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/model/MyInvitationSideEffect.kt
@@ -6,4 +6,6 @@ sealed interface MyInvitationSideEffect : BaseSideEffect {
     data object NavigateToCreate : MyInvitationSideEffect
     data class NavigateToDetail(val id: Long) : MyInvitationSideEffect
     data object RefreshFailure : MyInvitationSideEffect
+    data object DeleteSuccess : MyInvitationSideEffect
+    data object DeleteFailure : MyInvitationSideEffect
 }

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/model/MyInvitationUiEvent.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/model/MyInvitationUiEvent.kt
@@ -9,4 +9,5 @@ sealed interface MyInvitationUiEvent : BaseUiEvent {
     data class ClickInvitation(val id: Long) : MyInvitationUiEvent
     data class ChangeSort(val isUpcoming: Boolean, val newSort: SortDirection) : MyInvitationUiEvent
     data object ClickCreate : MyInvitationUiEvent
+    data class ClickDeleteInvitation(val id: Long) : MyInvitationUiEvent
 }

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/model/MyInvitationUiState.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/model/MyInvitationUiState.kt
@@ -4,5 +4,7 @@ import com.andlife.ui.base.BaseUiState
 
 data class MyInvitationUiState(
     val isRefreshing: Boolean = false,
-    val selectedTab: Int = 0
+    val selectedTab: Int = 0,
+    val upcomingTotalCount: Int = 0,
+    val pastTotalCount: Int = 0
 ) : BaseUiState

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationScreen.kt
@@ -10,12 +10,15 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
@@ -45,9 +48,11 @@ import com.andlife.ui.component.loading.InvitationLoadingIndicator
 import com.andlife.ui.component.paging.PagingStateContent
 import com.andlife.ui.util.collectWithLifecycle
 import kotlinx.collections.immutable.toImmutableList
+import kotlinx.coroutines.launch
 
 @Composable
 fun MyInvitationRoute(
+    snackbarHostState: SnackbarHostState,
     onNavigateToCreate: () -> Unit,
     onNavigateToDetail: (Long) -> Unit,
     modifier: Modifier = Modifier,
@@ -56,12 +61,32 @@ fun MyInvitationRoute(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val upcomingItems = viewModel.upcomingMyInvitationPagingFlow.collectAsLazyPagingItems()
     val pastItems = viewModel.pastMyInvitationPagingFlow.collectAsLazyPagingItems()
+    val scope = rememberCoroutineScope()
+    var invitationIdToDelete by remember { mutableStateOf<Long?>(null) }
+
+    val refreshFailureMessage = stringResource(R.string.msg_refresh_failure)
+    val deleteSuccessMessage = stringResource(R.string.msg_delete_success)
+    val deleteFailureMessage = stringResource(R.string.msg_delete_failure)
 
     viewModel.effectFlow.collectWithLifecycle { effect ->
         when (effect) {
             is MyInvitationSideEffect.NavigateToDetail -> onNavigateToDetail(effect.id)
-            is MyInvitationSideEffect.RefreshFailure -> { /* TODO : 에러 스낵바 처리 */ }
+            is MyInvitationSideEffect.RefreshFailure -> {
+                scope.launch {
+                    snackbarHostState.showSnackbar(refreshFailureMessage)
+                }
+            }
             is MyInvitationSideEffect.NavigateToCreate -> onNavigateToCreate()
+            is MyInvitationSideEffect.DeleteSuccess -> {
+                scope.launch {
+                    snackbarHostState.showSnackbar(deleteSuccessMessage)
+                }
+            }
+            is MyInvitationSideEffect.DeleteFailure -> {
+                scope.launch {
+                    snackbarHostState.showSnackbar(deleteFailureMessage)
+                }
+            }
         }
     }
 

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationScreen.kt
@@ -1,9 +1,13 @@
 package com.andlife.myinvitation.screen
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -11,6 +15,8 @@ import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -30,6 +36,7 @@ import androidx.paging.LoadState
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemKey
+import com.andlife.designsystem.component.dialog.NachoDialog
 import com.andlife.designsystem.R as designR
 import com.andlife.designsystem.theme.NachoSpacing
 import com.andlife.designsystem.theme.NachoTheme
@@ -44,9 +51,11 @@ import com.andlife.ui.component.GenericTabRow
 import com.andlife.ui.component.invitation.InvitationListHeader
 import com.andlife.ui.component.invitation.InvitationTopBar
 import com.andlife.ui.component.listitem.InvitationListItem
+import com.andlife.ui.component.listitem.MenuItem
 import com.andlife.ui.component.loading.InvitationLoadingIndicator
 import com.andlife.ui.component.paging.PagingStateContent
 import com.andlife.ui.util.collectWithLifecycle
+import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
 
@@ -81,6 +90,8 @@ fun MyInvitationRoute(
                 scope.launch {
                     snackbarHostState.showSnackbar(deleteSuccessMessage)
                 }
+                upcomingItems.refresh()
+                pastItems.refresh()
             }
             is MyInvitationSideEffect.DeleteFailure -> {
                 scope.launch {
@@ -102,12 +113,68 @@ fun MyInvitationRoute(
         }
     }
 
+    invitationIdToDelete?.let { id ->
+        NachoDialog(
+            onDismiss = { invitationIdToDelete = null }
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(NachoSpacing.xLarge)
+            ) {
+                Text(
+                    text = stringResource(R.string.txt_delete_invitation_title),
+                    style = NachoTheme.typography.headingSmallSemiBold,
+                    color = NachoTheme.colorScheme.textPrimary
+                )
+
+                Text(
+                    text = stringResource(R.string.txt_delete_invitation_message),
+                    modifier = Modifier.padding(top = NachoSpacing.medium, bottom = NachoSpacing.xLarge),
+                    style = NachoTheme.typography.bodyMediumMedium,
+                    color = NachoTheme.colorScheme.textSecondary
+                )
+
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = androidx.compose.ui.Alignment.CenterVertically
+                ) {
+                    TextButton(
+                        onClick = { invitationIdToDelete = null }
+                    ) {
+                        Text(
+                            text = stringResource(R.string.txt_cancel),
+                            color = NachoTheme.colorScheme.textSecondary
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.padding(horizontal = NachoSpacing.small))
+
+                    TextButton(
+                        onClick = {
+                            viewModel.deleteInvitation(id)
+                            invitationIdToDelete = null
+                        },
+                        shape = NachoTheme.shapes.small
+                    ) {
+                        Text(
+                            text = stringResource(R.string.txt_confirm),
+                            color = NachoTheme.colorScheme.brandPrimary
+                        )
+                    }
+                }
+            }
+        }
+    }
+
     MyInvitationScreen(
         uiState = uiState,
         upcomingItems = upcomingItems,
         pastItems = pastItems,
         modifier = modifier,
         onEvent = viewModel::onEvent,
+        onDeleteClick = { invitationIdToDelete = it }
     )
 }
 
@@ -117,8 +184,9 @@ private fun MyInvitationScreen(
     uiState: MyInvitationUiState,
     upcomingItems: LazyPagingItems<InvitationSummaryUiModel>,
     pastItems: LazyPagingItems<InvitationSummaryUiModel>,
+    onEvent: (MyInvitationUiEvent) -> Unit,
+    onDeleteClick: (Long) -> Unit,
     modifier: Modifier = Modifier,
-    onEvent: (MyInvitationUiEvent) -> Unit
 ) {
     val tabs = stringArrayResource(R.array.arr_invitation_tabs).toImmutableList()
     val upcomingSortOptions = stringArrayResource(R.array.arr_invitation_sort_options).toImmutableList()
@@ -227,6 +295,12 @@ private fun MyInvitationScreen(
                                         address = invitation.address,
                                         dDayText = dDayLabel,
                                         onClick = { onEvent(MyInvitationUiEvent.ClickInvitation(invitation.id)) },
+                                        menuItems = persistentListOf(
+                                            MenuItem(
+                                                title = stringResource(R.string.txt_delete_invitation_title),
+                                                onClick = { onDeleteClick(invitation.id) }
+                                            )
+                                        )
                                     )
                                 }
                             }

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationScreen.kt
@@ -251,7 +251,7 @@ private fun MyInvitationScreen(
                             if (currentItems.itemCount > 0) {
                                 item {
                                     InvitationListHeader(
-                                        totalCount = currentItems.itemCount,
+                                        totalCount = if (isUpcoming) uiState.upcomingTotalCount else uiState.pastTotalCount,
                                         currentSort = currentSortOptions[currentSortIndex],
                                         sortOptions = currentSortOptions,
                                         onSortSelected = { index ->

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationScreen.kt
@@ -82,12 +82,14 @@ fun MyInvitationRoute(
             is MyInvitationSideEffect.NavigateToDetail -> onNavigateToDetail(effect.id)
             is MyInvitationSideEffect.RefreshFailure -> {
                 scope.launch {
+                    snackbarHostState.currentSnackbarData?.dismiss()
                     snackbarHostState.showSnackbar(refreshFailureMessage)
                 }
             }
             is MyInvitationSideEffect.NavigateToCreate -> onNavigateToCreate()
             is MyInvitationSideEffect.DeleteSuccess -> {
                 scope.launch {
+                    snackbarHostState.currentSnackbarData?.dismiss()
                     snackbarHostState.showSnackbar(deleteSuccessMessage)
                 }
                 upcomingItems.refresh()
@@ -95,6 +97,7 @@ fun MyInvitationRoute(
             }
             is MyInvitationSideEffect.DeleteFailure -> {
                 scope.launch {
+                    snackbarHostState.currentSnackbarData?.dismiss()
                     snackbarHostState.showSnackbar(deleteFailureMessage)
                 }
             }

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/collection/MyInvitationCollectionScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/collection/MyInvitationCollectionScreen.kt
@@ -58,6 +58,7 @@ fun MyInvitationCollectionScreen(
     NachoMediaGridView(
         items = uiState.mediaItems,
         onItemClick = onOpenStory,
+        isLoading = uiState.isLoading,
         modifier = modifier,
     )
 

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationCollectionViewModel.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationCollectionViewModel.kt
@@ -47,7 +47,7 @@ class MyInvitationCollectionViewModel
             }.stateIn(
                 scope = viewModelScope,
                 started = SharingStarted.WhileSubscribed(5_000),
-                initialValue = MyInvitationCollectionUiState(),
+                initialValue = MyInvitationCollectionUiState(isLoading = true),
             )
 
     val exoPlayer: ExoPlayer = ExoPlayer.Builder(context).build().apply {

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationViewModel.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationViewModel.kt
@@ -7,6 +7,8 @@ import androidx.paging.map
 import com.andlife.domain.model.invitation.InvitationStatus
 import com.andlife.domain.model.invitation.SortDirection
 import com.andlife.domain.repository.invitation.InvitationRepository
+import com.andlife.domain.util.onFailure
+import com.andlife.domain.util.onSuccess
 import com.andlife.model.invitation.InvitationSummaryUiModel
 import com.andlife.model.invitation.toUiModel
 import com.andlife.myinvitation.model.MyInvitationSideEffect
@@ -22,6 +24,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDateTime
 import javax.inject.Inject
 
@@ -95,6 +98,9 @@ class MyInvitationViewModel @Inject constructor(
             is MyInvitationUiEvent.ClickCreate -> {
                 sendEffect(MyInvitationSideEffect.NavigateToCreate)
             }
+            is MyInvitationUiEvent.ClickDeleteInvitation -> {
+                deleteInvitation(event.id)
+            }
         }
     }
 
@@ -103,4 +109,15 @@ class MyInvitationViewModel @Inject constructor(
         if (hasError) sendEffect(MyInvitationSideEffect.RefreshFailure)
     }
 
+    fun deleteInvitation(invitationId: Long) {
+        viewModelScope.launch {
+            invitationRepository.deleteInvitation(invitationId)
+                .onSuccess {
+                    sendEffect(MyInvitationSideEffect.DeleteSuccess)
+                }
+                .onFailure { it, msg ->
+                    sendEffect(MyInvitationSideEffect.DeleteFailure)
+                }
+        }
+    }
 }

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationViewModel.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationViewModel.kt
@@ -111,6 +111,7 @@ class MyInvitationViewModel @Inject constructor(
 
     fun deleteInvitation(invitationId: Long) {
         viewModelScope.launch {
+            updateState { copy(isRefreshing = true) }
             invitationRepository.deleteInvitation(invitationId)
                 .onSuccess {
                     sendEffect(MyInvitationSideEffect.DeleteSuccess)
@@ -118,6 +119,7 @@ class MyInvitationViewModel @Inject constructor(
                 .onFailure { it, msg ->
                     sendEffect(MyInvitationSideEffect.DeleteFailure)
                 }
+            updateState { copy(isRefreshing = false) }
         }
     }
 }

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationViewModel.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationViewModel.kt
@@ -43,7 +43,10 @@ class MyInvitationViewModel @Inject constructor(
             invitationRepository.getMyInvitations(
                 status = InvitationStatus.UPCOMING,
                 sortType = sort,
-                isMyInvitation = true
+                isMyInvitation = true,
+                onTotalCountLoaded = { totalCount ->
+                    updateState { copy(upcomingTotalCount = totalCount) }
+                }
             ).map { pagingData ->
                 pagingData.map { summary ->
                     summary.toUiModel { date, time ->
@@ -59,7 +62,10 @@ class MyInvitationViewModel @Inject constructor(
             invitationRepository.getMyInvitations(
                 status = InvitationStatus.PAST,
                 sortType = sort,
-                isMyInvitation = true
+                isMyInvitation = true,
+                onTotalCountLoaded = { totalCount ->
+                    updateState { copy(pastTotalCount = totalCount) }
+                }
             ).map { pagingData ->
                 pagingData.map { summary ->
                     summary.toUiModel { date, time ->

--- a/backend/src/main/kotlin/com/andlife/nachoserver/controller/invitation/InvitationController.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/controller/invitation/InvitationController.kt
@@ -19,6 +19,7 @@ import com.andlife.nachoserver.service.guestbook.GuestBookService
 import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import org.springframework.data.web.PageableDefault
+import org.springframework.web.bind.annotation.DeleteMapping
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
@@ -256,6 +257,22 @@ class InvitationController(
         } catch (e: Exception) {
             println(e.message)
             BaseResponse.error(responseCode = CommonResponseCode.INTERNAL_SERVER_ERROR)
+        }
+    }
+
+    @DeleteMapping("/{invitationId}")
+    fun deleteInvitation(
+        @PathVariable invitationId: Long,
+        authContext: AuthContext
+    ): BaseResponse<Unit> {
+        return when (authContext) {
+            is AuthContext.Member -> {
+                invitationService.deleteInvitation(invitationId, authContext.userId)
+                BaseResponse.success(Unit)
+            }
+            is AuthContext.Guest -> {
+                BaseResponse.error(CommonResponseCode.FORBIDDEN)
+            }
         }
     }
 

--- a/backend/src/main/kotlin/com/andlife/nachoserver/repository/guestbook/GuestBookRepository.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/repository/guestbook/GuestBookRepository.kt
@@ -37,6 +37,9 @@ interface GuestBookRepository : JpaRepository<GuestBook, Long> {
             ORDER BY gb.createdAt DESC
         """
     )
+
+    fun findAllByInvitationId(invitationId: Long): List<GuestBook>
+
     fun findAllByMyRelatedInvitations(
         @Param("userId") userId: Long,
         pageable: Pageable

--- a/backend/src/main/kotlin/com/andlife/nachoserver/repository/guestbook/GuestBookRepository.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/repository/guestbook/GuestBookRepository.kt
@@ -26,8 +26,9 @@ interface GuestBookRepository : JpaRepository<GuestBook, Long> {
     )
     fun findAllByInvitationId(invitationId: Long, pageable: Pageable): Page<GuestBook>
 
-    @Query(
-        """
+    fun findAllByInvitationId(invitationId: Long): List<GuestBook>
+
+    @Query("""
             SELECT DISTINCT gb FROM GuestBook gb
             JOIN FETCH gb.user u
             JOIN FETCH gb.invitation i
@@ -35,11 +36,7 @@ interface GuestBookRepository : JpaRepository<GuestBook, Long> {
             LEFT JOIN InvitationParticipant ip ON i.id = ip.invitation.id
             WHERE (h.id = :userId OR ip.user.id = :userId)
             ORDER BY gb.createdAt DESC
-        """
-    )
-
-    fun findAllByInvitationId(invitationId: Long): List<GuestBook>
-
+    """)
     fun findAllByMyRelatedInvitations(
         @Param("userId") userId: Long,
         pageable: Pageable

--- a/backend/src/main/kotlin/com/andlife/nachoserver/repository/invitation/InvitationCardRepository.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/repository/invitation/InvitationCardRepository.kt
@@ -1,7 +1,9 @@
 package com.andlife.nachoserver.repository.invitation
 
 import com.andlife.nachoserver.entity.InvitationCard
+import jakarta.transaction.Transactional
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 
@@ -12,4 +14,9 @@ interface InvitationCardRepository : JpaRepository<InvitationCard, Long> {
         WHERE ic.invitation.id = :invitationId
     """)
     fun findByInvitationIdWithDetails(@Param("invitationId") invitationId: Long): InvitationCard?
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM InvitationCard ic WHERE ic.invitation.id = :invitationId")
+    fun deleteByInvitationId(@Param("invitationId") invitationId: Long)
 }

--- a/backend/src/main/kotlin/com/andlife/nachoserver/repository/invitation/InvitationRepository.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/repository/invitation/InvitationRepository.kt
@@ -56,4 +56,6 @@ interface InvitationRepository : JpaRepository<Invitation, Long> {
         @Param("limitDate") limitDate: LocalDate,
         pageable: Pageable
     ): Page<Invitation>
+
+    fun findByIdAndHostId(id: Long, hostId: Long): Invitation?
 }

--- a/backend/src/main/kotlin/com/andlife/nachoserver/repository/participant/InvitationParticipantRepository.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/repository/participant/InvitationParticipantRepository.kt
@@ -1,9 +1,11 @@
 package com.andlife.nachoserver.repository.participant
 
 import com.andlife.nachoserver.entity.InvitationParticipant
+import jakarta.transaction.Transactional
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.query.Param
 import java.time.LocalDate
@@ -71,4 +73,9 @@ interface InvitationParticipantRepository : JpaRepository<InvitationParticipant,
         @Param("userId") userId: Long,
         @Param("invitationId") invitationId: Long
     ): InvitationParticipant?
+
+    @Modifying
+    @Transactional
+    @Query("DELETE FROM InvitationParticipant p WHERE p.invitation.id = :invitationId")
+    fun deleteAllByInvitationId(@Param("invitationId") invitationId: Long)
 }

--- a/backend/src/main/kotlin/com/andlife/nachoserver/service/guestbook/GuestBookService.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/service/guestbook/GuestBookService.kt
@@ -324,6 +324,18 @@ class GuestBookService(
         }
     }
 
+    @Transactional
+    fun deleteAllByInvitation(invitationId: Long) {
+        val guestBooks = guestBookRepository.findAllByInvitationId(invitationId)
+        val allMediaKeys = guestBooks.flatMap { getAllMediaKeys(it) }
+        guestBookRepository.deleteAll(guestBooks)
+        allMediaKeys.forEach { key ->
+            if (key.isNotBlank()) {
+                mediaService.deleteMedia(key)
+            }
+        }
+    }
+
     private fun validateOwner(guestBookUserId: Long, authContext: AuthContext) {
         when (authContext) {
             is AuthContext.Member -> {

--- a/backend/src/main/kotlin/com/andlife/nachoserver/service/invitation/InvitationService.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/service/invitation/InvitationService.kt
@@ -27,6 +27,7 @@ import org.springframework.data.domain.Pageable
 import org.springframework.data.domain.Sort
 import com.andlife.nachoserver.response.invitation.UpcomingInvitationResponse
 import com.andlife.nachoserver.response.invitation.toInvitationResponse
+import com.andlife.nachoserver.service.guestbook.GuestBookService
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate
@@ -42,7 +43,8 @@ class InvitationService(
     private val announcementRepository: AnnouncementRepository,
     private val participantRepository: InvitationParticipantRepository,
     private val userRepository: UserRepository,
-    private val guestBookRepository: GuestBookRepository
+    private val guestBookRepository: GuestBookRepository,
+    private val guestBookService: GuestBookService
 ) {
     @Transactional
     fun joinInvitation(
@@ -213,17 +215,10 @@ class InvitationService(
             ?: throw NoSuchElementException("삭제 권한이 없거나 초대장을 찾을 수 없습니다. ID: $invitationId")
 
         // 연관된 데이터 삭제
-        val guestBooks = guestBookRepository.findAllByInvitationId(invitationId)
-        guestBookRepository.deleteAll(guestBooks)
-
+        guestBookService.deleteAllByInvitation(invitationId)
         announcementRepository.deleteAllByInvitationId(invitationId)
         invitationCardRepository.deleteByInvitationId(invitationId)
         participantRepository.deleteAllByInvitationId(invitationId)
-
-        /**
-         * Todo
-         * - R2에 업로드 된 미디어 삭제 로직
-         */
 
         invitationRepository.delete(invitation)
     }

--- a/backend/src/main/kotlin/com/andlife/nachoserver/service/invitation/InvitationService.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/service/invitation/InvitationService.kt
@@ -6,6 +6,7 @@ import com.andlife.nachoserver.entity.Invitation
 import com.andlife.nachoserver.entity.InvitationCard
 import com.andlife.nachoserver.entity.User
 import com.andlife.nachoserver.entity.InvitationParticipant
+import com.andlife.nachoserver.repository.guestbook.GuestBookRepository
 import com.andlife.nachoserver.repository.invitation.AnnouncementRepository
 import com.andlife.nachoserver.repository.invitation.InvitationCardRepository
 import com.andlife.nachoserver.repository.invitation.InvitationRepository
@@ -17,8 +18,6 @@ import com.andlife.nachoserver.request.invitation.InvitationCardRequest
 import com.andlife.nachoserver.request.invitation.UpdateInvitationRequest
 import com.andlife.nachoserver.response.PagingMetaResponse
 import com.andlife.nachoserver.response.PagingResponse
-import com.andlife.nachoserver.response.invitation.AnnouncementResponse
-import com.andlife.nachoserver.response.invitation.InvitationCardResponse
 import com.andlife.nachoserver.response.invitation.InvitationResponse
 import com.andlife.nachoserver.response.invitation.InvitationSummaryResponse
 import com.andlife.nachoserver.response.invitation.JoinResponse
@@ -42,7 +41,8 @@ class InvitationService(
     private val invitationCardRepository: InvitationCardRepository,
     private val announcementRepository: AnnouncementRepository,
     private val participantRepository: InvitationParticipantRepository,
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val guestBookRepository: GuestBookRepository
 ) {
     @Transactional
     fun joinInvitation(
@@ -205,6 +205,27 @@ class InvitationService(
         card.backgroundImageUrl = request.backgroundImageUrl
 
         return invitationCardRepository.save(card).id
+    }
+
+    @Transactional
+    fun deleteInvitation(invitationId: Long, userId: Long) {
+        val invitation = invitationRepository.findByIdAndHostId(invitationId, userId)
+            ?: throw NoSuchElementException("삭제 권한이 없거나 초대장을 찾을 수 없습니다. ID: $invitationId")
+
+        // 연관된 데이터 삭제
+        val guestBooks = guestBookRepository.findAllByInvitationId(invitationId)
+        guestBookRepository.deleteAll(guestBooks)
+
+        announcementRepository.deleteAllByInvitationId(invitationId)
+        invitationCardRepository.deleteByInvitationId(invitationId)
+        participantRepository.deleteAllByInvitationId(invitationId)
+
+        /**
+         * Todo
+         * - R2에 업로드 된 미디어 삭제 로직
+         */
+
+        invitationRepository.delete(invitation)
     }
 
     fun getInvitation(invitationId: Long): InvitationResponse {


### PR DESCRIPTION
## 🔍 변경 사항
> 이번 PR에서 변경된 핵심 내용을 간단히 설명해주세요.

- 나의 초대 탭 초대장 삭제 기능 구현
- 모아보기 화면 이미지 짤림 문제 해결
- 모아보기 화면 데이터가 없을 경우 스켈레톤 UI로 대응
- 초대장 탭, 나의 초대 탭 리스트 카운트를 Total Count로 사용하도록 변경
  - 기존에는 total count가 아닌 현재 아이템의 count를 사용하고 있어, 서버에서 내려주는 페이징 메타 정보의 total count를 사용하는 형태로 수정했습니다.

## 📸 스크린샷 (선택)
> UI 변경 사항이 있다면 이미지를 첨부해주세요.

### 기존(스켈레톤 X) 

https://github.com/user-attachments/assets/0ed44845-c369-474a-944d-cf6bed83d880


데이터가 없을 때, 있을 때를 조건 분기 처리로 대응을 했더니,
위처럼 데이터가 없다는 UI가 먼저 나왔다가 데이터가 반영되는 문제가 있었습니다.

그래서 `NachoMediaGridView`에서 `isLoading` 값을 인자로 전달 받아
로딩 UI를 따로 배치하여 처리했습니다.

이 경우에서도 데이터가 있을 때,
데이터 없음 → 로딩 UI → GridView 형태로 변하는 문제가 있었는데
Ui State의 초기값이 false다 보니, false가 먼저 전달 됐다가
데이터 로드 함수가 호출 됐을 때 true가 전달 되는 것으로 판단을 했고
데이터를 불러오기 전에 미리 초기 UI 상태를 로딩으로 처리하도록 대응했습니다.

```Kotlin
override val uiState: StateFlow<InvitationCollectionUiState> =
  mutableUiState
      .onStart {
          loadMediaCollection()
      }.stateIn(
          scope = viewModelScope,
          started = SharingStarted.WhileSubscribed(5_000),
          initialValue = InvitationCollectionUiState(isLoading = true), // 초기값에 로딩 상태를 미리 넣어둠
      )
```

### 개선(스켈레톤 UI 적용)

https://github.com/user-attachments/assets/a28103c7-50f2-4716-a247-fdb328313262

### 초대장 삭제 기능

https://github.com/user-attachments/assets/51bf8519-9a7b-4689-935d-94613dddcf43

초대장이 삭제될 때 가지고 있는 참가자, 카드, 방명록, 공지사항도 같이 삭제되도록 처리를 했습니다.
여기서 R2에 업로드된 미디어들도 같이 삭제하게 구현을 하고 싶었는데,
정우님이 GuestBookService에 구현을 해놓으셔서
참고하여 작성했는데, 적절하게 처리 됐는지 검토해주시면 감사하겠습니다.

### 스토리 화면 이미지 짤림 문제

https://github.com/user-attachments/assets/63f9ed16-0659-4f81-91e6-676f90504917

이미지를 Fit으로만 변경할 경우
배경 화면이 너무 비는 것 같아
뒷 배경에 이미지를 Crop으로 채워놓고 블러 처리를 한 후
앞에 이미지를 Fit으로 사용하는 형태로 구현을 했습니다.

결국 두 장의 이미지를 사용하는 형태라
다른 의견이 있으시다면 참고하여 수정하도록 하겠습니다.

## 🔗 관련 이슈
> 해당 PR과 연결된 이슈 번호를 적어주세요. (예: #1)

- #125 

## ✅ 체크리스트
- [x] 팀 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 import는 삭제했나요?
