### PR TITLE
Feature/#133 비로그인 유저 초대장 리스트, 다가오는 초대 API 구현

### DIFF
--- a/android/core/data/src/main/kotlin/com/andlife/data/repository/invitation/InvitationRepositoryImpl.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/repository/invitation/InvitationRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.andlife.data.repository.invitation
 
+import android.util.Log
 import androidx.paging.Pager
 import androidx.paging.PagingConfig
 import androidx.paging.PagingData
@@ -36,6 +37,7 @@ internal class InvitationRepositoryImpl @Inject constructor(
             dto.toDomain().also { domainModel ->
                 if (!domainModel.isMember) {
                     userStorage.addInvitationId(domainModel.invitationId)
+                    Log.d("InvitationRepositoryImpl", "참여 성공: ${domainModel.invitationId}")
                 }
             }
         }

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/paging/PagingStateContent.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/paging/PagingStateContent.kt
@@ -2,6 +2,8 @@ package com.andlife.ui.component.paging
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -35,7 +37,9 @@ fun PagingStateContent(
             is LoadState.NotLoading -> {
                 if (itemCount == 0) {
                     Box(
-                        modifier = Modifier.fillMaxSize(),
+                        modifier = Modifier
+                            .fillMaxSize()
+                            .verticalScroll(rememberScrollState()),
                         contentAlignment = Alignment.Center,
                     ) {
                         Text(text = stringResource(R.string.label_paging_empty_result))

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/InvitationNavGraph.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/InvitationNavGraph.kt
@@ -3,7 +3,9 @@ package com.andlife.invitation
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavDeepLink
 import androidx.navigation.NavGraphBuilder
@@ -11,6 +13,8 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import com.andlife.invitation.screen.InvitationRoute
 import com.andlife.invitation.screen.detail.InvitationDetailRoute
+import com.andlife.invitation.viewmodel.InvitationDetailViewModel
+import com.andlife.invitation.viewmodel.InvitationViewModel
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.serialization.Serializable
 
@@ -39,11 +43,24 @@ fun NavGraphBuilder.invitationNavGraph(
     onNavigateToDetail: (Long) -> Unit,
     snackbarHostState: SnackbarHostState,
 ) {
-    composable<Invitation> {
+    composable<Invitation> { backStackEntry ->
+        val viewModel: InvitationViewModel = hiltViewModel()
+
+        val savedStateHandle = backStackEntry.savedStateHandle
+        val shouldRefresh = savedStateHandle.get<Boolean>(InvitationDetailViewModel.KEY_SHOULD_REFRESH) ?: false
+
+        LaunchedEffect(shouldRefresh) {
+            if (shouldRefresh) {
+                viewModel.handleDeepLinkRefresh()
+                savedStateHandle[InvitationDetailViewModel.KEY_SHOULD_REFRESH] = false
+            }
+        }
+
         InvitationRoute(
             onNavigateToDetail = onNavigateToDetail,
             modifier = Modifier.padding(paddingValues),
-            snackbarHostState = snackbarHostState
+            snackbarHostState = snackbarHostState,
+            viewModel = viewModel
         )
     }
 }

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/InvitationSideEffect.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/model/InvitationSideEffect.kt
@@ -7,4 +7,5 @@ sealed interface InvitationSideEffect : BaseSideEffect {
     data object RefreshFailure : InvitationSideEffect
     data object LeaveSuccess : InvitationSideEffect
     data object LeaveFailure : InvitationSideEffect
+    data object RefreshFromDeepLink : InvitationSideEffect
 }

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/InvitationScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/InvitationScreen.kt
@@ -97,6 +97,10 @@ fun InvitationRoute(
                     snackbarHostState.showSnackbar(leaveFailureMessage)
                 }
             }
+            is InvitationSideEffect.RefreshFromDeepLink -> {
+                upcomingItems.refresh()
+                pastItems.refresh()
+            }
         }
     }
 

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationDetailViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationDetailViewModel.kt
@@ -34,6 +34,7 @@ class InvitationDetailViewModel @Inject constructor(
     private val invitationId: Long = route.id
 
     private val isFromDeepLink: Boolean = route.isFromDeepLink
+    private val savedState = savedStateHandle
 
     override val uiState: StateFlow<InvitationDetailUiState> =
         mutableUiState
@@ -96,6 +97,9 @@ class InvitationDetailViewModel @Inject constructor(
     }
 
     private fun clickClose() {
+        if (isFromDeepLink) {
+            savedState[KEY_SHOULD_REFRESH] = true
+        }
         sendEffect(InvitationDetailSideEffect.NavigateBack)
     }
 
@@ -117,6 +121,10 @@ class InvitationDetailViewModel @Inject constructor(
         viewModelScope.launch {
             loadInvitation()
         }
+    }
+
+    companion object {
+        const val KEY_SHOULD_REFRESH = "should_refresh"
     }
 
 }

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationViewModel.kt
@@ -130,4 +130,8 @@ class InvitationViewModel @Inject constructor(
         if (hasError) sendEffect(InvitationSideEffect.RefreshFailure)
     }
 
+    fun handleDeepLinkRefresh() {
+        sendEffect(InvitationSideEffect.RefreshFromDeepLink)
+    }
+
 }

--- a/backend/src/main/kotlin/com/andlife/nachoserver/controller/invitation/InvitationController.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/controller/invitation/InvitationController.kt
@@ -68,16 +68,28 @@ class InvitationController(
         @RequestParam(required = false, defaultValue = "ASC") sortType: String,
         @PageableDefault(size = 10) pageable: Pageable
     ): BaseResponse<PagingResponse<InvitationSummaryResponse>> {
-        return when (authContext) {
+        val result = when (authContext) {
             is AuthContext.Member -> {
-                val result = invitationService.getParticipantInvitations(authContext.userId, status, sortType, pageable)
-                BaseResponse.success(result)
+                invitationService.getParticipantInvitations(
+                    userId = authContext.userId,
+                    guestInvitationIds = emptyList(),
+                    status = status,
+                    sortType = sortType,
+                    pageable = pageable
+                )
             }
             is AuthContext.Guest -> {
-                val result = invitationService.getParticipantInvitations(2L, status, sortType, pageable)
-                BaseResponse.success(result)
+                println(">>> [게스트 진입] 초대장 목록: ${authContext.invitationIds}")
+                invitationService.getParticipantInvitations(
+                    userId = null,
+                    guestInvitationIds = authContext.invitationIds,
+                    status = status,
+                    sortType = sortType,
+                    pageable = pageable
+                )
             }
         }
+        return BaseResponse.success(result)
     }
 
     @PostMapping("/{invitationId}/leave")

--- a/backend/src/main/kotlin/com/andlife/nachoserver/repository/invitation/InvitationRepository.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/repository/invitation/InvitationRepository.kt
@@ -39,21 +39,32 @@ interface InvitationRepository : JpaRepository<Invitation, Long> {
     """)
     fun findPastByHostId(hostId: Long, nowDate: LocalDate, nowTime: LocalTime, pageable: Pageable): Page<Invitation>
 
-    @Query(
-        """
-            SELECT DISTINCT i FROM Invitation i
-            JOIN FETCH i.host
-            LEFT JOIN InvitationParticipant ip ON i.id = ip.invitation.id
-            WHERE (i.host.id = :userId OR ip.user.id = :userId)
-            AND i.invitationDate >= :today 
-            AND i.invitationDate <= :limitDate
-            ORDER BY i.invitationDate ASC, i.startTime ASC
-        """
-    )
-    fun findUpcomingInvitationsWithinDays(
+    @Query("""
+        SELECT DISTINCT i FROM Invitation i
+        JOIN FETCH i.host
+        LEFT JOIN InvitationParticipant ip ON i.id = ip.invitation.id
+        WHERE (i.host.id = :userId OR ip.user.id = :userId)
+        AND i.invitationDate BETWEEN :startDate AND :endDate
+        ORDER BY i.invitationDate ASC, i.startTime ASC
+    """)
+    fun findUpcomingByParticipantIdWithinDays(
         @Param("userId") userId: Long,
-        @Param("today") today: LocalDate,
-        @Param("limitDate") limitDate: LocalDate,
+        @Param("startDate") startDate: LocalDate,
+        @Param("endDate") endDate: LocalDate,
+        pageable: Pageable
+    ): Page<Invitation>
+
+    @Query("""
+        SELECT i FROM Invitation i
+        JOIN FETCH i.host
+        WHERE i.id IN :ids
+        AND i.invitationDate BETWEEN :startDate AND :endDate
+        ORDER BY i.invitationDate ASC, i.startTime ASC
+    """)
+    fun findAllByIdInAndDateRange(
+        @Param("ids") ids: List<Long>,
+        @Param("startDate") startDate: LocalDate,
+        @Param("endDate") endDate: LocalDate,
         pageable: Pageable
     ): Page<Invitation>
 

--- a/backend/src/main/kotlin/com/andlife/nachoserver/repository/invitation/InvitationRepository.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/repository/invitation/InvitationRepository.kt
@@ -58,4 +58,21 @@ interface InvitationRepository : JpaRepository<Invitation, Long> {
     ): Page<Invitation>
 
     fun findByIdAndHostId(id: Long, hostId: Long): Invitation?
+
+    @Query("""
+        SELECT i FROM Invitation i 
+        WHERE i.id IN :ids 
+        AND (
+            (:status = 'UPCOMING' AND (i.invitationDate > CURRENT_DATE OR (i.invitationDate = CURRENT_DATE AND i.startTime >= CURRENT_TIME)))
+            OR 
+            (:status = 'PAST' AND (i.invitationDate < CURRENT_DATE OR (i.invitationDate = CURRENT_DATE AND i.startTime < CURRENT_TIME)))
+            OR
+            (:status = 'ALL')
+        )
+    """)
+    fun findAllByIdInWithStatus(
+        @Param("ids") ids: List<Long>,
+        @Param("status") status: String,
+        pageable: Pageable
+    ): Page<Invitation>
 }

--- a/backend/src/main/kotlin/com/andlife/nachoserver/response/PageResponse.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/response/PageResponse.kt
@@ -3,7 +3,19 @@ package com.andlife.nachoserver.response
 data class PagingResponse<T>(
     val meta: PagingMetaResponse,
     val content: List<T>
-)
+) {
+    companion object {
+        fun <T> empty(): PagingResponse<T> = PagingResponse(
+            meta = PagingMetaResponse(
+                isEnd = true,
+                pageableCount = 0,
+                totalCount = 0,
+                currentPage = 0
+            ),
+            content = emptyList()
+        )
+    }
+}
 
 data class PagingMetaResponse(
     val isEnd: Boolean,

--- a/backend/src/main/kotlin/com/andlife/nachoserver/service/invitation/InvitationService.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/service/invitation/InvitationService.kt
@@ -378,53 +378,56 @@ class InvitationService(
         days: Long,
         pageable: Pageable
     ): PagingResponse<UpcomingInvitationResponse> {
-
         val today = LocalDate.now()
         val limitDate = today.plusDays(days)
 
-        val currentUserId = (authContext as? AuthContext.Member)?.userId
-
-        val upcomingInvitationsPage = when (authContext) {
+        val upcomingInvitationsPage: Page<Invitation> = when (authContext) {
             is AuthContext.Member -> {
-                invitationRepository.findUpcomingInvitationsWithinDays(
+                invitationRepository.findUpcomingByParticipantIdWithinDays(
                     userId = authContext.userId,
-                    today = today,
-                    limitDate = limitDate,
+                    startDate = today,
+                    endDate = limitDate,
                     pageable = pageable
                 )
             }
             is AuthContext.Guest -> {
-                Page.empty(pageable) //TODO: 비로그인 유저 임시 빈값 조회
+                if (authContext.invitationIds.isEmpty()) {
+                    Page.empty(pageable)
+                } else {
+                    invitationRepository.findAllByIdInAndDateRange(
+                        ids = authContext.invitationIds,
+                        startDate = today,
+                        endDate = limitDate,
+                        pageable = pageable
+                    )
+                }
             }
         }
 
-        val responsePage = upcomingInvitationsPage.map { invitation ->
-            try {
-                UpcomingInvitationResponse(
-                    id = invitation.id,
-                    hostId = invitation.host.id,
-                    isOwner = invitation.host.id == currentUserId,
-                    title = invitation.title,
-                    thumbnailUrl = invitation.thumbnailUrls.firstOrNull(),
-                    invitationDate = invitation.invitationDate.toString(),
-                    startTime = invitation.startTime.toString(),
-                    displayHostName = invitation.displayHostName,
-                    hostProfileUrl = invitation.host.profileImageUrl,
-                )
-            } catch (e: Exception) {
-                println("ERROR: Mapping failed for Invitation ID ${invitation.id}: ${e.message}")
-                throw e
-            }
+        val currentUserId = (authContext as? AuthContext.Member)?.userId
+
+        val contents = upcomingInvitationsPage.content.map { invitation ->
+            UpcomingInvitationResponse(
+                id = invitation.id,
+                hostId = invitation.host.id,
+                isOwner = invitation.host.id == currentUserId,
+                title = invitation.title,
+                thumbnailUrl = invitation.thumbnailUrls.firstOrNull(),
+                invitationDate = invitation.invitationDate.toString(),
+                startTime = invitation.startTime.toString(),
+                displayHostName = invitation.displayHostName,
+                hostProfileUrl = invitation.host.profileImageUrl,
+            )
         }
 
         return PagingResponse(
             meta = PagingMetaResponse(
-                isEnd = !responsePage.hasNext(),
-                pageableCount = responsePage.numberOfElements,
-                totalCount = responsePage.totalElements,
-                currentPage = responsePage.number + 1
+                isEnd = upcomingInvitationsPage.isLast,
+                pageableCount = upcomingInvitationsPage.numberOfElements,
+                totalCount = upcomingInvitationsPage.totalElements,
+                currentPage = upcomingInvitationsPage.number
             ),
-            content = responsePage.content
+            content = contents
         )
     }
 }

--- a/backend/src/main/kotlin/com/andlife/nachoserver/service/invitation/InvitationService.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/service/invitation/InvitationService.kt
@@ -52,22 +52,34 @@ class InvitationService(
         userId: Long?,
         guestInvitationIds: List<Long>
     ): JoinResponse {
-        val invitation = invitationRepository.findById(invitationId)
-            .orElseThrow { NoSuchElementException("초대장을 찾을 수 없습니다. ID: $invitationId") }
+        return try {
+            val invitation = invitationRepository.findById(invitationId)
+                .orElseThrow { NoSuchElementException("초대장을 찾을 수 없습니다. ID: $invitationId") }
 
-        if (userId != null) {
-            val isAlreadyJoined = participantRepository.existsByInvitationIdAndUserId(invitationId, userId)
-            if (!isAlreadyJoined) {
-                val userProxy = userRepository.getReferenceById(userId)
-                participantRepository.save(InvitationParticipant(invitation = invitation, user = userProxy))
+            println(">>> [초대장 조회 성공] ID: $invitationId")
+
+            if (userId != null) {
+                println(">>> [멤버 로직 시작]")
+                val isAlreadyJoined = participantRepository.existsByInvitationIdAndUserId(invitationId, userId)
+                if (!isAlreadyJoined) {
+                    val userProxy = userRepository.getReferenceById(userId)
+                    participantRepository.save(InvitationParticipant(invitation = invitation, user = userProxy))
+                }
+                val response = JoinResponse(invitationId = invitationId, isMember = true, alreadyJoined = isAlreadyJoined)
+                println(">>> [Join 성공 직전] $response")
+                return response
             }
-            val response = JoinResponse(invitationId = invitationId, isMember = true, alreadyJoined = isAlreadyJoined)
-            println(">>> [Join 성공 직전] $response")
-            return response
-        }
 
-        val alreadyHasAccess = guestInvitationIds.contains(invitationId)
-        return JoinResponse(invitationId = invitationId, isMember = false, alreadyJoined = alreadyHasAccess)
+            println(">>> [게스트 로직 시작]")
+            val alreadyHasAccess = guestInvitationIds.contains(invitationId)
+            val response = JoinResponse(invitationId = invitationId, isMember = false, alreadyJoined = alreadyHasAccess)
+            println(">>> [Join 게스트 성공 직전] $response")
+            response
+        } catch (e: Exception) {
+            println(">>> [서비스 에러] ${e.javaClass.simpleName}: ${e.message}")
+            e.printStackTrace()
+            throw e
+        }
     }
 
     @Transactional
@@ -84,29 +96,50 @@ class InvitationService(
 
     @Transactional(readOnly = true)
     fun getParticipantInvitations(
-        userId: Long,
+        userId: Long?,
+        guestInvitationIds: List<Long>,
         status: String,
         sortType: String,
         pageable: Pageable
     ): PagingResponse<InvitationSummaryResponse> {
-        val now = LocalDateTime.now()
         val upperStatus = status.uppercase()
-
         val direction = if (sortType.uppercase() == "DESC") Sort.Direction.DESC else Sort.Direction.ASC
 
-        val sort = Sort.by(direction, "invitation.invitationDate")
-            .and(Sort.by(direction, "invitation.startTime"))
+        return if (userId != null) {
+            val sort = Sort.by(direction, "invitation.invitationDate")
+                .and(Sort.by(direction, "invitation.startTime"))
+            val adjustedPageable = PageRequest.of(pageable.pageNumber, pageable.pageSize, sort)
+            val now = LocalDateTime.now()
 
-        val adjustedPageable = PageRequest.of(pageable.pageNumber, pageable.pageSize, sort)
+            val participantPage = when (upperStatus) {
+                "UPCOMING" -> participantRepository.findUpcomingInvitations(userId, now.toLocalDate(), now.toLocalTime(), adjustedPageable)
+                "PAST" -> participantRepository.findPastInvitations(userId, now.toLocalDate(), now.toLocalTime(), adjustedPageable)
+                else -> participantRepository.findAllByUserIdWithInvitation(userId, adjustedPageable)
+            }
 
-        val participantPage: Page<InvitationParticipant> = when (upperStatus) {
-            "UPCOMING" -> participantRepository.findUpcomingInvitations(userId, now.toLocalDate(), now.toLocalTime(), adjustedPageable)
-            "PAST" -> participantRepository.findPastInvitations(userId, now.toLocalDate(), now.toLocalTime(), adjustedPageable)
-            else -> participantRepository.findAllByUserIdWithInvitation(userId, adjustedPageable)
+            convertToPagingResponse(participantPage.map { it.invitation }, userId)
+        } else {
+            val sort = Sort.by(direction, "invitationDate")
+                .and(Sort.by(direction, "startTime"))
+            val adjustedPageable = PageRequest.of(pageable.pageNumber, pageable.pageSize, sort)
+
+            if (guestInvitationIds.isEmpty()) {
+                return PagingResponse.empty()
+            }
+
+            val invitationPage = invitationRepository.findAllByIdInWithStatus(
+                guestInvitationIds, upperStatus, adjustedPageable
+            )
+
+            convertToPagingResponse(invitationPage, null)
         }
+    }
 
-        val contents = participantPage.content.map { participant ->
-            val invitation = participant.invitation
+    private fun convertToPagingResponse(
+        page: Page<Invitation>,
+        currentUserId: Long?
+    ): PagingResponse<InvitationSummaryResponse> {
+        val contents = page.content.map { invitation ->
             InvitationSummaryResponse(
                 id = invitation.id,
                 title = invitation.title,
@@ -115,16 +148,16 @@ class InvitationService(
                 address = invitation.address,
                 invitationDate = invitation.invitationDate.toString(),
                 startTime = invitation.startTime.toString(),
-                isOwner = invitation.host.id == userId
+                isOwner = invitation.host.id == currentUserId
             )
         }
 
         return PagingResponse(
             meta = PagingMetaResponse(
-                isEnd = participantPage.isLast,
-                pageableCount = participantPage.numberOfElements,
-                totalCount = participantPage.totalElements,
-                currentPage = participantPage.number
+                isEnd = page.isLast,
+                pageableCount = page.numberOfElements,
+                totalCount = page.totalElements,
+                currentPage = page.number
             ),
             content = contents
         )


### PR DESCRIPTION
## 🔍 변경 사항
> 이번 PR에서 변경된 핵심 내용을 간단히 설명해주세요.

- 비로그인 유저의 헤더에서 초대장 리스트를 뽑아 반환
- 데이터가 없는 화면에서도 pullToRefresh 가능하게 대응
- 딥링크로 진입 했을 경우 새로고침 필요 여부 전달
- 비로그인 유저 다가오는 초대 기능 구현

오전에 테스트 했을 때 새로고침 반영이 늦는 문제가 있었던 걸로 기억해서
새로고침 필요 여부를 전달하고 새로고침 되도록 대응을 해놨는데,

다시 테스트를 진행해보니 Home 화면으로 보내기 때문에
다시 초대장 탭에 진입했을 땐 새로고침이 무조건 되어 있을 것 같습니다.

따라서 새로고침 필요 여부를 굳이 전달하지 않아도 되지 않나? 생각이 드는데
NavigateBack 시키는 화면이 초대장 탭으로 바뀔 수도 있을 것 같아
일단은 해당 코드를 삭제시키지 않고 보존해뒀습니다.

## 📸 스크린샷 (선택)
> UI 변경 사항이 있다면 이미지를 첨부해주세요.

### 비로그인 유저 초대장 리스트
https://github.com/user-attachments/assets/51216cbc-cea7-4cfd-8e0c-2312cd564f31

### 비로그인 유저 다가오는 초대

https://github.com/user-attachments/assets/dc876842-d6b5-42d3-8cca-a3991a9c37f5


## 🔗 관련 이슈
> 해당 PR과 연결된 이슈 번호를 적어주세요. (예: #1)

- #133 

## ✅ 체크리스트
- [x] 팀 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 import는 삭제했나요?
