### PR TITLE
fix: timeSeconds 필드에 저장되는 값 썸네일지점 -> 영상 길이 로 수정

### DIFF
--- a/backend/src/main/kotlin/com/andlife/nachoserver/service/guestbook/GuestBookService.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/service/guestbook/GuestBookService.kt
@@ -228,7 +228,7 @@ class GuestBookService(
                         val previewThumbnail = VideoPreviewThumbnail(
                             video = video,
                             thumbnailUrl = mediaReq.thumbnailUrl,
-                            timeSeconds = 1.0 // 1초 지점의 썸네일: 이후 규칙이 변경되면 해당 부분도 수정 필요
+                            timeSeconds = if (mediaReq.durationSeconds != null) mediaReq.durationSeconds.toDouble() else 0.0,
                         )
                         video.previewThumbnails.add(previewThumbnail)
                     }


### PR DESCRIPTION
## 🔍 변경 사항
guestbook_audios, guestbook_videos 테이블의 duration은 제 로컬에서는 잘 저장되고 있어서 일단 이 부분만 고쳐두었습니다..!

## 📸 스크린샷 (선택)

## 🔗 관련 이슈
- Close #164

## ✅ 체크리스트
- [x] 팀 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 import는 삭제했나요?
