### PR TITLE
Feature/#154 유저 로그인/비로그인 싱크

### DIFF
--- a/android/app/src/main/kotlin/com/andlife/nacho/navigation/NavHost.kt
+++ b/android/app/src/main/kotlin/com/andlife/nacho/navigation/NavHost.kt
@@ -1,5 +1,6 @@
 package com.andlife.nacho.navigation
 
+import android.util.Log
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar

--- a/android/app/src/main/kotlin/com/andlife/nacho/navigation/NavHost.kt
+++ b/android/app/src/main/kotlin/com/andlife/nacho/navigation/NavHost.kt
@@ -1,6 +1,5 @@
 package com.andlife.nacho.navigation
 
-import android.util.Log
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
@@ -23,7 +22,6 @@ import androidx.navigation.navOptions
 import com.andlife.deeplink.DeepLinkManager
 import com.andlife.designsystem.preview.PreviewTheme
 import com.andlife.designsystem.theme.NachoTheme
-import com.andlife.home.Setting
 import com.andlife.home.homeNavGraph
 import com.andlife.home.settingNavGraph
 import com.andlife.invitation.invitationDetailNavGraph
@@ -35,7 +33,6 @@ import com.andlife.invitation_edit.addressSearchNavGraph
 import com.andlife.invitation_edit.invitationCreateNavGraph
 import com.andlife.invitation_edit.invitationEditNavGraph
 import com.andlife.invitation_edit.invitationPreviewNavGraph
-import com.andlife.login.Login
 import com.andlife.login.loginNavGraph
 import com.andlife.model.util.NavigationKeyConstant.CREATE_CARD_BY_INVITATION_ID
 import com.andlife.model.util.NavigationKeyConstant.CREATE_THANKS_CARD

