### PR TITLE
Fix/#158 방명록 정렬 및 초대장 작성자의 방명록 삭제 기능

### DIFF
--- a/android/core/data/src/main/kotlin/com/andlife/data/repository/guestbook/GuestBookMapper.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/repository/guestbook/GuestBookMapper.kt
@@ -36,6 +36,7 @@ fun GuestBookResponse.toDomain(): GuestBook =
         audioMedias = audioMedias.map { it.toDomain() },
         totalVisualCount = totalVisualCount,
         isOwner = isOwner,
+        isInvitationOwner = isInvitationOwner,
         createdAt = createdAt,
         updatedAt = updatedAt,
     )

--- a/android/core/network/src/main/kotlin/com/andlife/network/model/guestbook/GuestBookResponse.kt
+++ b/android/core/network/src/main/kotlin/com/andlife/network/model/guestbook/GuestBookResponse.kt
@@ -17,6 +17,7 @@ data class GuestBookResponse(
     val audioMedias: List<GuestBookMediaResponse>,
     val totalVisualCount: Int,
     val isOwner: Boolean,
+    val isInvitationOwner: Boolean,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime,
 )

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/guestbook/GuestBookItem.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/guestbook/GuestBookItem.kt
@@ -120,7 +120,8 @@ fun GuestBookItem(
         GuestBookItemHeader(
             author = guestBook.author,
             createdAt = guestBook.createdAt,
-            isOwner = useMenuButton && guestBook.isOwner,
+            canEdit = useMenuButton && guestBook.isOwner,
+            canDelete = useMenuButton && (guestBook.isOwner || guestBook.isInvitationOwner),
             onEditClick = { onEditClick(guestBook) },
             onDeleteClick = { onDeleteClick(guestBook) },
         )
@@ -157,7 +158,8 @@ fun GuestBookItem(
 private fun GuestBookItemHeader(
     author: AuthorUiModel,
     createdAt: LocalDateTime,
-    isOwner: Boolean,
+    canEdit: Boolean,
+    canDelete: Boolean,
     onEditClick: () -> Unit,
     onDeleteClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -201,7 +203,7 @@ private fun GuestBookItemHeader(
                 color = NachoTheme.colorScheme.textTertiary,
             )
         }
-        if (isOwner) {
+        if (canEdit || canDelete) {
             Box {
                 IconButton(onClick = { isMenuExpanded = true }) {
                     Icon(
@@ -217,32 +219,36 @@ private fun GuestBookItemHeader(
                     containerColor = NachoTheme.colorScheme.backgroundPrimary,
                     shape = NachoTheme.shapes.medium,
                 ) {
-                    Text(
-                        text = stringResource(R.string.txt_label_edit),
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .clickable {
-                                    isMenuExpanded = false
-                                    onEditClick()
-                                }
-                                .padding(NachoSpacing.large),
-                        style = NachoTheme.typography.bodyMediumMedium,
-                        color = NachoTheme.colorScheme.textPrimary,
-                    )
-                    Text(
-                        text = stringResource(R.string.txt_label_delete),
-                        modifier =
-                            Modifier
-                                .fillMaxWidth()
-                                .clickable {
-                                    isMenuExpanded = false
-                                    onDeleteClick()
-                                }
-                                .padding(NachoSpacing.large),
-                        style = NachoTheme.typography.bodyMediumMedium,
-                        color = NachoTheme.colorScheme.textPrimary,
-                    )
+                    if (canEdit) {
+                        Text(
+                            text = stringResource(R.string.txt_label_edit),
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .clickable {
+                                        isMenuExpanded = false
+                                        onEditClick()
+                                    }
+                                    .padding(NachoSpacing.large),
+                            style = NachoTheme.typography.bodyMediumMedium,
+                            color = NachoTheme.colorScheme.textPrimary,
+                        )
+                    }
+                    if (canDelete) {
+                        Text(
+                            text = stringResource(R.string.txt_label_delete),
+                            modifier =
+                                Modifier
+                                    .fillMaxWidth()
+                                    .clickable {
+                                        isMenuExpanded = false
+                                        onDeleteClick()
+                                    }
+                                    .padding(NachoSpacing.large),
+                            style = NachoTheme.typography.bodyMediumMedium,
+                            color = NachoTheme.colorScheme.textPrimary,
+                        )
+                    }
                 }
             }
         }
@@ -796,6 +802,7 @@ private fun GuestBookItemPreview() {
                                 ).toImmutableList(),
                             totalVisualCount = 2,
                             isOwner = true,
+                            isInvitationOwner = false,
                             createdAt = LocalDateTime(2025, 6, 1, 12, 0),
                             updatedAt = LocalDateTime(2025, 6, 1, 12, 0),
                         ),
@@ -858,6 +865,7 @@ private fun GuestBookItemPreview() {
                                 ).toImmutableList(),
                             totalVisualCount = 2,
                             isOwner = true,
+                            isInvitationOwner = false,
                             createdAt = LocalDateTime(2025, 6, 1, 12, 0),
                             updatedAt = LocalDateTime(2025, 6, 1, 12, 0),
                         ),

--- a/android/domain/src/main/kotlin/com/andlife/domain/model/guestbook/GuestBook.kt
+++ b/android/domain/src/main/kotlin/com/andlife/domain/model/guestbook/GuestBook.kt
@@ -11,6 +11,7 @@ data class GuestBook(
     val audioMedias: List<GuestBookMedia>,
     val totalVisualCount: Int,
     val isOwner: Boolean,
+    val isInvitationOwner: Boolean,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime,
 )

--- a/android/feature/home/src/main/kotlin/com/andlife/home/screen/HomeScreen.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/screen/HomeScreen.kt
@@ -625,7 +625,7 @@ private fun LazyListScope.homeGuestBookSection(
                     onInvitationTitleClick = {
                         onInvitationTitleClick(
                             guestBook.invitation?.id ?: -1L,
-                            guestBook.isOwner,
+                            guestBook.isInvitationOwner,
                         )
                     },
                     onVisualMediaClick = { onVisualMediaClick(it.url) },

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
@@ -706,6 +706,7 @@ private fun InvitationGuestBookResultPreview() {
             ).toImmutableList(),
             totalVisualCount = 0,
             isOwner = true,
+            isInvitationOwner = false,
             createdAt = LocalDateTime(2026, 1, 20, 10, 0),
             updatedAt = LocalDateTime(2026, 1, 20, 10, 0),
         ),
@@ -717,6 +718,7 @@ private fun InvitationGuestBookResultPreview() {
             audioMedias = emptyList<GuestBookMediaUiModel>().toImmutableList(),
             totalVisualCount = 0,
             isOwner = false,
+            isInvitationOwner = false,
             createdAt = LocalDateTime(2026, 1, 19, 15, 30),
             updatedAt = LocalDateTime(2026, 1, 19, 15, 30),
         )

--- a/android/feature/model/src/main/kotlin/com/andlife/model/guestbook/GuestBookUiModel.kt
+++ b/android/feature/model/src/main/kotlin/com/andlife/model/guestbook/GuestBookUiModel.kt
@@ -18,6 +18,7 @@ data class GuestBookUiModel(
     val audioMedias: ImmutableList<GuestBookMediaUiModel>,
     val totalVisualCount: Int,
     val isOwner: Boolean,
+    val isInvitationOwner: Boolean,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime,
 )
@@ -31,6 +32,7 @@ fun GuestBook.toUiModel(): GuestBookUiModel = GuestBookUiModel(
     audioMedias = audioMedias.map { it.toUiModel() }.toImmutableList(),
     totalVisualCount = totalVisualCount,
     isOwner = isOwner,
+    isInvitationOwner = isInvitationOwner,
     createdAt = createdAt,
     updatedAt = updatedAt,
 )

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
@@ -708,6 +708,7 @@ private fun InvitationGuestBookResultPreview() {
             ).toImmutableList(),
             totalVisualCount = 0,
             isOwner = true,
+            isInvitationOwner = false,
             createdAt = LocalDateTime(2026, 1, 20, 10, 0),
             updatedAt = LocalDateTime(2026, 1, 20, 10, 0),
         ),
@@ -719,6 +720,7 @@ private fun InvitationGuestBookResultPreview() {
             audioMedias = emptyList<GuestBookMediaUiModel>().toImmutableList(),
             totalVisualCount = 0,
             isOwner = false,
+            isInvitationOwner = false,
             createdAt = LocalDateTime(2026, 1, 19, 15, 30),
             updatedAt = LocalDateTime(2026, 1, 19, 15, 30),
         )

--- a/backend/src/main/kotlin/com/andlife/nachoserver/controller/invitation/InvitationController.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/controller/invitation/InvitationController.kt
@@ -162,7 +162,7 @@ class InvitationController(
     fun getGuestBooks(
         @PathVariable invitationId: Long,
         authContext: AuthContext,
-        @PageableDefault(size = 10, sort = ["createdAt"], direction = Sort.Direction.DESC) pageable: Pageable
+        @PageableDefault(size = 10, sort = ["createdAt", "id"], direction = Sort.Direction.DESC) pageable: Pageable
     ): BaseResponse<PagingResponse<GuestBookResponse>> {
         val result = guestBookService.getGuestBooks(invitationId, pageable, authContext)
         return BaseResponse.success(result)
@@ -214,7 +214,7 @@ class InvitationController(
     @GetMapping("/guestbooks/all")
     fun getAllRelatedGuestBooks(
         authContext: AuthContext,
-        @PageableDefault(size = 10, sort = ["createdAt"], direction = Sort.Direction.DESC) pageable: Pageable
+        @PageableDefault(size = 10, sort = ["createdAt", "id"], direction = Sort.Direction.DESC) pageable: Pageable
     ): BaseResponse<PagingResponse<GuestBookResponse>> {
         val result = guestBookService.getAllRelatedGuestBooks(authContext, pageable)
         return BaseResponse.success(result)

--- a/backend/src/main/kotlin/com/andlife/nachoserver/repository/guestbook/GuestBookRepository.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/repository/guestbook/GuestBookRepository.kt
@@ -35,7 +35,7 @@ interface GuestBookRepository : JpaRepository<GuestBook, Long> {
             JOIN FETCH i.host h
             LEFT JOIN InvitationParticipant ip ON i.id = ip.invitation.id
             WHERE (h.id = :userId OR ip.user.id = :userId)
-            ORDER BY gb.createdAt DESC
+            ORDER BY gb.createdAt DESC, gb.id DESC
     """)
     fun findAllByMyRelatedInvitations(
         @Param("userId") userId: Long,

--- a/backend/src/main/kotlin/com/andlife/nachoserver/repository/guestbook/GuestBookRepository.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/repository/guestbook/GuestBookRepository.kt
@@ -21,7 +21,6 @@ interface GuestBookRepository : JpaRepository<GuestBook, Long> {
         JOIN FETCH gb.user
         JOIN FETCH gb.invitation
         WHERE gb.invitation.id = :invitationId
-        ORDER BY gb.createdAt DESC, gb.id DESC
     """
     )
     fun findAllByInvitationId(invitationId: Long, pageable: Pageable): Page<GuestBook>
@@ -35,7 +34,6 @@ interface GuestBookRepository : JpaRepository<GuestBook, Long> {
             JOIN FETCH i.host h
             LEFT JOIN InvitationParticipant ip ON i.id = ip.invitation.id
             WHERE (h.id = :userId OR ip.user.id = :userId)
-            ORDER BY gb.createdAt DESC, gb.id DESC
     """)
     fun findAllByMyRelatedInvitations(
         @Param("userId") userId: Long,

--- a/backend/src/main/kotlin/com/andlife/nachoserver/response/guestbook/GuestBookResponse.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/response/guestbook/GuestBookResponse.kt
@@ -14,6 +14,7 @@ data class GuestBookResponse(
     val audioMedias: List<GuestBookMediaResponse>,
     val totalVisualCount: Int,
     val isOwner: Boolean,
+    val isInvitationOwner: Boolean,
     val createdAt: LocalDateTime,
     val updatedAt: LocalDateTime,
 )
@@ -84,6 +85,7 @@ fun GuestBook.toGuestBookResponse(): GuestBookResponse {
         audioMedias = audioMedias.sortedBy { it.displayOrder },
         totalVisualCount = visualMedias.size,
         isOwner = true,
+        isInvitationOwner = false,
         createdAt = this.createdAt,
         updatedAt = this.updatedAt
     )

--- a/backend/src/main/kotlin/com/andlife/nachoserver/service/guestbook/GuestBookService.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/service/guestbook/GuestBookService.kt
@@ -106,6 +106,7 @@ class GuestBookService(
                 is AuthContext.Member -> authContext.userId == guestBook.user.id
                 is AuthContext.Guest -> false
             }
+            val isInvitationOwner = (authContext is AuthContext.Member && guestBook.invitation.host.id == authContext.userId)
 
             val allMedia = mutableListOf<GuestBookMediaResponse>()
 
@@ -154,6 +155,7 @@ class GuestBookService(
                 audioMedias = audioMedias,
                 totalVisualCount = visualMedias.size,
                 isOwner = isOwner,
+                isInvitationOwner = isInvitationOwner,
                 createdAt = guestBook.createdAt,
                 updatedAt = guestBook.updatedAt
             )
@@ -395,6 +397,7 @@ class GuestBookService(
 
             val (audioMedias, visualMedias) = allMedia.partition { it.type == MediaType.AUDIO }
             val isOwner = (authContext is AuthContext.Member && guestBook.user.id == authContext.userId)
+            val isInvitationOwner = (authContext is AuthContext.Member && guestBook.invitation.host.id == authContext.userId)
 
             GuestBookResponse(
                 id = guestBook.id,
@@ -412,8 +415,9 @@ class GuestBookService(
                 audioMedias = audioMedias,
                 totalVisualCount = visualMedias.size,
                 isOwner = isOwner,
+                isInvitationOwner = isInvitationOwner,
                 createdAt = guestBook.createdAt,
-                updatedAt = guestBook.updatedAt
+                updatedAt = guestBook.updatedAt,
             )
         }
 

--- a/backend/src/main/kotlin/com/andlife/nachoserver/service/guestbook/GuestBookService.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/service/guestbook/GuestBookService.kt
@@ -323,7 +323,7 @@ class GuestBookService(
         val guestBook = guestBookRepository.findByIdOrNull(guestBookId)
             ?: throw EntityNotFoundException("방명록을 찾을 수 없습니다. id: $guestBookId")
 
-        validateOwner(guestBook.user.id, authContext)
+        validateOwnerOrInvitationHost(guestBook, authContext)
 
         val mediaKeys = getAllMediaKeys(guestBook)
         guestBookRepository.delete(guestBook)
@@ -341,6 +341,22 @@ class GuestBookService(
         allMediaKeys.forEach { key ->
             if (key.isNotBlank()) {
                 mediaService.deleteMedia(key)
+            }
+        }
+    }
+
+    private fun validateOwnerOrInvitationHost(guestBook: GuestBook, authContext: AuthContext) {
+        when (authContext) {
+            is AuthContext.Member -> {
+                val isGuestBookOwner = guestBook.user.id == authContext.userId
+                val isInvitationHost = guestBook.invitation.host.id == authContext.userId
+                if (!isGuestBookOwner && !isInvitationHost) {
+                    throw BusinessException(CommonResponseCode.FORBIDDEN)
+                }
+            }
+
+            is AuthContext.Guest -> {
+                throw BusinessException(CommonResponseCode.FORBIDDEN)
             }
         }
     }


### PR DESCRIPTION
## 🔍 변경 사항
- 방명록 데이터와 홈 데이터 정렬 기준 통일
  - 기존에 JPQL의 ORDER BY와 Pageable의 Sort가 둘다 들어가 있어서 Pageable의 Sort에만 의존하도록 남겨놓았습니다.
    - Repository JPQL: ORDER BY gb.createdAt DESC, gb.id DESC                                  
    - Controller Pageable: sort = ["createdAt"], direction = Sort.Direction.DESC    --> 이것만 정렬 기준으로 사용하도록
  - 추가로 시간이 같은 경우에는 id를 2차 정렬 조건으로 넣어주었습니다.
    -  @PageableDefault(size = 10, sort = ["createdAt", "id"], direction = Sort.Direction.DESC) pageable: Pageable
- 홈화면에서 최근 게시글 방명록 눌렀을 때 분기 처리 로직
  - 기존에는 방명록 작성자(isOwner) 기준 분기 처리되었어서, 초대장 작성자(isInvitationOwner) 기준으로 변경하였습니다.
- 내가 만든 초대장이라면 방명록을 삭제할 수 있도록 적용하였습니다.

## 🔗 관련 이슈
- Close #158

## ✅ 체크리스트
- [x] 팀 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 import는 삭제했나요?
