### PR TITLE
Fix/#174 미디어 다운로드 notification 버전 대응

### DIFF
--- a/android/core/data/src/main/kotlin/com/andlife/data/util/media/download/DownloadConstants.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/util/media/download/DownloadConstants.kt
@@ -56,8 +56,6 @@ object DownloadFile {
     const val MIME_IMAGE = "image/*"
     const val MIME_VIDEO = "video/*"
     const val MIME_AUDIO = "audio/*"
-    const val MIME_FOLDER_Q = "vnd.android.document/root"
-    const val URI_STORAGE_ROOT = "content://com.android.externalstorage.documents/root/primary"
 }
 
 object DownloadError {
@@ -67,4 +65,8 @@ object DownloadError {
     const val MISSING_BODY = "응답 본문이 없습니다."
     const val FAILED = "다운로드 실패: "
     const val UNKNOWN = "알 수 없는 오류"
+}
+
+object FileConstants {
+    const val FILE_SCHEMA = "file://"
 }

--- a/android/core/data/src/main/kotlin/com/andlife/data/util/media/download/DownloadConstants.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/util/media/download/DownloadConstants.kt
@@ -33,14 +33,17 @@ object DownloadNoti {
     const val CHANNEL_NAME_PROGRESS = "다운로드 진행 상태"
     const val CHANNEL_NAME_COMPLETE = "다운로드 완료 안내"
 
-    const val ID_COMPLETE_VISUAL = 1001
-    const val ID_COMPLETE_AUDIO = 1002
+    const val ID_COMPLETE_IMAGE = 1001
+    const val ID_COMPLETE_VIDEO = 1002
+    const val ID_COMPLETE_AUDIO = 1003
 
     const val TITLE_DOWNLOADING = "다운로드 중"
     const val MSG_PREPARING = "파일을 저장하고 있습니다."
+    const val TITLE_COMPLETE_IMAGE = "이미지 저장 완료"
+    const val TITLE_COMPLETE_VIDEO = "비디오 저장 완료"
     const val TITLE_COMPLETE_AUDIO = "오디오 저장 완료"
-    const val TITLE_COMPLETE_VISUAL = "미디어 저장 완료"
-    const val MSG_COMPLETE_SUFFIX = "개의 파일이 저장되었습니다."
+
+    const val MSG_COMPLETE = "파일이 저장되었습니다."
     const val ACTION_CANCEL = "취소"
 
     const val MSG_CANCELLED = "다운로드가 취소되었습니다."
@@ -55,10 +58,6 @@ object DownloadFile {
     const val MIME_AUDIO = "audio/*"
     const val MIME_FOLDER_Q = "vnd.android.document/root"
     const val URI_STORAGE_ROOT = "content://com.android.externalstorage.documents/root/primary"
-
-    const val PREF_NAME = "download_prefs"
-    const val KEY_COUNT_AUDIO = "audio_count"
-    const val KEY_COUNT_VISUAL = "visual_count"
 }
 
 object DownloadError {

--- a/android/core/data/src/main/kotlin/com/andlife/data/util/media/download/DownloadNotificationManager.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/util/media/download/DownloadNotificationManager.kt
@@ -77,25 +77,20 @@ class DownloadNotificationManager @Inject constructor(
     fun notifyComplete(fileName: String, mediaType: MediaType, savedUri: String) {
         val notificationManager =
             context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
-        val prefs = context.getSharedPreferences(DownloadFile.PREF_NAME, Context.MODE_PRIVATE)
 
-        val isAudio = mediaType == MediaType.AUDIO
-        val notificationId =
-            if (isAudio) DownloadNoti.ID_COMPLETE_AUDIO else DownloadNoti.ID_COMPLETE_VISUAL
-        val countKey =
-            if (isAudio) DownloadFile.KEY_COUNT_AUDIO else DownloadFile.KEY_COUNT_VISUAL
-
-        val currentCount = synchronized(DownloadNotificationManager::class.java) {
-            val activeNotification = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                notificationManager.activeNotifications.any { it.id == notificationId }
-            } else {
-                true
-            }
-
-            val newCount = if (!activeNotification) 1 else prefs.getInt(countKey, 0) + 1
-            prefs.edit().putInt(countKey, newCount).apply()
-            newCount
+        val notificationId = when (mediaType) {
+            MediaType.IMAGE -> DownloadNoti.ID_COMPLETE_IMAGE
+            MediaType.VIDEO -> DownloadNoti.ID_COMPLETE_VIDEO
+            MediaType.AUDIO -> DownloadNoti.ID_COMPLETE_AUDIO
         }
+
+        val title = when (mediaType) {
+            MediaType.IMAGE -> DownloadNoti.TITLE_COMPLETE_IMAGE
+            MediaType.VIDEO -> DownloadNoti.TITLE_COMPLETE_VIDEO
+            MediaType.AUDIO -> DownloadNoti.TITLE_COMPLETE_AUDIO
+        }
+
+        notificationManager.cancel(notificationId)
 
         val viewIntent = createViewIntent(mediaType, fileName, savedUri)
         val pendingIntent = PendingIntent.getActivity(
@@ -107,20 +102,16 @@ class DownloadNotificationManager @Inject constructor(
 
         val notification = NotificationCompat.Builder(context, DownloadNoti.CHANNEL_ID_COMPLETE)
             .setSmallIcon(R.drawable.stat_sys_download_done)
-            .setContentTitle(
-                if (isAudio) DownloadNoti.TITLE_COMPLETE_AUDIO else DownloadNoti.TITLE_COMPLETE_VISUAL,
-            )
-            .setContentText("$currentCount${DownloadNoti.MSG_COMPLETE_SUFFIX}")
+            .setContentTitle(title)
+            .setContentText(DownloadNoti.MSG_COMPLETE)
             .setSubText(fileName)
-            .setNumber(currentCount)
-            .setOnlyAlertOnce(true)
             .setAutoCancel(true)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setContentIntent(pendingIntent)
             .build()
 
         notificationManager.notify(notificationId, notification)
-        Log.d("DownloadNotificationManager", "알림 전송 완료: ID=$notificationId, 현재 카운트=$currentCount")
+        Log.d("DownloadNotificationManager", "알림 전송 완료: ID=$notificationId")
     }
 
     private fun createViewIntent(mediaType: MediaType, fileName: String, savedUri: String): Intent {

--- a/android/core/data/src/main/kotlin/com/andlife/data/util/media/download/DownloadNotificationManager.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/util/media/download/DownloadNotificationManager.kt
@@ -126,16 +126,17 @@ class DownloadNotificationManager @Inject constructor(
             }
 
             MediaType.AUDIO -> {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                    Intent(Intent.ACTION_VIEW).apply {
-                        setDataAndType(Uri.parse(savedUri), mimeType)
-                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_GRANT_READ_URI_PERMISSION)
-                    }
-                } else {
-                    Intent(Intent.ACTION_VIEW).apply {
-                        setDataAndType(Uri.parse(savedUri), mimeType)
+                val baseIntent = Intent(Intent.ACTION_VIEW).apply {
+                    setDataAndType(Uri.parse(savedUri), mimeType)
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_GRANT_READ_URI_PERMISSION)
+                }
+
+                if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+                    Intent.createChooser(baseIntent, null).apply {
                         addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                     }
+                } else {
+                    baseIntent
                 }
             }
         }

--- a/android/core/data/src/main/kotlin/com/andlife/data/util/media/download/DownloadNotificationManager.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/util/media/download/DownloadNotificationManager.kt
@@ -9,7 +9,6 @@ import android.content.Context
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
-import android.provider.MediaStore
 import android.util.Log
 import androidx.core.app.NotificationCompat
 import com.andlife.domain.model.guestbook.MediaType
@@ -47,7 +46,7 @@ class DownloadNotificationManager @Inject constructor(
         }
     }
 
-    fun createProgressNotification(workId: UUID, progress: Int): Notification {
+    fun createProgressNotification(workId: UUID, fileName: String, progress: Int): Notification {
         val cancelIntent = Intent(context, DownloadCancelReceiver::class.java).apply {
             putExtra(DownloadKey.EXTRA_WORK_ID, workId.toString())
         }
@@ -63,6 +62,7 @@ class DownloadNotificationManager @Inject constructor(
             .setSmallIcon(R.drawable.stat_sys_download)
             .setContentTitle(DownloadNoti.TITLE_DOWNLOADING)
             .setContentText(if (progress > 0) "$progress%" else DownloadNoti.MSG_PREPARING)
+            .setSubText(fileName)
             .setProgress(100, progress, progress <= 0)
             .setPriority(NotificationCompat.PRIORITY_LOW)
             .setOngoing(true)
@@ -74,7 +74,7 @@ class DownloadNotificationManager @Inject constructor(
             .build()
     }
 
-    fun notifyComplete(fileName: String, mediaType: MediaType) {
+    fun notifyComplete(fileName: String, mediaType: MediaType, savedUri: String) {
         val notificationManager =
             context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
         val prefs = context.getSharedPreferences(DownloadFile.PREF_NAME, Context.MODE_PRIVATE)
@@ -97,7 +97,7 @@ class DownloadNotificationManager @Inject constructor(
             newCount
         }
 
-        val viewIntent = createFolderViewIntent(mediaType, fileName)
+        val viewIntent = createViewIntent(mediaType, fileName, savedUri)
         val pendingIntent = PendingIntent.getActivity(
             context,
             notificationId,
@@ -123,35 +123,26 @@ class DownloadNotificationManager @Inject constructor(
         Log.d("DownloadNotificationManager", "알림 전송 완료: ID=$notificationId, 현재 카운트=$currentCount")
     }
 
-    private fun createFolderViewIntent(mediaType: MediaType, fileName: String): Intent {
+    private fun createViewIntent(mediaType: MediaType, fileName: String, savedUri: String): Intent {
         val mimeType = resolveMimeType(fileName, mediaType)
 
         return when (mediaType) {
             MediaType.IMAGE, MediaType.VIDEO -> {
                 Intent(Intent.ACTION_VIEW).apply {
-                    val uri = if (mediaType == MediaType.IMAGE) {
-                        MediaStore.Images.Media.EXTERNAL_CONTENT_URI
-                    } else {
-                        MediaStore.Video.Media.EXTERNAL_CONTENT_URI
-                    }
-                    val folderMimeType =
-                        if (mediaType == MediaType.IMAGE) DownloadFile.MIME_IMAGE else DownloadFile.MIME_VIDEO
-                    setDataAndType(uri, folderMimeType)
-                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                    setDataAndType(Uri.parse(savedUri), mimeType)
+                    addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_GRANT_READ_URI_PERMISSION)
                 }
             }
 
             MediaType.AUDIO -> {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                     Intent(Intent.ACTION_VIEW).apply {
-                        val rootUri = Uri.parse(DownloadFile.URI_STORAGE_ROOT)
-                        setDataAndType(rootUri, DownloadFile.MIME_FOLDER_Q)
-                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                        setDataAndType(Uri.parse(savedUri), mimeType)
+                        addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_GRANT_READ_URI_PERMISSION)
                     }
                 } else {
-                    Intent(Intent.ACTION_GET_CONTENT).apply {
-                        type = mimeType
-                        addCategory(Intent.CATEGORY_OPENABLE)
+                    Intent(Intent.ACTION_VIEW).apply {
+                        setDataAndType(Uri.parse(savedUri), mimeType)
                         addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
                     }
                 }

--- a/android/core/data/src/main/kotlin/com/andlife/data/util/media/download/DownloadWorker.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/util/media/download/DownloadWorker.kt
@@ -33,7 +33,8 @@ class DownloadWorker @AssistedInject constructor(
     private val uniqueNotificationId: Int by lazy { id.hashCode() }
 
     override suspend fun getForegroundInfo(): ForegroundInfo {
-        val notification = notificationManager.createProgressNotification(id, 0)
+        val fileName = inputData.getString(DownloadKey.FILE_NAME) ?: ""
+        val notification = notificationManager.createProgressNotification(id, fileName, 0)
         return buildForegroundInfo(notification)
     }
 
@@ -65,11 +66,11 @@ class DownloadWorker @AssistedInject constructor(
                     fileName = fileName,
                     mediaType = mediaType,
                     contentLength = body.contentLength(),
-                    onProgress = { progress -> updateProgress(progress) },
+                    onProgress = { progress -> updateProgress(fileName, progress) },
                     isStopped = { isStopped },
                 )
 
-                notificationManager.notifyComplete(fileName, mediaType)
+                notificationManager.notifyComplete(fileName, mediaType, uri)
                 Result.success(workDataOf(DownloadKey.RESULT_URL to uri))
             }
         } catch (e: Exception) {
@@ -82,13 +83,13 @@ class DownloadWorker @AssistedInject constructor(
         }
     }
 
-    private suspend fun updateProgress(progress: Int) {
+    private suspend fun updateProgress(fileName: String, progress: Int) {
         val progressData = workDataOf(
             DownloadKey.PROGRESS to progress,
         )
         setProgress(progressData)
 
-        val notification = notificationManager.createProgressNotification(id, progress)
+        val notification = notificationManager.createProgressNotification(id, fileName, progress)
         try {
             setForeground(buildForegroundInfo(notification))
         } catch (e: Exception) {

--- a/android/core/data/src/main/kotlin/com/andlife/data/util/media/download/DownloadWorker.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/util/media/download/DownloadWorker.kt
@@ -3,6 +3,8 @@ package com.andlife.data.util.media.download
 import android.app.Notification
 import android.content.Context
 import android.content.pm.ServiceInfo
+import android.media.MediaScannerConnection
+import android.net.Uri
 import android.os.Build
 import android.util.Log
 import androidx.hilt.work.HiltWorker
@@ -17,10 +19,12 @@ import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.job
+import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import kotlin.coroutines.cancellation.CancellationException
+import kotlin.coroutines.resume
 
 @HiltWorker
 class DownloadWorker @AssistedInject constructor(
@@ -74,7 +78,13 @@ class DownloadWorker @AssistedInject constructor(
                     isStopped = { isStopped },
                 )
 
-                notificationManager.notifyComplete(fileName, mediaType, uri)
+                val contentUri = if (uri.startsWith(FileConstants.FILE_SCHEMA)) {
+                    scanToContentUri(Uri.parse(uri).path ?: "") ?: uri
+                } else {
+                    uri
+                }
+                notificationManager.notifyComplete(fileName, mediaType, contentUri)
+
                 Result.success(workDataOf(DownloadKey.RESULT_URL to uri))
             }
         } catch (e: Exception) {
@@ -112,6 +122,17 @@ class DownloadWorker @AssistedInject constructor(
     fun errorData(message: String): Data {
         return workDataOf(DownloadKey.ERROR_MESSAGE to message)
     }
+
+    private suspend fun scanToContentUri(filePath: String): String? =
+        suspendCancellableCoroutine { cont ->
+            MediaScannerConnection.scanFile(
+                context,
+                arrayOf(filePath),
+                null
+            ) { _, contentUri ->
+                cont.resume(contentUri?.toString())
+            }
+        }
 
     companion object {
         private const val TAG = "DownloadWorker"

--- a/android/core/data/src/main/kotlin/com/andlife/data/util/media/download/DownloadWorker.kt
+++ b/android/core/data/src/main/kotlin/com/andlife/data/util/media/download/DownloadWorker.kt
@@ -16,6 +16,7 @@ import com.andlife.network.di.NachoMedia
 import dagger.assisted.Assisted
 import dagger.assisted.AssistedInject
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.job
 import kotlinx.coroutines.withContext
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -56,7 +57,10 @@ class DownloadWorker @AssistedInject constructor(
             setProgress(workDataOf(DownloadKey.PROGRESS to 0))
 
             val request = Request.Builder().url(url).build()
-            okHttpClient.newCall(request).execute().use { response ->
+            val call = okHttpClient.newCall(request)
+            coroutineContext.job.invokeOnCompletion { call.cancel() }
+            call.execute().use { response ->
+
                 if (!response.isSuccessful) throw Exception("${DownloadError.FAILED}${response.code}")
 
                 val body = checkNotNull(response.body) { DownloadError.MISSING_BODY }

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/util/ContextExtensions.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/util/ContextExtensions.kt
@@ -31,3 +31,8 @@ fun Context.shouldRequestStoragePermission(): Boolean {
     return Build.VERSION.SDK_INT <= Build.VERSION_CODES.P &&
         ContextCompat.checkSelfPermission(this, Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED
 }
+
+fun Context.shouldRequestNotificationPermission(): Boolean {
+    return Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+        ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED
+}

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/collection/InviatationStoryScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/collection/InviatationStoryScreen.kt
@@ -42,6 +42,7 @@ import com.andlife.ui.component.collection.StoryContent
 import com.andlife.ui.component.collection.StoryTopHeader
 import com.andlife.ui.component.dialog.NachoInfoDialog
 import com.andlife.ui.component.dialog.NachoPermissionDialog
+import com.andlife.ui.util.shouldRequestNotificationPermission
 import com.andlife.ui.util.shouldRequestStoragePermission
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
@@ -63,13 +64,32 @@ fun InvitationStoryRoute(
     val context = LocalContext.current
 
     var showPermissionDeniedDialog by remember { mutableStateOf(false) }
+    var showNotificationPermissionDeniedDialog by remember { mutableStateOf(false) }
     var showNetworkInfoDialog by remember { mutableStateOf(false) }
+
+    val notificationPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (!isGranted) {
+            showNotificationPermissionDeniedDialog = true
+        } else if (!uiState.networkDialogDismissed) {
+            showNetworkInfoDialog = true
+        } else {
+            viewModel.onEvent(InvitationCollectionUiEvent.DownloadMedia)
+        }
+    }
 
     val permissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission()
     ) { isGranted ->
         if (isGranted) {
-            viewModel.onEvent(InvitationCollectionUiEvent.DownloadMedia)
+            if (context.shouldRequestNotificationPermission()) {
+                notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            } else if (!uiState.networkDialogDismissed) {
+                showNetworkInfoDialog = true
+            } else {
+                viewModel.onEvent(InvitationCollectionUiEvent.DownloadMedia)
+            }
         } else {
             showPermissionDeniedDialog = true
         }
@@ -105,6 +125,8 @@ fun InvitationStoryRoute(
         onDownloadClick = {
             if (context.shouldRequestStoragePermission()) {
                 permissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            } else if (context.shouldRequestNotificationPermission()) {
+                notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
             } else if (!uiState.networkDialogDismissed) {
                 showNetworkInfoDialog = true
             } else {
@@ -134,6 +156,20 @@ fun InvitationStoryRoute(
         NachoPermissionDialog(
             message = stringResource(R.string.snack_permission_denied),
             onDismiss = { showPermissionDeniedDialog = false },
+        )
+    }
+
+    if (showNotificationPermissionDeniedDialog) {
+        NachoPermissionDialog(
+            message = stringResource(R.string.snack_notification_permission_denied),
+            onDismiss = {
+                showNotificationPermissionDeniedDialog = false
+                if (!uiState.networkDialogDismissed) {
+                    showNetworkInfoDialog = true
+                } else {
+                    viewModel.onEvent(InvitationCollectionUiEvent.DownloadMedia)
+                }
+            },
         )
     }
 }

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/collection/InviatationStoryScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/collection/InviatationStoryScreen.kt
@@ -162,14 +162,7 @@ fun InvitationStoryRoute(
     if (showNotificationPermissionDeniedDialog) {
         NachoPermissionDialog(
             message = stringResource(R.string.snack_notification_permission_denied),
-            onDismiss = {
-                showNotificationPermissionDeniedDialog = false
-                if (!uiState.networkDialogDismissed) {
-                    showNetworkInfoDialog = true
-                } else {
-                    viewModel.onEvent(InvitationCollectionUiEvent.DownloadMedia)
-                }
-            },
+            onDismiss = { showNotificationPermissionDeniedDialog = false },
         )
     }
 }

--- a/android/feature/invitation/src/main/res/values/strings.xml
+++ b/android/feature/invitation/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
 
     <string name="snack_download_fail">저장에 실패하였습니다</string>
     <string name="snack_permission_denied">파일을 저장하려면 저장공간 접근 권한이 필요합니다</string>
+    <string name="snack_notification_permission_denied">다운로드 진행 상태를 알림으로 받으려면 알림 권한이 필요합니다</string>
     <string name="snack_download_guide">다운로드 상태는 상단 알림창에서 확인 가능합니다</string>
 
     <string name="dialog_network_title">안내</string>

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/manager/KakaoShareManager.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/manager/KakaoShareManager.kt
@@ -24,7 +24,7 @@ class KakaoShareManager @Inject constructor(
         imageUrl: String?,
         date: String,
         location: String,
-    ) {
+    ): Boolean {
         val appsFlyerUrl = deepLinkManager.buildAppsFlyerUrl(invitationId)
         Log.d(TAG, "invitationId: $invitationId, appsFlyerUrl: $appsFlyerUrl")
 
@@ -72,8 +72,10 @@ class KakaoShareManager @Inject constructor(
                     context.startActivity(result.intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK))
                 }
             }
+            return true
         } else {
             Log.e(TAG, "KakaoTalk not available")
+            return false
         }
     }
 

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/model/detail/MyInvitationDetailSideEffect.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/model/detail/MyInvitationDetailSideEffect.kt
@@ -38,4 +38,6 @@ sealed interface MyInvitationDetailSideEffect : BaseSideEffect {
 
     data object InvitationDeleted : MyInvitationDetailSideEffect
     data object InvitationDeleteFailed : MyInvitationDetailSideEffect
+
+    data object KakaoTalkNotAvailable : MyInvitationDetailSideEffect
 }

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationDetailScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationDetailScreen.kt
@@ -171,6 +171,12 @@ fun MyInvitationDetailRoute(
                     snackbarHostState.showSnackbar(res.getString(R.string.msg_invitation_delete_failed))
                 }
             }
+            is MyInvitationDetailSideEffect.KakaoTalkNotAvailable -> {
+                coroutineScope.launch {
+                    snackbarHostState.currentSnackbarData?.dismiss()
+                    snackbarHostState.showSnackbar(res.getString(R.string.msg_kakaotalk_available_failed))
+                }
+            }
         }
     }
 

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/collection/MyInvitationStoryScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/collection/MyInvitationStoryScreen.kt
@@ -160,16 +160,10 @@ fun MyInvitationStoryRoute(
     }
 
     if (showNotificationPermissionDeniedDialog) {
+
         NachoPermissionDialog(
             message = stringResource(R.string.snack_notification_permission_denied),
-            onDismiss = {
-                showNotificationPermissionDeniedDialog = false
-                if (!uiState.networkDialogDismissed) {
-                    showNetworkInfoDialog = true
-                } else {
-                    viewModel.onEvent(MyInvitationCollectionUiEvent.DownloadMedia)
-                }
-            },
+            onDismiss = { showNotificationPermissionDeniedDialog = false },
         )
     }
 }

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/collection/MyInvitationStoryScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/collection/MyInvitationStoryScreen.kt
@@ -42,6 +42,7 @@ import com.andlife.ui.component.collection.StoryContent
 import com.andlife.ui.component.collection.StoryTopHeader
 import com.andlife.ui.component.dialog.NachoInfoDialog
 import com.andlife.ui.component.dialog.NachoPermissionDialog
+import com.andlife.ui.util.shouldRequestNotificationPermission
 import com.andlife.ui.util.shouldRequestStoragePermission
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.coroutines.launch
@@ -63,13 +64,32 @@ fun MyInvitationStoryRoute(
     val context = LocalContext.current
 
     var showPermissionDeniedDialog by remember { mutableStateOf(false) }
+    var showNotificationPermissionDeniedDialog by remember { mutableStateOf(false) }
     var showNetworkInfoDialog by remember { mutableStateOf(false) }
+
+    val notificationPermissionLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (!isGranted) {
+            showNotificationPermissionDeniedDialog = true
+        } else if (!uiState.networkDialogDismissed) {
+            showNetworkInfoDialog = true
+        } else {
+            viewModel.onEvent(MyInvitationCollectionUiEvent.DownloadMedia)
+        }
+    }
 
     val permissionLauncher = rememberLauncherForActivityResult(
         contract = ActivityResultContracts.RequestPermission()
     ) { isGranted ->
         if (isGranted) {
-            viewModel.onEvent(MyInvitationCollectionUiEvent.DownloadMedia)
+            if (context.shouldRequestNotificationPermission()) {
+                notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
+            } else if (!uiState.networkDialogDismissed) {
+                showNetworkInfoDialog = true
+            } else {
+                viewModel.onEvent(MyInvitationCollectionUiEvent.DownloadMedia)
+            }
         } else {
             showPermissionDeniedDialog = true
         }
@@ -105,6 +125,8 @@ fun MyInvitationStoryRoute(
         onDownloadClick = {
             if (context.shouldRequestStoragePermission()) {
                 permissionLauncher.launch(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+            } else if (context.shouldRequestNotificationPermission()) {
+                notificationPermissionLauncher.launch(Manifest.permission.POST_NOTIFICATIONS)
             } else if (!uiState.networkDialogDismissed) {
                 showNetworkInfoDialog = true
             } else {
@@ -134,6 +156,20 @@ fun MyInvitationStoryRoute(
         NachoPermissionDialog(
             message = stringResource(R.string.snack_permission_denied),
             onDismiss = { showPermissionDeniedDialog = false },
+        )
+    }
+
+    if (showNotificationPermissionDeniedDialog) {
+        NachoPermissionDialog(
+            message = stringResource(R.string.snack_notification_permission_denied),
+            onDismiss = {
+                showNotificationPermissionDeniedDialog = false
+                if (!uiState.networkDialogDismissed) {
+                    showNetworkInfoDialog = true
+                } else {
+                    viewModel.onEvent(MyInvitationCollectionUiEvent.DownloadMedia)
+                }
+            },
         )
     }
 }

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationDetailViewModel.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationDetailViewModel.kt
@@ -107,13 +107,17 @@ class MyInvitationDetailViewModel @Inject constructor(
         val locationText = content.location.name
         val firstImage = content.imageList.firstOrNull()
 
-        kakaoShareManager.share(
+        val isAvailable = kakaoShareManager.share(
             invitationId = myInvitationId,
             title = content.title,
             imageUrl = firstImage,
             date = dateText,
             location = locationText,
         )
+
+        if (!isAvailable) {
+            sendEffect(MyInvitationDetailSideEffect.KakaoTalkNotAvailable)
+        }
     }
 
     private fun deleteInvitation() {

--- a/android/feature/myinvitation/src/main/res/values/strings.xml
+++ b/android/feature/myinvitation/src/main/res/values/strings.xml
@@ -38,6 +38,7 @@
 
     <string name="snack_download_fail">저장에 실패하였습니다</string>
     <string name="snack_permission_denied">파일을 저장하려면 저장공간 접근 권한이 필요합니다</string>
+    <string name="snack_notification_permission_denied">다운로드 진행 상태를 알림으로 받으려면 알림 권한이 필요합니다</string>
     <string name="snack_download_guide">다운로드 상태는 상단 알림창에서 확인 가능합니다</string>
 
     <string name="dialog_network_title">안내</string>
@@ -52,5 +53,6 @@
     <string name="txt_delete_thanks_card">감사카드 삭제</string>
     <string name="desc_delete_thanks_card">정말 감사카드를 삭제하시겠습니까?</string>
     <string name="label_guestbook_empty">작성된 방명록이 없습니다.\n첫 인사를 남겨보세요!</string>
-    <string name="msg_invitation_delete_failed">초대장 삭제에 실패하였습니다.</string>
+    <string name="msg_invitation_delete_failed">초대장 삭제에 실패하였습니다</string>
+    <string name="msg_kakaotalk_available_failed">카카오톡이 설치되어 있지 않습니다</string>
 </resources>


### PR DESCRIPTION
## 🔍 변경 사항
- 2차 QA 중 공유하기 버튼 눌렀을 때 카카오톡 미설치 시 안내 스낵바 추가
- 알림 권한 허용 요청이 안되어서 미디어 다운로드(이미지/영상) 시 알림이 나타나지 않는 현상 수정
- 미디어 다운로드 완료 알람 클릭 시 이동 로직 수정
  - 기존
    - "다운로드 중" 진행 중인 미디어가 모두 알람창에 나타납니다.
    - 완료되었을 경우 "n개의 미디어 다운로드 완료", "n개의 오디오 다운로드 완료" 알람창을 띄웁니다.
    - 완료 알람 눌렀을 때 미디어는 갤러리로, 오디오는 파일 시스템으로 이동합니다.
  - 변경
    - "다운로드 중" 진행 중인 미디어가 모두 알람창에 나타납니다.
    - 완료되었을 경우 "비디오 저장 완료" "이미지 저장 완료" "오디오 저장 완료" 알람창을 띄웁니다.
    - 완료 알람을 눌렀을 경우 마지막으로 완료된 미디어로 이동합니다.
  - 기타사항
    - 완료 클릭시 uri 를 전달하면서 겪었던 문제입니다.
    -  API 28 이하에서는 파일 저장 시 `file://`로, API 29 부터는 시스템이 관리하는 `content://` 형태의 주소를 사용합니다.
    - 그래서 낮은 버전의 기기라면 `file://` 로 관리되는 주소를, `content://` 형태의 주소(Content URI)로 변환해야 다른 앱(갤러리, 파일 뷰어 등)이 이 파일에 접근할 수 있습니다.
    - `MediaScannerConnection.scanFile`를 사용해 변환해주어 버전 대응했습니다.
- 테스트 진행 해봤을 때 이상 없었지만, 혹시 몰라 여러분들 기기로도 한번씩 테스트 부탁드립니다!

## 📸 스크린샷
- 안드로이드 13(api 35)

https://github.com/user-attachments/assets/545abf81-9ba7-4f24-8200-c4f6f6a81801

- 안드로이드 10(api 29)

https://github.com/user-attachments/assets/b8d1e9c5-3142-4b75-982e-a9dda4d02cf5

- 안드로이드 9(api 28)

https://github.com/user-attachments/assets/46cfd2f0-ed06-4c90-be7e-90cc3a62eb6d

## 🔗 관련 이슈
- Close #174

## ✅ 체크리스트
- [x] 팀 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 import는 삭제했나요?