--- a/android/core/data/src/main/kotlin/com/andlife/data/auth/AuthTokenProviderImpl.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/auth/AuthTokenProviderImpl.kt
@@ -7,7 +7,6 @@ import javax.inject.Inject
 class AuthTokenProviderImpl @Inject constructor(
     private val userStorage: UserStorage
 ) : AuthTokenProvider {
-    override fun getUserId(): Long? = userStorage.getUserId()
     override fun getInvitationIds(): List<Long> = userStorage.getInvitationIds()
     override suspend fun getAccessToken(): String? = userStorage.getAccessToken()
     override suspend fun getRefreshToken(): String? = userStorage.getRefreshToken()

--- a/android/core/data/src/main/kotlin/com/andlife/data/datasource/remote/user/UserRemoteDataSource.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/datasource/remote/user/UserRemoteDataSource.kt
@@ -10,4 +10,5 @@ interface UserRemoteDataSource {
     suspend fun login(request: AuthRequest): Result<AuthResponse, DataError>
     suspend fun getUserInfo(): Result<UserResponse, DataError>
     suspend fun reissue(refreshToken: String): Result<AuthResponse, DataError>
+    suspend fun syncInvitations(invitationIds: List<Long>): Result<Unit, DataError>
 }

--- a/android/core/data/src/main/kotlin/com/andlife/data/datasource/remote/user/UserRemoteDataSourceImpl.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/datasource/remote/user/UserRemoteDataSourceImpl.kt
@@ -3,7 +3,9 @@ package com.andlife.data.datasource.remote.user
 import com.andlife.data.util.apiCall
 import com.andlife.domain.error.DataError
 import com.andlife.domain.util.Result
+import com.andlife.domain.util.map
 import com.andlife.network.api.auth.AuthService
+import com.andlife.network.api.invitation.InvitationService
 import com.andlife.network.api.user.UserService
 import com.andlife.network.model.auth.AuthRequest
 import com.andlife.network.model.auth.AuthResponse
@@ -14,6 +16,7 @@ import javax.inject.Inject
 class UserRemoteDataSourceImpl @Inject constructor(
     private val authService: AuthService,
     private val userService: UserService,
+    private val invitationService: InvitationService
 ) : UserRemoteDataSource {
     override suspend fun login(request: AuthRequest): Result<AuthResponse, DataError> =
         apiCall { authService.login(request) }
@@ -23,4 +26,7 @@ class UserRemoteDataSourceImpl @Inject constructor(
 
     override suspend fun reissue(refreshToken: String): Result<AuthResponse, DataError> =
         apiCall { authService.reissue(RefreshTokenRequest(refreshToken)) }
+
+    override suspend fun syncInvitations(invitationIds: List<Long>): Result<Unit, DataError> =
+        apiCall { invitationService.syncInvitations(invitationIds) }.map { Unit }
 }

--- a/android/core/data/src/main/kotlin/com/andlife/data/repository/user/UserRepositoryImpl.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/repository/user/UserRepositoryImpl.kt
@@ -20,11 +20,6 @@ internal class UserRepositoryImpl @Inject constructor(
     private val userRemoteDataSource: UserRemoteDataSource,
     private val authStateManager: AuthStateManager
 ) : UserRepository {
-    override fun getUserId(): Long? = userStorage.getUserId()
-
-    override suspend fun saveUserId(userId: Long) = userStorage.saveUserId(userId)
-
-    override suspend fun clearUserSession() = userStorage.clearUserSession()
     override suspend fun login(accessToken: String): Result<Unit, DataError> {
         return userRemoteDataSource.login(AuthRequest(accessToken))
             .map { authResponse ->

--- a/android/core/data/src/main/kotlin/com/andlife/data/repository/user/UserRepositoryImpl.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/repository/user/UserRepositoryImpl.kt
@@ -29,16 +29,16 @@ internal class UserRepositoryImpl @Inject constructor(
             }
     }
 
-    private suspend fun syncGuestInvitations() {
+    private suspend fun syncGuestInvitations(): Result<Unit, DataError> {
         val invitationIds = userStorage.getInvitationIds()
 
-        if (invitationIds.isNotEmpty()) {
-            val syncResult = userRemoteDataSource.syncInvitations(invitationIds)
-
-            if (syncResult is Result.Success) {
+        if (invitationIds.isEmpty()) {
+            return Result.Success(Unit)
+        }
+        return userRemoteDataSource.syncInvitations(invitationIds)
+            .map {
                 userStorage.clearGuestData()
             }
-        }
     }
 
     override suspend fun guestLogin(): Result<Unit, InvitationError> {

--- a/android/core/data/src/main/kotlin/com/andlife/data/repository/user/UserRepositoryImpl.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/repository/user/UserRepositoryImpl.kt
@@ -25,7 +25,20 @@ internal class UserRepositoryImpl @Inject constructor(
             .map { authResponse ->
                 authStateManager.setAuthenticated(authResponse.user.toDomain())
                 saveToken(authResponse.accessToken, authResponse.refreshToken)
+                syncGuestInvitations()
             }
+    }
+
+    private suspend fun syncGuestInvitations() {
+        val invitationIds = userStorage.getInvitationIds()
+
+        if (invitationIds.isNotEmpty()) {
+            val syncResult = userRemoteDataSource.syncInvitations(invitationIds)
+
+            if (syncResult is Result.Success) {
+                userStorage.clearGuestData()
+            }
+        }
     }
 
     override suspend fun guestLogin(): Result<Unit, InvitationError> {

--- a/android/core/datastore/src/main/kotlin/com/andlife/datastore/UserStorage.kt
+++ b/android/core/datastore/src/main/kotlin/com/andlife/datastore/UserStorage.kt
@@ -18,15 +18,10 @@ class UserStorage @Inject constructor(
     @param:ApplicationContext private val context: Context
 ) {
     companion object {
-        private val USER_ID = longPreferencesKey("USER_ID")
         private val GUEST_INVITATION_IDS = stringSetPreferencesKey("GUEST_INVITATION_IDS")
         private val ACCESS_TOKEN = stringPreferencesKey("access_token")
         private val REFRESH_TOKEN = stringPreferencesKey("refresh_token")
         private val WAS_LOGGED_IN = booleanPreferencesKey("was_logged_in")
-    }
-
-    fun getUserId(): Long? = runBlocking {
-        context.dataStore.data.first()[USER_ID]
     }
 
     fun getInvitationIds(): List<Long> = runBlocking {

--- a/android/core/datastore/src/main/kotlin/com/andlife/datastore/UserStorage.kt
+++ b/android/core/datastore/src/main/kotlin/com/andlife/datastore/UserStorage.kt
@@ -34,16 +34,6 @@ class UserStorage @Inject constructor(
         ids.mapNotNull { it.toLongOrNull() }
     }
 
-    suspend fun saveUserId(userId: Long) {
-        context.dataStore.edit { it[USER_ID] = userId }
-    }
-
-    suspend fun clearUserSession() {
-        context.dataStore.edit { prefs ->
-            prefs.remove(USER_ID)
-        }
-    }
-
     suspend fun addInvitationId(invitationId: Long) {
         context.dataStore.edit { prefs ->
             val currentIds = prefs[GUEST_INVITATION_IDS] ?: emptySet()

--- a/android/core/network/src/main/kotlin/com/andlife/network/api/invitation/InvitationService.kt
+++ b/android/core/network/src/main/kotlin/com/andlife/network/api/invitation/InvitationService.kt
@@ -18,6 +18,11 @@ import retrofit2.http.Query
 
 interface InvitationService {
 
+    @POST("/api/invitations/sync")
+    suspend fun syncInvitations(
+        @Body invitationIds: List<Long>
+    ): BaseResponse<Unit>
+
     @POST("/api/invitations/{invitationId}/join")
     suspend fun joinInvitation(
         @Path("invitationId") invitationId: Long

--- a/android/core/network/src/main/kotlin/com/andlife/network/auth/AuthTokenProvider.kt
+++ b/android/core/network/src/main/kotlin/com/andlife/network/auth/AuthTokenProvider.kt
@@ -1,7 +1,6 @@
 package com.andlife.network.auth
 
 interface AuthTokenProvider {
-    fun getUserId(): Long?
     fun getInvitationIds(): List<Long>
     suspend fun getAccessToken(): String?
     suspend fun getRefreshToken(): String?

--- a/android/domain/src/main/kotlin/com/andlife/domain/repository/user/UserRepository.kt
+++ b/android/domain/src/main/kotlin/com/andlife/domain/repository/user/UserRepository.kt
@@ -6,9 +6,6 @@ import com.andlife.domain.model.auth.AuthState
 import com.andlife.domain.util.Result
 
 interface UserRepository {
-    fun getUserId(): Long?
-    suspend fun saveUserId(userId: Long)
-    suspend fun clearUserSession()
     suspend fun login(accessToken: String): Result<Unit, DataError>
     suspend fun guestLogin(): Result<Unit, InvitationError>
     suspend fun initializeAuth(): Result<AuthState, DataError>

--- a/android/feature/invitation-edit/src/main/kotlin/com/andlife/invitation_edit/viewmodel/InvitationCreateViewModel.kt
+++ b/android/feature/invitation-edit/src/main/kotlin/com/andlife/invitation_edit/viewmodel/InvitationCreateViewModel.kt
@@ -26,6 +26,7 @@ import com.andlife.model.editor.CardImage
 import com.andlife.model.editor.NachoUiCard
 import com.andlife.model.editor.toDomain
 import com.andlife.domain.util.RefreshEventHub
+import com.andlife.domain.util.RefreshEventHub.RefreshTarget
 import com.andlife.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList
@@ -225,7 +226,8 @@ class InvitationCreateViewModel @Inject constructor(
                 .onSuccess { id ->
                     updateState { copy(isLoading = false) }
                     createCardSession.clear()
-                    RefreshEventHub.emit(RefreshEventHub.RefreshTarget.ALL)
+                    RefreshEventHub.emit(RefreshTarget.MY_INVITATION)
+                    RefreshEventHub.emit(RefreshTarget.HOME)
                     sendEffect(InvitationFormSideEffect.SuccessSave(id))
                 }
                 .onFailure { error, msg ->

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationDetailViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationDetailViewModel.kt
@@ -57,7 +57,8 @@ class InvitationDetailViewModel @Inject constructor(
 
         invitationRepository.joinInvitation(invitationId)
             .onSuccess {
-                RefreshEventHub.emit(RefreshTarget.ALL)
+                RefreshEventHub.emit(RefreshTarget.HOME)
+                RefreshEventHub.emit(RefreshTarget.INVITATION)
                 loadInvitation()
             }
             .onFailure { error, _ ->

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationViewModel.kt
@@ -8,6 +8,8 @@ import androidx.paging.map
 import com.andlife.domain.model.invitation.InvitationStatus
 import com.andlife.domain.model.invitation.SortDirection
 import com.andlife.domain.repository.invitation.InvitationRepository
+import com.andlife.domain.util.RefreshEventHub
+import com.andlife.domain.util.RefreshEventHub.RefreshTarget
 import com.andlife.domain.util.onFailure
 import com.andlife.domain.util.onSuccess
 import com.andlife.invitation.model.InvitationSideEffect
@@ -116,6 +118,7 @@ class InvitationViewModel @Inject constructor(
             invitationRepository.leaveInvitation(invitationId)
                 .onSuccess {
                     sendEffect(InvitationSideEffect.LeaveSuccess)
+                    RefreshEventHub.emit(RefreshTarget.HOME)
                 }
                 .onFailure { it, msg ->
                     sendEffect(InvitationSideEffect.LeaveFailure)

--- a/backend/src/main/kotlin/com/andlife/nachoserver/controller/invitation/InvitationController.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/controller/invitation/InvitationController.kt
@@ -35,6 +35,22 @@ class InvitationController(
     private val invitationService: InvitationService,
     private val guestBookService: GuestBookService,
 ) {
+    @PostMapping("/sync")
+    fun syncInvitations(
+        @RequestBody invitationIds: List<Long>,
+        authContext: AuthContext
+    ): BaseResponse<Unit> {
+        return when (authContext) {
+            is AuthContext.Member -> {
+                invitationService.syncInvitations(authContext.userId, invitationIds)
+                BaseResponse.success(Unit)
+            }
+            is AuthContext.Guest -> {
+                BaseResponse.error(CommonResponseCode.UNAUTHORIZED)
+            }
+        }
+    }
+
     @PostMapping("/{invitationId}/join")
     fun joinInvitation(
         @PathVariable invitationId: Long,

--- a/backend/src/main/kotlin/com/andlife/nachoserver/service/invitation/InvitationService.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/service/invitation/InvitationService.kt
@@ -43,10 +43,26 @@ class InvitationService(
     private val announcementRepository: AnnouncementRepository,
     private val participantRepository: InvitationParticipantRepository,
     private val userRepository: UserRepository,
-    private val guestBookRepository: GuestBookRepository,
     private val guestBookService: GuestBookService,
     private val thanksCardRepository: ThanksCardRepository
 ) {
+    @Transactional
+    fun syncInvitations(userId: Long, invitationIds: List<Long>) {
+        val user = userRepository.findById(userId)
+            .orElseThrow { NoSuchElementException("사용자를 찾을 수 없습니다. ID: $userId") }
+
+        invitationIds.forEach { invitationId ->
+            if (!participantRepository.existsByInvitationIdAndUserId(invitationId, userId)) {
+                invitationRepository.findById(invitationId).ifPresent { invitation ->
+                    participantRepository.save(
+                        InvitationParticipant(user = user, invitation = invitation)
+                    )
+                    println(">>> [Sync 성공] User${userId} → Invitation ID: $invitationId")
+                }
+            }
+        }
+    }
+
     @Transactional
     fun joinInvitation(
         invitationId: Long,


### PR DESCRIPTION
## 🔍 변경 사항
> 이번 PR에서 변경된 핵심 내용을 간단히 설명해주세요.

- [x] 로컬에 ID를 저장하던 로직들 삭제
- [x] 로그인 시 로컬에 가지고 있던 초대장들을 추가하여 싱크를 맞추도록 구현
  - [x] 추가에 성공할 경우 로컬에 저장된 ID들은 제거 
- [x] 초대장을 나갔을 때 Home 화면도 새로고침 되도록 수정
- [ ] 로그아웃 시 각 탭 페이징 소스 초기화

로그아웃 시 각 탭 페이징 소스 초기화 작업은 문제 상황이 발생 중인가 싶어서 
재연해보기 위해 로그인, 비로그인을 반복하면서 초대장 데이터도 추가/삭제 해봤는데
재연이 되지 않아서 NavGraph 쪽 코드를 보니
로그아웃 시 기존 화면들을 스택에서 다 제거하는 것을 보고
기존 ViewModel들이 다 사라지기 때문에 대응이 된 것으로 생각되어 따로 작업하지 않았습니다.

## 📸 스크린샷 (선택)
> UI 변경 사항이 있다면 이미지를 첨부해주세요.

https://github.com/user-attachments/assets/6d25f4b9-b644-4efa-b3d1-e04315a7b54e


## 🔗 관련 이슈
> 해당 PR과 연결된 이슈 번호를 적어주세요. (예: #1)

- #154 

## ✅ 체크리스트
- [x] 팀 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 import는 삭제했나요?
