### PR TITLE
Feature/#152 login 화면 UI 보완 및 비로그인과 빈데이터 화면 대응

### DIFF
--- a/android/app/src/main/kotlin/com/andlife/nacho/navigation/NavHost.kt
+++ b/android/app/src/main/kotlin/com/andlife/nacho/navigation/NavHost.kt
@@ -78,6 +78,15 @@ fun NachoNavHost(
                 paddingValues = innerPadding,
                 snackbarHostState = snackbarHostState,
                 onNavigateToCreate = navigator::navigateToMyInvitationCreate,
+                onNavigateToLogin = {
+                    val navOptions = navOptions {
+                        popUpTo(navigator.navController.graph.id) {
+                            inclusive = true
+                        }
+                        launchSingleTop = true
+                    }
+                    navigator.navigateToLogin(navOptions)
+                },
                 onNavigateToInvitationDetail = navigator::navigateToInvitationDetail,
                 onNavigateToMyInvitationDetail = navigator::navigateToMyInvitationDetail,
                 onNavigateToSetting = navigator::navigateToSetting,

--- a/android/core/designsystem/src/main/res/drawable/ic_home_logo.xml
+++ b/android/core/designsystem/src/main/res/drawable/ic_home_logo.xml
@@ -1,0 +1,31 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:aapt="http://schemas.android.com/aapt"
+    android:width="200dp"
+    android:height="200dp"
+    android:viewportWidth="100"
+    android:viewportHeight="100">
+
+    <path
+        android:pathData="M50,2L50,2A48,48 0,0 1,98 50L98,50A48,48 0,0 1,50 98L50,98A48,48 0,0 1,2 50L2,50A48,48 0,0 1,50 2z">
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:startX="18.06"
+                android:startY="18.94"
+                android:endX="85.94"
+                android:endY="86.82"
+                android:type="linear">
+                <item android:offset="0" android:color="#FFF43F5E"/>
+                <item android:offset="1" android:color="#FFFB7185"/>
+            </gradient>
+        </aapt:attr>
+    </path>
+
+    <path
+        android:pathData="M29.86,41.1L50.43,25.86L71,41.1V46.18L54.02,58.76C52.98,59.54 51.73,59.94 50.43,59.94C49.13,59.94 47.88,59.53 46.84,58.76L29.86,46.18V41.1ZM50.43,18.8C49.13,18.8 47.88,19.22 46.84,19.98L25.77,35.59C24.03,36.89 23,38.92 23,41.1V66.8C23,70.58 26.07,73.66 29.86,73.66H71C74.78,73.66 77.86,70.58 77.86,66.8V41.1C77.86,38.92 76.83,36.87 75.08,35.59L54.02,19.98C52.98,19.22 51.73,18.8 50.43,18.8Z"
+        android:fillColor="#ffffff"/>
+
+    <path
+        android:pathData="M71,78C72.1,78 73,78.9 73,80C73,81.1 72.1,82 71,82H29C27.9,82 27,81.1 27,80C27,78.9 27.9,78 29,78H71Z"
+        android:fillColor="#ffffff"
+        android:fillAlpha="0.75"/>
+</vector>

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/dialog/LoginDialog.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/dialog/LoginDialog.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.andlife.designsystem.component.dialog.NachoDialog
@@ -23,7 +24,9 @@ fun LoginDialog(
 ) {
     NachoDialog(onDismiss = onDismiss) {
         Column(
-            modifier = Modifier.padding(NachoSpacing.xLarge),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(NachoSpacing.xLarge),
             verticalArrangement = Arrangement.spacedBy(NachoSpacing.medium)
         ) {
             Text(
@@ -34,23 +37,24 @@ fun LoginDialog(
             Text(
                 text = stringResource(R.string.msg_guide_login),
                 color = NachoTheme.colorScheme.textSecondary,
-                style = NachoTheme.typography.bodyMediumRegular,
+                style = NachoTheme.typography.bodyMediumMedium,
             )
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 horizontalArrangement = Arrangement.End,
+                verticalAlignment = Alignment.CenterVertically,
             ) {
                 TextButton(onClick = onDismiss) {
                     Text(
                         text = stringResource(R.string.txt_label_cancel),
-                        color = NachoTheme.colorScheme.textPrimary,
+                        color = NachoTheme.colorScheme.textSecondary,
                         style = NachoTheme.typography.bodyMediumSemiBold,
                     )
                 }
                 TextButton(onClick = onConfirm) {
                     Text(
                         text = stringResource(R.string.txt_move),
-                        color = NachoTheme.colorScheme.brandDark,
+                        color = NachoTheme.colorScheme.brandPrimary,
                         style = NachoTheme.typography.bodyMediumSemiBold,
                     )
                 }

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/dialog/NachoInfoDialog.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/dialog/NachoInfoDialog.kt
@@ -98,6 +98,7 @@ fun NachoInfoDialog(
                     Text(
                         text = dismissText,
                         color = NachoTheme.colorScheme.textSecondary,
+                        style = NachoTheme.typography.bodyMediumSemiBold,
                     )
                 }
 
@@ -113,6 +114,7 @@ fun NachoInfoDialog(
                     Text(
                         text = confirmText,
                         color = NachoTheme.colorScheme.brandPrimary,
+                        style = NachoTheme.typography.bodyMediumSemiBold,
                     )
                 }
             }

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/paging/PagingStateContent.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/paging/PagingStateContent.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
 import androidx.paging.LoadState
 import com.andlife.designsystem.preview.PreviewTheme
 import com.andlife.designsystem.theme.NachoTheme
@@ -22,6 +23,7 @@ fun PagingStateContent(
     itemCount: Int,
     onRetry: () -> Unit,
     modifier: Modifier = Modifier,
+    emptyComment: String = stringResource(R.string.label_paging_empty_result),
     content: @Composable () -> Unit,
 ) {
     Box(modifier = modifier.fillMaxSize()) {
@@ -42,7 +44,13 @@ fun PagingStateContent(
                             .verticalScroll(rememberScrollState()),
                         contentAlignment = Alignment.Center,
                     ) {
-                        Text(text = stringResource(R.string.label_paging_empty_result))
+                        Text(
+                            text = emptyComment,
+                            style = NachoTheme.typography.bodyLargeMedium,
+                            color = NachoTheme.colorScheme.textSecondary,
+                            textAlign = TextAlign.Center,
+                            lineHeight = NachoTheme.typography.bodyLargeMedium.lineHeight * 1.4f
+                        )
                     }
                 } else {
                     content()

--- a/android/core/ui/src/main/res/drawable/ic_thumbnail.xml
+++ b/android/core/ui/src/main/res/drawable/ic_thumbnail.xml
@@ -4,43 +4,39 @@
     android:height="209dp"
     android:viewportWidth="371"
     android:viewportHeight="209">
-  <path
-      android:pathData="M0,0h371v209h-371z"
-      android:fillColor="#ffffff"/>
-  <path
-      android:strokeWidth="1"
-      android:pathData="M0,0h371v209h-371z"
-      android:fillColor="#00000000"
-      android:strokeColor="#E5E7EB"/>
-  <path
-      android:pathData="M186,57L186,57A48,48 0,0 1,234 105L234,105A48,48 0,0 1,186 153L186,153A48,48 0,0 1,138 105L138,105A48,48 0,0 1,186 57z">
-    <aapt:attr name="android:fillColor">
-      <gradient
-          android:startX="104.06"
-          android:startY="90.94"
-          android:endX="171.94"
-          android:endY="158.82"
-          android:type="linear">
-        <item android:offset="0" android:color="#FFF43F5E"/>
-        <item android:offset="1" android:color="#FFFB7185"/>
-      </gradient>
-    </aapt:attr>
-  </path>
-  <path
-      android:strokeWidth="1"
-      android:pathData="M186,57L186,57A48,48 0,0 1,234 105L234,105A48,48 0,0 1,186 153L186,153A48,48 0,0 1,138 105L138,105A48,48 0,0 1,186 57z"
-      android:fillColor="#00000000"
-      android:strokeColor="#E5E7EB"/>
-  <path
-      android:pathData="M165.86,96.1L186.43,80.86L207,96.1V101.18L190.02,113.76C188.98,114.54 187.73,114.94 186.43,114.94C185.13,114.94 183.88,114.53 182.84,113.76L165.86,101.18V96.1ZM186.43,73.8C185.13,73.8 183.88,74.22 182.84,74.98L161.77,90.59C160.03,91.89 159,93.92 159,96.1V121.8C159,125.58 162.07,128.66 165.86,128.66H207C210.78,128.66 213.86,125.58 213.86,121.8V96.1C213.86,93.92 212.83,91.87 211.08,90.59L190.02,74.98C188.98,74.22 187.73,73.8 186.43,73.8Z"
-      android:fillColor="#ffffff"/>
-  <path
-      android:pathData="M207,133C208.1,133 209,133.9 209,135C209,136.1 208.1,137 207,137H165C163.9,137 163,136.1 163,135C163,133.9 163.9,133 165,133H207Z"
-      android:fillColor="#ffffff"
-      android:fillAlpha="0.75"/>
-  <path
-      android:strokeWidth="1"
-      android:pathData="M207,133C208.1,133 209,133.9 209,135C209,136.1 208.1,137 207,137H165C163.9,137 163,136.1 163,135C163,133.9 163.9,133 165,133H207Z"
-      android:fillColor="#00000000"
-      android:strokeColor="#E5E7EB"/>
+
+    <path
+        android:pathData="M0,0h371v209h-371z"
+        android:fillColor="#ffffff"/>
+
+    <path
+        android:strokeWidth="1"
+        android:pathData="M0.5,0.5h370v208h-370z"
+        android:fillColor="#00000000"
+        android:strokeColor="#E5E7EB"/>
+
+    <path
+        android:pathData="M186,47L186,47A58,58 0,0 1,244 105L244,105A58,58 0,0 1,186 163L186,163A58,58 0,0 1,128 105L128,105A58,58 0,0 1,186 47z">
+        <aapt:attr name="android:fillColor">
+            <gradient
+                android:startX="128"
+                android:startY="65"
+                android:endX="244"
+                android:endY="145"
+                android:type="linear">
+                <item android:offset="0" android:color="#FFF43F5E"/>
+                <item android:offset="1" android:color="#FFFB7185"/>
+            </gradient>
+        </aapt:attr>
+    </path>
+
+    <path
+        android:pathData="M165.43,96.27L186,81.03L206.57,96.27V101.35L189.59,113.93C188.55,114.71 187.3,115.11 186,115.11C184.7,115.11 183.45,114.7 182.41,113.93L165.43,101.35V96.27ZM186,73.97C184.7,73.97 183.45,74.39 182.41,75.15L161.34,90.76C159.6,92.06 158.57,94.09 158.57,96.27V121.97C158.57,125.75 161.64,128.83 165.43,128.83H206.57C210.35,128.83 213.43,125.75 213.43,121.97V96.27C213.43,94.09 212.4,92.04 210.65,90.76L189.59,75.15C188.55,74.39 187.3,73.97 186,73.97Z"
+        android:fillColor="#ffffff"/>
+
+    <path
+        android:pathData="M206.57,133.17C207.67,133.17 208.57,134.07 208.57,135.17C208.57,136.27 207.67,137.17 206.57,137.17H165.43C164.33,137.17 163.43,136.27 163.43,135.17C163.43,134.07 164.33,133.17 165.43,133.17H206.57Z"
+        android:fillColor="#ffffff"
+        android:fillAlpha="0.75"/>
+
 </vector>

--- a/android/core/ui/src/main/res/values/strings.xml
+++ b/android/core/ui/src/main/res/values/strings.xml
@@ -5,7 +5,7 @@
 
     <string name="label_loading_fetch_failed">데이터를 불러오는 데 실패했습니다.</string>
     <string name="label_loading_retry">재시도</string>
-    <string name="label_paging_empty_result">결과가 없습니다.</string>
+    <string name="label_paging_empty_result">검색된 결과가 없습니다.</string>
 
     <string name="desc_schedule_list_image">다가오는 초대의 이미지</string>
     <string name="desc_invitation_list_image">초대장 리스트 카드의 이미지</string>
@@ -58,6 +58,9 @@
     <string name="msg_leave_failure">나가기에 실패했습니다. 다시 시도해주세요.</string>
     <string name="msg_delete_success">초대장을 삭제했습니다.</string>
     <string name="msg_delete_failure">삭제에 실패했습니다. 다시 시도해주세요.</string>
+
+    <string name="label_invitation_empty">아직 참여한 초대장이 없어요.\n공유받은 초대장 링크를 확인해보세요.</string>
+    <string name="label_myinvitation_empty">아직 내가 만든 초대장이 없어요.\n나만의 초대장을 만들어보세요.</string>
 
     <!--  모아보기 Media  -->
     <string name="desc_media_image">방명록의 이미지</string>

--- a/android/core/ui/src/main/res/values/strings.xml
+++ b/android/core/ui/src/main/res/values/strings.xml
@@ -50,8 +50,9 @@
     <string name="txt_delete_invitation_message">초대장을 삭제하시겠습니까?\n삭제한 초대장은 복구할 수 없습니다.</string>
     <string name="txt_confirm">확인</string>
     <string name="txt_cancel">취소</string>
-    <string name="desc_not_logged">현재 비로그인 상태입니다\n로그인 하여 초대장을 작성해보세요</string>
-    <string name="txt_go_login">로그인하기</string>
+    <string name="desc_not_logged_title">나만의 초대장을 만들어볼까요?</string>
+    <string name="desc_not_logged_content">로그인하고 소중한 추억을 기록해보세요</string>
+    <string name="txt_start_login">로그인하고 시작하기</string>
 
     <string name="msg_leave_success">초대장에서 나갔습니다.</string>
     <string name="msg_leave_failure">나가기에 실패했습니다. 다시 시도해주세요.</string>

--- a/android/feature/home/src/main/kotlin/com/andlife/home/HomeNavGraph.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/HomeNavGraph.kt
@@ -38,13 +38,13 @@ fun NavGraphBuilder.homeNavGraph(
     paddingValues: PaddingValues,
     snackbarHostState: SnackbarHostState,
     onNavigateToCreate: () -> Unit,
+    onNavigateToLogin: () -> Unit,
     onNavigateToInvitationDetail: (Long) -> Unit,
     onNavigateToMyInvitationDetail: (Long) -> Unit,
     onNavigateToSetting: () -> Unit,
 ) {
     composable<Home> {
         val viewModel: HomeViewModel = hiltViewModel()
-
         val needsRefresh by RefreshEventHub.homeRefresh.collectAsStateWithLifecycle()
 
         LaunchedEffect(needsRefresh) {
@@ -58,6 +58,7 @@ fun NavGraphBuilder.homeNavGraph(
         HomeRoute(
             snackbarHostState = snackbarHostState,
             onNavigateToCreate = onNavigateToCreate,
+            onNavigateToLogin = onNavigateToLogin,
             onNavigateToInvitationDetail = onNavigateToInvitationDetail,
             onNavigateToMyInvitationDetail = onNavigateToMyInvitationDetail,
             onNavigateToSetting = onNavigateToSetting,

--- a/android/feature/home/src/main/kotlin/com/andlife/home/HomeNavGraph.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/HomeNavGraph.kt
@@ -33,7 +33,6 @@ fun NavController.navigateToSetting(navOptions: NavOptions) {
     navigate(Setting, navOptions)
 }
 
-
 fun NavGraphBuilder.homeNavGraph(
     paddingValues: PaddingValues,
     snackbarHostState: SnackbarHostState,

--- a/android/feature/home/src/main/kotlin/com/andlife/home/model/home/HomeUiEvent.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/model/home/HomeUiEvent.kt
@@ -36,4 +36,6 @@ sealed interface HomeUiEvent : BaseUiEvent {
     data class UpdateMediaPlayState(
         val isPlaying: Boolean
     ) : HomeUiEvent
+
+    data object DismissLoginDialog : HomeUiEvent
 }

--- a/android/feature/home/src/main/kotlin/com/andlife/home/model/home/HomeUiState.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/model/home/HomeUiState.kt
@@ -11,6 +11,7 @@ data class HomeUiState(
     val isMediaPlaying: Boolean = false,
     val upcomingInvitations: ImmutableList<UpcomingInvitationUiModel> = persistentListOf(),
     val audioPlaybackState: AudioPlaybackState = AudioPlaybackState(),
+    val showLoginDialog: Boolean = false,
 ) : BaseUiState {
 
     val canPlayVideo: Boolean

--- a/android/feature/home/src/main/kotlin/com/andlife/home/screen/HomeScreen.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/screen/HomeScreen.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
@@ -546,7 +545,7 @@ private fun UpcomingStatusContent(
             )
             Text(
                 text = description,
-                style = NachoTheme.typography.bodyMediumRegular,
+                style = NachoTheme.typography.bodyLargeMedium,
                 color = NachoTheme.colorScheme.textSecondary,
                 textAlign = TextAlign.Center
             )
@@ -596,18 +595,19 @@ private fun LazyListScope.homeGuestBookSection(
 
     if (isInitialLoading || isInitialError || isEmpty) {
         item {
-            GuestBookStatusContent(
-                modifier = Modifier.padding(
-                    vertical = NachoSpacing.threeXLarge,
-                    horizontal = NachoSpacing.large
-                ),
-                isLoading = isInitialLoading,
-                title = when {
-                    isInitialError -> stringResource(R.string.error_msg_failed_load_post)
-                    isEmpty -> stringResource(R.string.txt_empty_new_post_desc)
-                    else -> null
-                },
-            )
+            Box(
+                modifier = Modifier.fillParentMaxHeight(0.3f),
+                contentAlignment = Alignment.Center
+            ) {
+                GuestBookStatusContent(
+                    isLoading = isInitialLoading,
+                    title = when {
+                        isInitialError -> stringResource(R.string.error_msg_failed_load_post)
+                        isEmpty -> stringResource(R.string.txt_empty_new_post_desc)
+                        else -> null
+                    },
+                )
+            }
         }
     } else {
         items(
@@ -654,16 +654,10 @@ private fun LazyListScope.homeGuestBookSection(
 private fun GuestBookStatusContent(
     modifier: Modifier = Modifier,
     title: String? = null,
-    description: String? = null,
-    buttonText: String? = null,
-    onButtonClick: (() -> Unit)? = null,
     isLoading: Boolean = false,
 ) {
     Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .wrapContentHeight()
-            .padding(vertical = NachoSpacing.threeXLarge),
+        modifier = modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center,
     ) {
@@ -673,27 +667,11 @@ private fun GuestBookStatusContent(
             title?.let {
                 Text(
                     text = it,
-                    style = NachoTheme.typography.bodyMediumRegular,
-                    color = NachoTheme.colorScheme.textPrimary,
-                    textAlign = TextAlign.Center
-                )
-            }
-
-            description?.let {
-                Spacer(Modifier.height(NachoSpacing.small))
-                Text(
-                    text = it,
-                    style = NachoTheme.typography.bodyMediumRegular,
+                    style = NachoTheme.typography.bodyLargeMedium,
                     color = NachoTheme.colorScheme.textSecondary,
-                    textAlign = TextAlign.Center
+                    textAlign = TextAlign.Center,
+                    lineHeight = NachoTheme.typography.bodyLargeMedium.lineHeight * 1.4f
                 )
-            }
-
-            if (buttonText != null && onButtonClick != null) {
-                Spacer(Modifier.height(NachoSpacing.large))
-                NachoButton(onClick = onButtonClick) {
-                    Text(text = buttonText)
-                }
             }
         }
     }

--- a/android/feature/home/src/main/kotlin/com/andlife/home/screen/HomeScreen.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/screen/HomeScreen.kt
@@ -110,6 +110,17 @@ fun HomeRoute(
     val lazyListState = rememberLazyListState()
     val refreshFailMessage = stringResource(R.string.snack_refresh_failure)
 
+    val navigateToLoginWithCleanup: () -> Unit = {
+        isMediaActive = false
+        scope.launch {
+            viewModel.videoPlayerPool.pauseAllPlayers()
+            viewModel.onEvent(HomeUiEvent.ClickAudioMedia(""))
+
+            delay(50L)
+            onNavigateToLogin()
+        }
+    }
+
     viewModel.effectFlow.collectWithLifecycle { effect ->
         when (effect) {
             is HomeSideEffect.ShowMessage -> {
@@ -221,7 +232,7 @@ fun HomeRoute(
             },
             onConfirm = {
                 viewModel.onEvent(HomeUiEvent.DismissLoginDialog)
-                onNavigateToLogin()
+                navigateToLoginWithCleanup()
             }
         )
     }

--- a/android/feature/home/src/main/kotlin/com/andlife/home/screen/HomeScreen.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/screen/HomeScreen.kt
@@ -69,6 +69,7 @@ import com.andlife.model.common.VideoCandidate
 import com.andlife.model.guestbook.GuestBookUiModel
 import com.andlife.model.guestbook.MediaUiType
 import com.andlife.model.invitation.UpcomingInvitationUiModel
+import com.andlife.ui.component.dialog.LoginDialog
 import com.andlife.ui.component.guestbook.FakeAutoVideoPlayerPool
 import com.andlife.ui.component.guestbook.GuestBookItem
 import com.andlife.ui.component.listitem.InvitationScheduleListItem
@@ -92,6 +93,7 @@ private const val SKELETON_ITEM_COUNT = 2
 fun HomeRoute(
     snackbarHostState: SnackbarHostState,
     onNavigateToCreate: () -> Unit,
+    onNavigateToLogin: () -> Unit,
     onNavigateToInvitationDetail: (Long) -> Unit,
     onNavigateToMyInvitationDetail: (Long) -> Unit,
     onNavigateToSetting: () -> Unit,
@@ -211,6 +213,18 @@ fun HomeRoute(
         videoPlayerPool = viewModel.videoPlayerPool,
         modifier = modifier,
     )
+
+    if (uiState.showLoginDialog) {
+        LoginDialog(
+            onDismiss = {
+                viewModel.onEvent(HomeUiEvent.DismissLoginDialog)
+            },
+            onConfirm = {
+                viewModel.onEvent(HomeUiEvent.DismissLoginDialog)
+                onNavigateToLogin()
+            }
+        )
+    }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -351,7 +365,6 @@ fun HomeScreen(
         }
     }
 }
-
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/android/feature/home/src/main/kotlin/com/andlife/home/screen/SettingScreen.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/screen/SettingScreen.kt
@@ -433,10 +433,14 @@ private fun ProfileContent(
                     .fillMaxWidth()
                     .padding(NachoSpacing.large),
                 horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.Center
+                verticalArrangement = Arrangement.spacedBy(NachoSpacing.small)
             ) {
-                Text(text = stringResource(R.string.txt_not_login_user))
-                Spacer(modifier = Modifier.width(NachoSpacing.large))
+                Text(
+                    text = stringResource(R.string.txt_not_login_user),
+                    style = NachoTheme.typography.bodyLargeMedium,
+                    color = NachoTheme.colorScheme.textSecondary,
+                )
+
                 NachoButton(
                     onClick = onNavigateToLogin,
                     elevation =
@@ -446,7 +450,7 @@ private fun ProfileContent(
                         ),
                     containerColor = NachoTheme.colorScheme.brandOnPrimary,
                     contentColor = NachoTheme.colorScheme.brandPrimary,
-                    contentPadding = PaddingValues(horizontal = NachoSpacing.small, vertical = NachoSpacing.xSmall),
+                    contentPadding = PaddingValues(NachoSpacing.small),
                 ) {
                     Text(
                         text = stringResource(R.string.txt_go_login),

--- a/android/feature/home/src/main/kotlin/com/andlife/home/viewmodel/HomeViewModel.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/viewmodel/HomeViewModel.kt
@@ -4,6 +4,8 @@ import androidx.lifecycle.viewModelScope
 import androidx.paging.PagingData
 import androidx.paging.cachedIn
 import androidx.paging.map
+import com.andlife.domain.model.auth.AuthState
+import com.andlife.domain.repository.auth.AuthStateManager
 import com.andlife.domain.repository.guestbook.GuestBookRepository
 import com.andlife.domain.repository.invitation.InvitationRepository
 import com.andlife.home.model.home.HomeSideEffect
@@ -30,6 +32,7 @@ import javax.inject.Inject
 class HomeViewModel @Inject constructor(
     private val guestBookRepository: GuestBookRepository,
     private val invitationRepository: InvitationRepository,
+    private val authStateManager: AuthStateManager,
     val audioPlayerManager: AudioPlayerManager,
     val videoPlayerPool: AutoVideoPlayerPool,
 ) : BaseViewModel<HomeUiState, HomeUiEvent, HomeSideEffect>(initialState = HomeUiState()) {
@@ -74,6 +77,8 @@ class HomeViewModel @Inject constructor(
             is HomeUiEvent.ClickCreate -> navigateToCreate()
             is HomeUiEvent.Refresh -> refresh()
             is HomeUiEvent.UpdateMediaPlayState -> updatePlayState(event.isPlaying)
+            HomeUiEvent.DismissLoginDialog -> dismissLoginDialog()
+
         }
     }
 
@@ -110,7 +115,12 @@ class HomeViewModel @Inject constructor(
     }
 
     private fun navigateToCreate() {
-        sendEffect(HomeSideEffect.NavigateToCreate)
+        val isAuthenticated = authStateManager.authState.value is AuthState.Authenticated
+        if (!isAuthenticated) {
+            updateState { copy(showLoginDialog = true) }
+        } else {
+            sendEffect(HomeSideEffect.NavigateToCreate)
+        }
     }
 
     private fun showMediaMessage(type: String, url: String) {
@@ -140,5 +150,9 @@ class HomeViewModel @Inject constructor(
 
     fun handleRefresh() {
         sendEffect(HomeSideEffect.NeedRefresh)
+    }
+
+    private fun dismissLoginDialog() {
+        updateState { copy(showLoginDialog = false) }
     }
 }

--- a/android/feature/home/src/main/res/values/strings.xml
+++ b/android/feature/home/src/main/res/values/strings.xml
@@ -40,8 +40,8 @@
     <string name="txt_app_version">앱 버전</string>
 
     <string name="txt_logout">로그아웃</string>
-    <string name="txt_not_login_user">로그인 상태가 아닙니다.</string>
-    <string name="txt_go_login">로그인하러가기</string>
+    <string name="txt_not_login_user">로그인 후 더 많은 기능을 이용해 보세요!</string>
+    <string name="txt_go_login">로그인하기</string>
     <string name="txt_question_logout">정말 로그아웃 하시겠습니까?</string>
     <string name="desc_logout">로그아웃 상세 아이콘 버튼</string>
     <string name="txt_quit">회원탈퇴</string>

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/InvitationScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/InvitationScreen.kt
@@ -184,6 +184,7 @@ private fun InvitationScreen(
                     PagingStateContent(
                         loadState = currentItems.loadState.refresh,
                         itemCount = currentItems.itemCount,
+                        emptyComment = stringResource(R.string.label_invitation_empty),
                         onRetry = { currentItems.retry() }
                     ) {
                         LazyColumn(

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
@@ -520,6 +520,7 @@ private fun InvitationGuestBookScreen(
                         PagingStateContent(
                             loadState = guestBooks.loadState.refresh,
                             itemCount = guestBooks.itemCount,
+                            emptyComment = stringResource(R.string.label_guestbook_empty),
                             modifier = Modifier.fillMaxSize(),
                             onRetry = { guestBooks.retry() }
                         ) {}

--- a/android/feature/invitation/src/main/res/values/strings.xml
+++ b/android/feature/invitation/src/main/res/values/strings.xml
@@ -35,5 +35,6 @@
     <string name="dialog_confirm">다운로드</string>
     <string name="dialog_cancel">취소</string>
 
+    <string name="label_guestbook_empty">작성된 방명록이 없습니다.\n첫 인사를 남겨보세요!</string>
 </resources>
 

--- a/android/feature/login/src/main/kotlin/com/andlife/login/screen/LoginScreen.kt
+++ b/android/feature/login/src/main/kotlin/com/andlife/login/screen/LoginScreen.kt
@@ -1,23 +1,22 @@
 package com.andlife.login.screen
 
 import android.util.Log
-import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -28,11 +27,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Shape
-import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalResources
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.res.vectorResource
 import androidx.compose.ui.text.LinkAnnotation
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextLinkStyles
@@ -40,14 +38,12 @@ import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.withLink
-import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.andlife.designsystem.component.NachoButton
 import com.andlife.designsystem.preview.PreviewTheme
 import com.andlife.designsystem.theme.KakaoButtonColor
-import com.andlife.designsystem.theme.KakaoTextColor
 import com.andlife.designsystem.theme.NachoSpacing
-import com.andlife.designsystem.theme.NachoStroke
 import com.andlife.designsystem.theme.NachoTheme
 import com.andlife.domain.error.LoginError
 import com.andlife.domain.util.onFailure
@@ -55,12 +51,14 @@ import com.andlife.domain.util.onSuccess
 import com.andlife.login.LocalLoginManager
 import com.andlife.login.R
 import com.andlife.login.model.LoginSideEffect
-import com.andlife.login.model.LoginUiState
 import com.andlife.login.model.LoginUiEvent
+import com.andlife.login.model.LoginUiState
 import com.andlife.login.social.SocialType
 import com.andlife.login.viewmodel.LoginViewModel
+import com.andlife.ui.component.loading.InvitationLoadingIndicator
 import com.andlife.ui.util.collectWithLifecycle
 import kotlinx.coroutines.launch
+import com.andlife.designsystem.R as designR
 
 @Composable
 fun LoginRoute(
@@ -80,6 +78,7 @@ fun LoginRoute(
                 snackbarHostState.currentSnackbarData?.dismiss()
                 snackbarHostState.showSnackbar(res.getString(R.string.fail_guest_login))
             }
+
             LoginSideEffect.FailSocialLogin -> {
                 snackbarHostState.currentSnackbarData?.dismiss()
                 snackbarHostState.showSnackbar(res.getString(R.string.fail_kakao_login))
@@ -127,43 +126,88 @@ private fun LoginScreen(
             SnackbarHost(snackbarHostState)
         }
     ) { innerPadding ->
-        Box(modifier = Modifier.padding(innerPadding)) {
-            Column(
-                horizontalAlignment = Alignment.CenterHorizontally,
-                verticalArrangement = Arrangement.spacedBy(NachoSpacing.large)
-            ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(innerPadding)
+                .padding(horizontal = NachoSpacing.large),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Spacer(modifier = Modifier.weight(1f))
 
-                Spacer(modifier = Modifier.fillMaxHeight(0.7f))
+            logoSection(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = NachoSpacing.large)
+            )
+
+            Spacer(modifier = Modifier.weight(0.6f))
+
+            Column(
+                verticalArrangement = Arrangement.spacedBy(NachoSpacing.large),
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
                 KakaoLoginButton(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = NachoSpacing.large),
+                    modifier = Modifier.fillMaxWidth(),
                     onLoginClick = { onSocialLogin(SocialType.KAKAO) }
                 )
                 GuestLoginButton(
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .padding(horizontal = NachoSpacing.large),
+                    modifier = Modifier.fillMaxWidth(),
                     onGuestLoginClick = { onEvent(LoginUiEvent.GuestLogin) }
                 )
-
-                PolicyAndTermsText(
-                    modifier = Modifier.padding(top = NachoSpacing.large),
-                    onPrivacyPolicyClick = {
-                        Log.d("Login", "onPrivacyPolicyClick")
-                    },
-                    onTermsOfServiceClick = {
-                        Log.d("Login", "onTermsOfServiceClick")
-                    }
-                )
-                Spacer(modifier = Modifier.fillMaxHeight(0.05f))
             }
-            if (uiState.isLoading) {
-                CircularProgressIndicator(
-                    modifier = Modifier.align(Alignment.Center)
+
+            Spacer(modifier = Modifier.weight(0.8f))
+
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(NachoSpacing.medium)
+            ) {
+                PolicyAndTermsText(
+                    onPrivacyPolicyClick = { Log.d("Login", "onPrivacyPolicyClick") },
+                    onTermsOfServiceClick = { Log.d("Login", "onTermsOfServiceClick") }
+                )
+
+                CopyrightText(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = NachoSpacing.large),
                 )
             }
         }
+        if (uiState.isLoading) {
+            Box(modifier = Modifier.fillMaxSize(), contentAlignment = Alignment.Center) {
+                InvitationLoadingIndicator()
+            }
+        }
+    }
+}
+
+@Composable
+private fun logoSection(modifier: Modifier = Modifier) {
+    Column(
+        modifier = modifier,
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(NachoSpacing.twoXLarge)
+    ) {
+        Text(
+            text = stringResource(R.string.txt_login_title),
+            style = NachoTheme.typography.headingLarge,
+            color = NachoTheme.colorScheme.textSecondary,
+        )
+        Text(
+            text = stringResource(R.string.txt_login_content),
+            style = NachoTheme.typography.bodyLargeSemiBold,
+            color = NachoTheme.colorScheme.textTertiary,
+            textAlign = TextAlign.Center,
+        )
+
+        Image(
+            painter = painterResource(designR.drawable.ic_home_logo),
+            contentDescription = null,
+            modifier = Modifier.fillMaxWidth(),
+        )
     }
 }
 
@@ -174,30 +218,36 @@ private fun KakaoLoginButton(
     shape: Shape = RoundedCornerShape(NachoSpacing.medium),
     isLoading: Boolean = false
 ) {
-    Surface(
+
+    NachoButton(
         modifier = modifier,
         shape = shape,
-        color = KakaoButtonColor,
         enabled = !isLoading,
-        onClick = onLoginClick
+        onClick = onLoginClick,
+        containerColor = KakaoButtonColor,
+        contentColor = NachoTheme.colorScheme.textSecondary,
+        contentPadding = PaddingValues(NachoSpacing.xLarge)
     ) {
         Row(
-            modifier = Modifier.padding(
-                vertical = NachoSpacing.medium,
-                horizontal = NachoSpacing.large
-            ),
-            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(
-                imageVector = ImageVector.vectorResource(R.drawable.ic_kakao_logo),
+                painter = painterResource(R.drawable.ic_kakao_logo),
                 contentDescription = null,
                 tint = Color(0xFF000000)
+
             )
+
             Spacer(modifier = Modifier.weight(1f))
+
             Text(
                 text = stringResource(R.string.txt_kakao_login),
-                color = KakaoTextColor,
+                style = NachoTheme.typography.bodyLargeMedium,
+                color = NachoTheme.colorScheme.textSecondary,
             )
+
             Spacer(modifier = Modifier.weight(1f))
         }
     }
@@ -210,32 +260,35 @@ private fun GuestLoginButton(
     shape: Shape = RoundedCornerShape(NachoSpacing.medium),
     isLoading: Boolean = false
 ) {
-    Surface(
+
+    NachoButton(
         modifier = modifier,
         shape = shape,
-        shadowElevation = 1.dp,
-        border = BorderStroke(
-            width = NachoStroke.small,
-            color = NachoTheme.colorScheme.backgroundBorder
-        ),
         enabled = !isLoading,
-        color = NachoTheme.colorScheme.backgroundPrimary,
-        onClick = onGuestLoginClick
+        onClick = onGuestLoginClick,
+        containerColor = NachoTheme.colorScheme.backgroundPrimary,
+        contentColor = NachoTheme.colorScheme.textSecondary,
+        contentPadding = PaddingValues(NachoSpacing.xLarge)
     ) {
         Row(
-            modifier = Modifier.padding(
-                vertical = NachoSpacing.medium,
-                horizontal = NachoSpacing.large
-            ),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.Center
+            modifier = Modifier
+                .fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically
         ) {
             Icon(
-                imageVector = ImageVector.vectorResource(R.drawable.ic_baseline_person_24),
+                painter = painterResource(R.drawable.ic_baseline_person_24),
                 contentDescription = null,
+                tint = Color(0xFF000000)
+
             )
+
             Spacer(modifier = Modifier.weight(1f))
-            Text(stringResource(R.string.txt_guest_login))
+
+            Text(
+                text = stringResource(R.string.txt_guest_login),
+                style = NachoTheme.typography.bodyLargeMedium,
+                color = NachoTheme.colorScheme.textSecondary,
+            )
             Spacer(modifier = Modifier.weight(1f))
         }
     }
@@ -292,6 +345,19 @@ private fun PolicyAndTermsText(
             textAlign = TextAlign.Center
         )
     }
+}
+
+@Composable
+private fun CopyrightText(
+    modifier: Modifier = Modifier,
+) {
+    Text(
+        text = stringResource(R.string.txt_login_copyright),
+        modifier = modifier.fillMaxWidth(),
+        style = NachoTheme.typography.bodySmallRegular,
+        color = NachoTheme.colorScheme.textTertiary,
+        textAlign = TextAlign.Center,
+    )
 }
 
 @Composable

--- a/android/feature/login/src/main/kotlin/com/andlife/login/screen/LoginScreen.kt
+++ b/android/feature/login/src/main/kotlin/com/andlife/login/screen/LoginScreen.kt
@@ -142,7 +142,7 @@ private fun LoginScreen(
                     .padding(top = NachoSpacing.large)
             )
 
-            Spacer(modifier = Modifier.weight(0.6f))
+            Spacer(modifier = Modifier.weight(0.7f))
 
             Column(
                 verticalArrangement = Arrangement.spacedBy(NachoSpacing.large),
@@ -158,7 +158,7 @@ private fun LoginScreen(
                 )
             }
 
-            Spacer(modifier = Modifier.weight(0.8f))
+            Spacer(modifier = Modifier.weight(0.5f))
 
             Column(
                 horizontalAlignment = Alignment.CenterHorizontally,
@@ -226,7 +226,7 @@ private fun KakaoLoginButton(
         onClick = onLoginClick,
         containerColor = KakaoButtonColor,
         contentColor = NachoTheme.colorScheme.textSecondary,
-        contentPadding = PaddingValues(NachoSpacing.xLarge)
+        contentPadding = PaddingValues(NachoSpacing.large)
     ) {
         Row(
             modifier = Modifier
@@ -268,7 +268,7 @@ private fun GuestLoginButton(
         onClick = onGuestLoginClick,
         containerColor = NachoTheme.colorScheme.backgroundPrimary,
         contentColor = NachoTheme.colorScheme.textSecondary,
-        contentPadding = PaddingValues(NachoSpacing.xLarge)
+        contentPadding = PaddingValues(NachoSpacing.large)
     ) {
         Row(
             modifier = Modifier

--- a/android/feature/login/src/main/kotlin/com/andlife/login/screen/LoginScreen.kt
+++ b/android/feature/login/src/main/kotlin/com/andlife/login/screen/LoginScreen.kt
@@ -43,6 +43,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.andlife.designsystem.component.NachoButton
 import com.andlife.designsystem.preview.PreviewTheme
 import com.andlife.designsystem.theme.KakaoButtonColor
+import com.andlife.designsystem.theme.KakaoTextColor
 import com.andlife.designsystem.theme.NachoSpacing
 import com.andlife.designsystem.theme.NachoTheme
 import com.andlife.domain.error.LoginError
@@ -236,7 +237,7 @@ private fun KakaoLoginButton(
             Icon(
                 painter = painterResource(R.drawable.ic_kakao_logo),
                 contentDescription = null,
-                tint = Color(0xFF000000)
+                tint = KakaoTextColor
 
             )
 
@@ -278,7 +279,7 @@ private fun GuestLoginButton(
             Icon(
                 painter = painterResource(R.drawable.ic_baseline_person_24),
                 contentDescription = null,
-                tint = Color(0xFF000000)
+                tint = KakaoTextColor
 
             )
 

--- a/android/feature/login/src/main/res/values/strings.xml
+++ b/android/feature/login/src/main/res/values/strings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="txt_kakao_login">카카오 로그인</string>
-    <string name="txt_guest_login">비로그인으로 둘러보기</string>
+    <string name="txt_kakao_login">카카오로 시작하기</string>
+    <string name="txt_guest_login">로그인 없이 둘러보기</string>
     <string name="fail_kakao_login">카카오 로그인에 실패했습니다.</string>
     <string name="fail_guest_login">게스트 로그인에 실패했습니다.</string>
     <string name="whenloggingin">"로그인 시 "</string>
@@ -9,5 +9,9 @@
     <string name="and">" 및 "</string>
     <string name="privacypolicy">개인정보처리방침</string>
     <string name="agree">에\n동의하는 것으로 간주됩니다.</string>
+
+    <string name="txt_login_title">나에게로의 초대</string>
+    <string name="txt_login_content">나만의 초대장을 공유하고\n추억을 기록해보세요</string>
+    <string name="txt_login_copyright">Copyright ©ANDLIFE All rights reserved.</string>
 
 </resources>

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationScreen.kt
@@ -268,6 +268,7 @@ private fun MyInvitationScreen(
                             PagingStateContent(
                                 loadState = currentItems.loadState.refresh,
                                 itemCount = currentItems.itemCount,
+                                emptyComment = stringResource(R.string.label_myinvitation_empty),
                                 onRetry = { currentItems.retry() }
                             ) {
                                 LazyColumn(
@@ -358,7 +359,8 @@ private fun MyInvitationScreen(
                         verticalArrangement = Arrangement.spacedBy(NachoSpacing.large)
                     ) {
                         Text(
-                            text = stringResource(R.string.desc_not_logged_title),                            style = NachoTheme.typography.headingSmallSemiBold,
+                            text = stringResource(R.string.desc_not_logged_title),
+                            style = NachoTheme.typography.headingSmallSemiBold,
                             color = NachoTheme.colorScheme.textPrimary,
                             textAlign = TextAlign.Center
                         )

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationScreen.kt
@@ -9,9 +9,10 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material3.ButtonDefaults
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.FloatingActionButton
 import androidx.compose.material3.Icon
@@ -42,12 +43,9 @@ import androidx.paging.compose.collectAsLazyPagingItems
 import androidx.paging.compose.itemKey
 import com.andlife.designsystem.component.NachoButton
 import com.andlife.designsystem.component.dialog.NachoDialog
-import com.andlife.designsystem.theme.NachoElevation
-import com.andlife.designsystem.R as designR
 import com.andlife.designsystem.theme.NachoSpacing
 import com.andlife.designsystem.theme.NachoTheme
 import com.andlife.domain.model.auth.AuthState
-import com.andlife.domain.model.card.TextAlignment
 import com.andlife.domain.model.invitation.SortDirection
 import com.andlife.model.invitation.InvitationSummaryUiModel
 import com.andlife.myinvitation.model.MyInvitationSideEffect
@@ -66,6 +64,7 @@ import com.andlife.ui.util.collectWithLifecycle
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
+import com.andlife.designsystem.R as designR
 
 @Composable
 fun MyInvitationRoute(
@@ -96,6 +95,7 @@ fun MyInvitationRoute(
                     snackbarHostState.showSnackbar(refreshFailureMessage)
                 }
             }
+
             is MyInvitationSideEffect.NavigateToCreate -> onNavigateToCreate()
             is MyInvitationSideEffect.DeleteSuccess -> {
                 scope.launch {
@@ -105,12 +105,14 @@ fun MyInvitationRoute(
                 upcomingItems.refresh()
                 pastItems.refresh()
             }
+
             is MyInvitationSideEffect.DeleteFailure -> {
                 scope.launch {
                     snackbarHostState.currentSnackbarData?.dismiss()
                     snackbarHostState.showSnackbar(deleteFailureMessage)
                 }
             }
+
             is MyInvitationSideEffect.NeedRefresh -> {
                 upcomingItems.refresh()
                 pastItems.refresh()
@@ -356,27 +358,31 @@ private fun MyInvitationScreen(
                         verticalArrangement = Arrangement.spacedBy(NachoSpacing.large)
                     ) {
                         Text(
-                            text = stringResource(R.string.desc_not_logged),
-                            style = NachoTheme.typography.bodyLargeMedium,
+                            text = stringResource(R.string.desc_not_logged_title),                            style = NachoTheme.typography.headingSmallSemiBold,
+                            color = NachoTheme.colorScheme.textPrimary,
                             textAlign = TextAlign.Center
                         )
+
+                        Text(
+                            text = stringResource(R.string.desc_not_logged_content),
+                            style = NachoTheme.typography.bodyLargeMedium,
+                            color = NachoTheme.colorScheme.textSecondary,
+                            textAlign = TextAlign.Center
+                        )
+
+                        Spacer(modifier = Modifier.height(NachoSpacing.large))
+
                         NachoButton(
                             onClick = { onEvent(MyInvitationUiEvent.ClickLogin) },
-                            elevation =
-                                ButtonDefaults.buttonElevation(
-                                    defaultElevation = NachoElevation.none,
-                                    pressedElevation = NachoElevation.none,
-                                ),
-                            containerColor = NachoTheme.colorScheme.brandOnPrimary,
-                            contentColor = NachoTheme.colorScheme.brandPrimary,
-                            contentPadding = PaddingValues(
-                                horizontal = NachoSpacing.small,
-                                vertical = NachoSpacing.xSmall
-                            ),
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(horizontal = NachoSpacing.twoXLarge),
+                            shape = RoundedCornerShape(NachoSpacing.medium),
+                            contentPadding = PaddingValues(vertical = NachoSpacing.medium),
                         ) {
                             Text(
-                                text = stringResource(R.string.txt_go_login),
-                                color = NachoTheme.colorScheme.brandPrimary
+                                text = stringResource(R.string.txt_start_login),
+                                style = NachoTheme.typography.bodyLargeSemiBold
                             )
                         }
                     }

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
@@ -523,6 +523,7 @@ private fun InvitationGuestBookScreen(
                             loadState = guestBooks.loadState.refresh,
                             itemCount = guestBooks.itemCount,
                             modifier = Modifier.fillMaxSize(),
+                            emptyComment = stringResource(R.string.label_guestbook_empty),
                             onRetry = { guestBooks.retry() }
                         ) {}
                     } else {

--- a/android/feature/myinvitation/src/main/res/values/strings.xml
+++ b/android/feature/myinvitation/src/main/res/values/strings.xml
@@ -46,4 +46,6 @@
     <string name="txt_share_kakao">카카오톡 공유하기</string>
     <string name="txt_copy_invitation_link">초대장 링크 복사하기</string>
     <string name="snack_link_copied">초대장 링크가 복사되었습니다</string>
+
+    <string name="label_guestbook_empty">작성된 방명록이 없습니다.\n첫 인사를 남겨보세요!</string>
 </resources>


### PR DESCRIPTION
## 🔍 변경 사항
- 로그인 화면 UI 보완했습니다.
- 홈화면에서 데이터 없는 경우 초대 작성화면으로 이동할 때 로그인 체크하는 로직 추가했습니다.
- 비로그인 시 각 화면 코멘트 스타일 맞추고 수정했습니다. 확인해보시고 변경 필요하다면 피드백 부탁드립니다.

## 📸 스크린샷
<p align="center">
  <img src="https://github.com/user-attachments/assets/4ba48aae-54dd-4d81-a30f-a3b0cc9d2e8c" width="32%">
  <img src="https://github.com/user-attachments/assets/44abf691-63e4-4b58-8906-e1f3a6b294f6" width="32%">
  <img src="https://github.com/user-attachments/assets/d2e28d8f-a9cb-453d-a298-d2b1152e3ff4" width="32%">
</p>

<p align="center">
  <img src="https://github.com/user-attachments/assets/3da25607-5153-4c22-945c-07eb0ab1d970" width="32%">
  <img src="https://github.com/user-attachments/assets/bfc30ab7-c734-40d8-bc68-061960c82ce0" width="32%">
  <img src="https://github.com/user-attachments/assets/6be05521-7f76-44bd-b9e6-6448b7787310" width="32%">
</p>

## 🔗 관련 이슈
- Close #152

## ✅ 체크리스트
- [x] 팀 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 import는 삭제했나요?
