### PR TITLE
2차 QA 로그인하러가기 navoptions 제거 

### DIFF
--- a/android/app/src/main/kotlin/com/andlife/nacho/navigation/NachoNavigator.kt
+++ b/android/app/src/main/kotlin/com/andlife/nacho/navigation/NachoNavigator.kt
@@ -147,7 +147,7 @@ class NachoNavigator(
         navController.navigateToUpdateCard(cardId)
     }
 
-    fun navigateToLogin(navOptions: NavOptions) {
+    fun navigateToLogin(navOptions: NavOptions? = null) {
         navController.navigateToLogin(navOptions)
     }
 

--- a/android/app/src/main/kotlin/com/andlife/nacho/navigation/NavHost.kt
+++ b/android/app/src/main/kotlin/com/andlife/nacho/navigation/NavHost.kt
@@ -77,15 +77,7 @@ fun NachoNavHost(
                 paddingValues = innerPadding,
                 snackbarHostState = snackbarHostState,
                 onNavigateToCreate = navigator::navigateToMyInvitationCreate,
-                onNavigateToLogin = {
-                    val navOptions = navOptions {
-                        popUpTo(navigator.navController.graph.id) {
-                            inclusive = true
-                        }
-                        launchSingleTop = true
-                    }
-                    navigator.navigateToLogin(navOptions)
-                },
+                onNavigateToLogin = { navigator.navigateToLogin() },
                 onNavigateToInvitationDetail = navigator::navigateToInvitationDetail,
                 onNavigateToMyInvitationDetail = navigator::navigateToMyInvitationDetail,
                 onNavigateToSetting = navigator::navigateToSetting,
@@ -94,6 +86,9 @@ fun NachoNavHost(
             settingNavGraph(
                 onNavigateBack = navigator::navigatePopBackStack,
                 onNavigateToLogin = {
+                    navigator.navigateToLogin()
+                },
+                onLogout = {
                     val navOptions = navOptions {
                         popUpTo(navigator.navController.graph.id) {
                             inclusive = true
@@ -113,15 +108,7 @@ fun NachoNavHost(
             invitationDetailNavGraph(
                 deepLinks = navDeepLink { uriPattern = deepLinkManager.getKakaoDeepLinkPattern() },
                 onNavigateBack = navigator::navigatePopBackStack,
-                onNavigateToLogin = {
-                    val navOptions = navOptions {
-                        popUpTo(navigator.navController.graph.id) {
-                            inclusive = true
-                        }
-                        launchSingleTop = true
-                    }
-                    navigator.navigateToLogin(navOptions)
-                }
+                onNavigateToLogin = { navigator.navigateToLogin() }
             )
 
             myInvitationNavGraph(
@@ -129,14 +116,7 @@ fun NachoNavHost(
                 paddingValues = innerPadding,
                 onNavigateToCreate = navigator::navigateToMyInvitationCreate,
                 onNavigateToDetail = navigator::navigateToMyInvitationDetail,
-                onNavigateToLogin = {
-                    val navOptions = navOptions {
-                        popUpTo(navigator.navController.graph.id) {
-                            inclusive = true
-                        }
-                        launchSingleTop = true
-                    }
-                    navigator.navigateToLogin(navOptions)
+                onNavigateToLogin = { navigator.navigateToLogin()
                 }
             )
 

--- a/android/core/designsystem/src/main/kotlin/com/andlife/designsystem/component/NachoButton.kt
+++ b/android/core/designsystem/src/main/kotlin/com/andlife/designsystem/component/NachoButton.kt
@@ -37,6 +37,8 @@ fun NachoButton(
         ),
     containerColor: Color = NachoTheme.colorScheme.brandPrimary,
     contentColor: Color = NachoTheme.colorScheme.brandOnPrimary,
+    disabledContainerColor: Color = Color.Unspecified,
+    disabledContentColor: Color = Color.Unspecified,
     content: @Composable RowScope.() -> Unit,
 ) {
     Button(
@@ -48,6 +50,8 @@ fun NachoButton(
             ButtonDefaults.buttonColors(
                 containerColor = containerColor,
                 contentColor = contentColor,
+                disabledContainerColor = disabledContainerColor,
+                disabledContentColor = disabledContentColor,
             ),
         elevation = elevation,
         contentPadding = contentPadding,

--- a/android/feature/home/src/main/kotlin/com/andlife/home/HomeNavGraph.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/HomeNavGraph.kt
@@ -69,12 +69,14 @@ fun NavGraphBuilder.homeNavGraph(
 fun NavGraphBuilder.settingNavGraph(
     onNavigateBack: () -> Unit,
     onNavigateToLogin: () -> Unit,
+    onLogout: () -> Unit,
 ) {
     composable<Setting> {
         SettingRoute(
             onNavigateBack = onNavigateBack,
             modifier = Modifier.padding(),
-            onNavigateToLogin = onNavigateToLogin
+            onNavigateToLogin = onNavigateToLogin,
+            onLogout = onLogout
         )
     }
 }

--- a/android/feature/home/src/main/kotlin/com/andlife/home/screen/SettingScreen.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/screen/SettingScreen.kt
@@ -68,6 +68,7 @@ import com.andlife.designsystem.R as designR
 fun SettingRoute(
     onNavigateBack: () -> Unit,
     onNavigateToLogin: () -> Unit,
+    onLogout: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: SettingViewModel = hiltViewModel()
 ) {
@@ -87,7 +88,7 @@ fun SettingRoute(
         when (effect) {
             SettingSideEffect.NavigateToLogin -> {
                 isLogoutDialogVisible = false
-                onNavigateToLogin()
+                onLogout()
             }
 
             SettingSideEffect.PopBackStack -> {
@@ -193,7 +194,7 @@ fun SettingScreen(
                     .fillMaxWidth()
                     .padding(paddingValues)
                     .verticalScroll(scrollState)
-                    .padding(vertical = NachoSpacing.twoXLarge, horizontal = NachoSpacing.medium),
+                    .padding(vertical = NachoSpacing.twoXLarge),
                 verticalArrangement = Arrangement.spacedBy(NachoSpacing.large),
             ) {
 
@@ -206,7 +207,7 @@ fun SettingScreen(
                         onNameChange = { nameState = it },
                         onClickImage = {},
                         onClickEdit = {},
-                        modifier = Modifier.padding(vertical = NachoSpacing.medium),
+                        modifier = Modifier.padding(vertical = NachoSpacing.medium, horizontal = NachoSpacing.large),
                     )
                 }
 
@@ -241,6 +242,7 @@ fun SettingScreen(
                     showDivider = false
                 ) { modifier ->
                     AccountContent(
+                        authState = uiState.authState,
                         onClickLogout = onClickLogout,
                         onClickQuit = onClickQuit,
                         modifier = modifier,
@@ -309,13 +311,12 @@ private fun SettingSection(
                 color = NachoTheme.colorScheme.textSecondary,
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(NachoSpacing.small),
+                    .padding(vertical = NachoSpacing.small, horizontal = NachoSpacing.large),
             )
         }
 
         val contentModifier = Modifier.padding(
             vertical = NachoSpacing.medium,
-            horizontal = NachoSpacing.medium,
         )
         content(contentModifier)
 
@@ -469,7 +470,9 @@ private fun NotificationContent(
     modifier: Modifier = Modifier,
 ) {
     Row(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = NachoSpacing.large),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically,
     ) {
@@ -499,7 +502,9 @@ private fun PolicyContent(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier.fillMaxWidth()
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = NachoSpacing.large),
     ) {
         Row(
             modifier = Modifier
@@ -556,7 +561,9 @@ private fun AppInfoContent(
     modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = modifier.fillMaxWidth(),
+        modifier = modifier
+            .fillMaxWidth()
+            .padding(horizontal = NachoSpacing.large),
     ) {
         Row(
             modifier = Modifier
@@ -602,18 +609,20 @@ private fun AppInfoContent(
 
 @Composable
 private fun AccountContent(
+    authState: AuthState,
     onClickLogout: () -> Unit,
     onClickQuit: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(
-        modifier = modifier.fillMaxWidth(),
-    ) {
+    Column(modifier = modifier.fillMaxWidth()) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
-                .clickable { onClickLogout() }
-                .padding(vertical = NachoSpacing.medium),
+                .clickable(
+                    onClick = onClickLogout,
+                    enabled = authState is AuthState.Authenticated
+                )
+                .padding(horizontal = NachoSpacing.large, vertical = NachoSpacing.medium),
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
             Text(
@@ -635,8 +644,9 @@ private fun AccountContent(
         Row(
             modifier = Modifier
                 .fillMaxWidth()
+                .padding(vertical = NachoSpacing.medium)
                 .clickable { onClickQuit() }
-                .padding(vertical = NachoSpacing.medium),
+                .padding(horizontal = NachoSpacing.large, vertical = NachoSpacing.medium),
             horizontalArrangement = Arrangement.SpaceBetween,
         ) {
             Text(

--- a/android/feature/invitation-edit/src/main/kotlin/com/andlife/invitation_edit/section/AnnouncementSection.kt
+++ b/android/feature/invitation-edit/src/main/kotlin/com/andlife/invitation_edit/section/AnnouncementSection.kt
@@ -78,17 +78,17 @@ fun LazyListScope.announcementSection(
                     containerColor = NachoTheme.colorScheme.brandOnPrimary,
                     contentColor = NachoTheme.colorScheme.brandPrimary,
                     contentPadding = PaddingValues(horizontal = NachoSpacing.small, vertical = NachoSpacing.xSmall),
+                    disabledContainerColor = Color.Transparent,
+                    disabledContentColor = NachoTheme.colorScheme.textTertiary
                 ) {
                     Icon(
                         painter = painterResource(id = designR.drawable.ic_add_24),
                         contentDescription = stringResource(R.string.desc_add_announcement),
-                        tint = NachoTheme.colorScheme.brandPrimary,
                     )
                     Spacer(Modifier.width(NachoSpacing.small))
                     Text(
                         text = stringResource(R.string.txt_add_announcement),
                         style = NachoTheme.typography.bodyMediumMedium,
-                        color = NachoTheme.colorScheme.brandPrimary,
                     )
                 }
             }

--- a/android/feature/invitation-edit/src/main/kotlin/com/andlife/invitation_edit/section/CardSection.kt
+++ b/android/feature/invitation-edit/src/main/kotlin/com/andlife/invitation_edit/section/CardSection.kt
@@ -75,17 +75,17 @@ fun CardSection(
                     containerColor = NachoTheme.colorScheme.brandOnPrimary,
                     contentColor = NachoTheme.colorScheme.brandPrimary,
                     contentPadding = PaddingValues(horizontal = NachoSpacing.small, vertical = NachoSpacing.xSmall),
+                    disabledContainerColor = Color.Transparent,
+                    disabledContentColor = NachoTheme.colorScheme.textTertiary
                 ) {
                     Icon(
                         painter = painterResource(iconRes),
                         contentDescription = stringResource(buttonDescRes),
-                        tint = NachoTheme.colorScheme.brandPrimary,
                     )
                     Spacer(Modifier.width(NachoSpacing.small))
                     Text(
                         text = stringResource(buttonText),
                         style = NachoTheme.typography.bodyMediumMedium,
-                        color = NachoTheme.colorScheme.brandPrimary,
                     )
                 }
             }

--- a/android/feature/invitation-edit/src/main/kotlin/com/andlife/invitation_edit/section/TopBarSection.kt
+++ b/android/feature/invitation-edit/src/main/kotlin/com/andlife/invitation_edit/section/TopBarSection.kt
@@ -11,6 +11,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import com.andlife.designsystem.component.NachoButton
@@ -66,6 +67,8 @@ internal fun TopBarSection(
                     ),
                     containerColor = NachoTheme.colorScheme.brandOnPrimary,
                     contentColor = NachoTheme.colorScheme.brandPrimary,
+                    disabledContainerColor = Color.Transparent,
+                    disabledContentColor = NachoTheme.colorScheme.textTertiary
                 ) {
                     Text(
                         text = stringResource(R.string.txt_preview),

--- a/android/feature/login/src/main/kotlin/com/andlife/login/LoginNavGraph.kt
+++ b/android/feature/login/src/main/kotlin/com/andlife/login/LoginNavGraph.kt
@@ -11,7 +11,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data object Login
 
-fun NavController.navigateToLogin(navOptions: NavOptions) {
+fun NavController.navigateToLogin(navOptions: NavOptions?) {
     navigate(Login, navOptions)
 }
 


### PR DESCRIPTION
## 🔍 변경 사항
- [x] 비로그인 -> 로그인하러 가기 시 navoption 제거 (뒤로 가기 시 다시 이전에 있던 화면으로 이동)
- [x] 로그아웃: 로그인 유저만 클릭 가능하게 수정
- [x] 초대 생성: 생성 될 동안 NachoButton Container 색상 및 content enabled 색상 처리 

## 📸 스크린샷 (선택)
[Screen_recording_20260204_020142.webm](https://github.com/user-attachments/assets/aaa9aad8-4e52-4596-ab1b-988bf7615d95)

## ✅ 체크리스트
- [x] 팀 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 import는 삭제했나요?
