### PR TITLE
Feature/#200 미디어 업로드 중 뒤로가기 임시 조치

### DIFF
--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/detail/InvitationDetailScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/detail/InvitationDetailScreen.kt
@@ -55,7 +55,9 @@ import com.andlife.invitation.model.detail.InvitationDetailUiState
 import com.andlife.invitation.screen.collection.InvitationCollectionRoute
 import com.andlife.invitation.screen.guestbook.InvitationGuestBookRoute
 import com.andlife.invitation.viewmodel.InvitationDetailViewModel
+import com.andlife.invitation.viewmodel.InvitationGuestBookViewModel
 import com.andlife.ui.component.GenericTabRow
+import com.andlife.ui.component.dialog.NachoInfoDialog
 import com.andlife.ui.component.loading.InvitationLoadingError
 import com.andlife.ui.component.loading.InvitationLoadingIndicator
 import com.andlife.ui.component.lottie.LottieEffect
@@ -74,6 +76,9 @@ fun InvitationDetailRoute(
     viewModel: InvitationDetailViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val guestBookViewModel: InvitationGuestBookViewModel = hiltViewModel()
+    val guestBookUiState by guestBookViewModel.uiState.collectAsStateWithLifecycle()
+    val isGuestBookUploading = guestBookUiState.isUploading
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
@@ -113,6 +118,7 @@ fun InvitationDetailRoute(
     Box {
         InvitationDetailScreen(
             uiState = uiState,
+            isGuestBookUploading = isGuestBookUploading,
             snackbarHostState = snackbarHostState,
             scrollBehavior = scrollBehavior,
             onEvent = viewModel::onEvent,
@@ -176,6 +182,7 @@ fun InvitationDetailRoute(
 @Composable
 private fun InvitationDetailScreen(
     uiState: InvitationDetailUiState,
+    isGuestBookUploading: Boolean,
     snackbarHostState: SnackbarHostState,
     scrollBehavior: TopAppBarScrollBehavior,
     onEvent: (InvitationDetailUiEvent) -> Unit,
@@ -187,15 +194,20 @@ private fun InvitationDetailScreen(
     val tabTitles = stringArrayResource(R.array.txt_tap_title).toImmutableList()
     val coroutineScope = rememberCoroutineScope()
     var isMapVisible by remember { mutableStateOf(true) }
-    val navigateBackWithMapCleanup: () -> Unit = {
+    var showUploadCancelDialog by remember { mutableStateOf(false) }
+
+    val doNavigateBack: () -> Unit = {
         isMapVisible = false
         coroutineScope.launch {
             delay(50L)
             onEvent(InvitationDetailUiEvent.ClickBack)
         }
     }
+    val navigateBackWithCleanup: () -> Unit = {
+        if (isGuestBookUploading) showUploadCancelDialog = true else doNavigateBack()
+    }
 
-    BackHandler(onBack = navigateBackWithMapCleanup)
+    BackHandler(onBack = navigateBackWithCleanup)
 
     Scaffold(
         modifier = modifier
@@ -210,7 +222,7 @@ private fun InvitationDetailScreen(
                 title = uiState.invitationContentsUiModel.title,
                 hasThanksCard = uiState.hasThanksCard,
                 showActions = !uiState.isLoading && !uiState.isError,
-                onBack = navigateBackWithMapCleanup,
+                onBack = navigateBackWithCleanup,
                 onClickThanksCard = { onEvent(InvitationDetailUiEvent.ClickThanksCard) },
                 onLeave = { onEvent(InvitationDetailUiEvent.ClickLeaveInvitation) },
             )
@@ -270,6 +282,20 @@ private fun InvitationDetailScreen(
                 },
             )
         }
+    }
+
+    if (showUploadCancelDialog) {
+        NachoInfoDialog(
+            title = stringResource(R.string.dialog_back_title),
+            message = stringResource(R.string.dialog_back_message),
+            confirmText = stringResource(R.string.dialog_back_confirm),
+            dismissText = stringResource(R.string.dialog_back_cancel),
+            onConfirm = {
+                showUploadCancelDialog = false
+                doNavigateBack()
+            },
+            onDismiss = { showUploadCancelDialog = false },
+        )
     }
 }
 

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/detail/InvitationDetailScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/detail/InvitationDetailScreen.kt
@@ -44,6 +44,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import com.andlife.designsystem.component.dialog.NachoDialog
 import com.andlife.designsystem.theme.NachoSpacing
 import com.andlife.designsystem.theme.NachoTheme
@@ -74,11 +76,13 @@ fun InvitationDetailRoute(
     onNavigateToLogin: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: InvitationDetailViewModel = hiltViewModel(),
+    guestBookViewModel: InvitationGuestBookViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val guestBookViewModel: InvitationGuestBookViewModel = hiltViewModel()
-    val guestBookUiState by guestBookViewModel.uiState.collectAsStateWithLifecycle()
-    val isGuestBookUploading = guestBookUiState.isUploading
+    val isGuestBookUploading by guestBookViewModel.uiState
+        .map { it.isUploading }
+        .distinctUntilChanged()
+        .collectAsStateWithLifecycle(initialValue = false)
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
@@ -125,7 +125,6 @@ fun InvitationGuestBookRoute(
     var scrollToTop by remember { mutableStateOf(false) }
     var showRecordingBottomSheet by remember { mutableStateOf(false) }
     var lastPrecachedCount by remember { mutableIntStateOf(0) }
-    var showUploadCancelDialog by remember { mutableStateOf(false) }
 
     var isMediaActive by remember { mutableStateOf(true) }
     val navigateBackWithCleanup: () -> Unit = {
@@ -381,21 +380,6 @@ fun InvitationGuestBookRoute(
         )
     }
 
-    if (showUploadCancelDialog) {
-        NachoInfoDialog(
-            title = stringResource(R.string.dialog_back_title),
-            message = stringResource(R.string.dialog_back_message),
-            confirmText = stringResource(R.string.dialog_back_confirm),
-            dismissText = stringResource(R.string.dialog_back_cancel),
-            onConfirm = {
-                showUploadCancelDialog = false
-                navigateBackWithCleanup()
-            },
-            onDismiss = { showUploadCancelDialog = false },
-        )
-    }
-
-
     if (showPermissionDialog != null) {
         NachoPermissionDialog(
             message = when (showPermissionDialog) {
@@ -441,7 +425,6 @@ fun InvitationGuestBookRoute(
         lazyListState = lazyListState,
         videoPlayerPool = viewModel.videoPlayerPool,
         onDeleteMenuClick = { guestBookId -> showDeleteDialog = guestBookId },
-        onBackDuringUpload = { showUploadCancelDialog = true },
         context = context,
         cameraPermissionLauncher = cameraPermissionLauncher,
         audioPermissionLauncher = audioPermissionLauncher,
@@ -490,7 +473,6 @@ private fun InvitationGuestBookScreen(
     lazyListState: LazyListState,
     videoPlayerPool: AutoVideoPlayerPool,
     onDeleteMenuClick: (Long) -> Unit,
-    onBackDuringUpload: () -> Unit,
     context: Context,
     cameraPermissionLauncher: ActivityResultLauncher<String>,
     audioPermissionLauncher: ActivityResultLauncher<String>,
@@ -505,12 +487,8 @@ private fun InvitationGuestBookScreen(
         if (!isImVisible) focusManager.clearFocus()
     }
 
-    BackHandler(enabled = true) {
+    BackHandler(enabled = !uiState.isUploading) {
         when {
-            uiState.isUploading -> {
-                onBackDuringUpload()
-            }
-
             isImVisible -> {
                 focusManager.clearFocus()
             }
@@ -775,7 +753,6 @@ private fun InvitationGuestBookEmptyPreview() {
             snackbarHostState = SnackbarHostState(),
             lazyListState = rememberLazyListState(),
             onDeleteMenuClick = {},
-            onBackDuringUpload = {},
             focusManager = LocalFocusManager.current,
             context = LocalContext.current,
             cameraPermissionLauncher = rememberLauncherForActivityResult(

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
@@ -125,6 +125,7 @@ fun InvitationGuestBookRoute(
     var scrollToTop by remember { mutableStateOf(false) }
     var showRecordingBottomSheet by remember { mutableStateOf(false) }
     var lastPrecachedCount by remember { mutableIntStateOf(0) }
+    var showUploadCancelDialog by remember { mutableStateOf(false) }
 
     var isMediaActive by remember { mutableStateOf(true) }
     val navigateBackWithCleanup: () -> Unit = {
@@ -380,6 +381,21 @@ fun InvitationGuestBookRoute(
         )
     }
 
+    if (showUploadCancelDialog) {
+        NachoInfoDialog(
+            title = stringResource(R.string.dialog_back_title),
+            message = stringResource(R.string.dialog_back_message),
+            confirmText = stringResource(R.string.dialog_back_confirm),
+            dismissText = stringResource(R.string.dialog_back_cancel),
+            onConfirm = {
+                showUploadCancelDialog = false
+                navigateBackWithCleanup()
+            },
+            onDismiss = { showUploadCancelDialog = false },
+        )
+    }
+
+
     if (showPermissionDialog != null) {
         NachoPermissionDialog(
             message = when (showPermissionDialog) {
@@ -425,6 +441,7 @@ fun InvitationGuestBookRoute(
         lazyListState = lazyListState,
         videoPlayerPool = viewModel.videoPlayerPool,
         onDeleteMenuClick = { guestBookId -> showDeleteDialog = guestBookId },
+        onBackDuringUpload = { showUploadCancelDialog = true },
         context = context,
         cameraPermissionLauncher = cameraPermissionLauncher,
         audioPermissionLauncher = audioPermissionLauncher,
@@ -473,6 +490,7 @@ private fun InvitationGuestBookScreen(
     lazyListState: LazyListState,
     videoPlayerPool: AutoVideoPlayerPool,
     onDeleteMenuClick: (Long) -> Unit,
+    onBackDuringUpload: () -> Unit,
     context: Context,
     cameraPermissionLauncher: ActivityResultLauncher<String>,
     audioPermissionLauncher: ActivityResultLauncher<String>,
@@ -489,6 +507,10 @@ private fun InvitationGuestBookScreen(
 
     BackHandler(enabled = true) {
         when {
+            uiState.isUploading -> {
+                onBackDuringUpload()
+            }
+
             isImVisible -> {
                 focusManager.clearFocus()
             }
@@ -753,6 +775,7 @@ private fun InvitationGuestBookEmptyPreview() {
             snackbarHostState = SnackbarHostState(),
             lazyListState = rememberLazyListState(),
             onDeleteMenuClick = {},
+            onBackDuringUpload = {},
             focusManager = LocalFocusManager.current,
             context = LocalContext.current,
             cameraPermissionLauncher = rememberLauncherForActivityResult(

--- a/android/feature/invitation/src/main/res/values/strings.xml
+++ b/android/feature/invitation/src/main/res/values/strings.xml
@@ -39,5 +39,10 @@
 
     <string name="label_guestbook_empty">작성된 방명록이 없습니다.\n첫 인사를 남겨보세요!</string>
     <string name="msg_leave_invitation_error">초대장 나가기에 실패하였습니다.</string>
+
+    <string name="dialog_back_title">업로드 중</string>
+    <string name="dialog_back_message">업로드 중에 나가면 업로드가 취소될 수 있습니다.\n그래도 나가시겠습니까?</string>
+    <string name="dialog_back_confirm">나가기</string>
+    <string name="dialog_back_cancel">취소</string>
 </resources>
 

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationDetailScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationDetailScreen.kt
@@ -280,16 +280,21 @@ private fun MyInvitationDetailScreen(
     val tabTitles = stringArrayResource(R.array.txt_tap_title).toImmutableList()
     val coroutineScope = rememberCoroutineScope()
     var isMapVisible by remember { mutableStateOf(true) }
+    var isGuestBookUploading by remember { mutableStateOf(false) }
+    var showUploadCancelDialog by remember { mutableStateOf(false) }
 
-    val navigateBackWithMapCleanup: () -> Unit = {
+    val doNavigateBack: () -> Unit = {
         isMapVisible = false
         coroutineScope.launch {
             delay(50L)
             onEvent(MyInvitationDetailUiEvent.ClickBack)
         }
     }
+    val navigateBackWithCleanup: () -> Unit = {
+        if (isGuestBookUploading) showUploadCancelDialog = true else doNavigateBack()
+    }
 
-    BackHandler(onBack = navigateBackWithMapCleanup)
+    BackHandler(onBack = navigateBackWithCleanup)
 
     Scaffold(
         modifier = modifier
@@ -304,7 +309,7 @@ private fun MyInvitationDetailScreen(
                 title = uiState.invitationContentsUiModel.title,
                 hasThanksCard = uiState.hasThanksCard,
                 showActions = !uiState.isLoading && !uiState.isError,
-                onBack = navigateBackWithMapCleanup,
+                onBack = navigateBackWithCleanup,
                 onClickThanksCard = { onEvent(MyInvitationDetailUiEvent.ClickThanksCard) },
                 onEditThanksCard = { onEditThanksCard() },
                 onDeleteThanksCard = onDeleteThanksCard,
@@ -369,7 +374,8 @@ private fun MyInvitationDetailScreen(
 
                             1 -> MyInvitationGuestBookRoute(
                                 onNavigateBack = onNavigateBack,
-                                onNavigateToLogin = onNavigateToLogin
+                                onNavigateToLogin = onNavigateToLogin,
+                                onUploadingChanged = { isGuestBookUploading = it },
                             )
 
                             2 -> MyInvitationCollectionRoute()
@@ -377,6 +383,20 @@ private fun MyInvitationDetailScreen(
                     },
             )
         }
+    }
+
+    if (showUploadCancelDialog) {
+        NachoInfoDialog(
+            title = stringResource(R.string.dialog_back_title),
+            message = stringResource(R.string.dialog_back_message),
+            confirmText = stringResource(R.string.dialog_back_confirm),
+            dismissText = stringResource(R.string.dialog_back_cancel),
+            onConfirm = {
+                showUploadCancelDialog = false
+                doNavigateBack()
+            },
+            onDismiss = { showUploadCancelDialog = false },
+        )
     }
 }
 

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationDetailScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationDetailScreen.kt
@@ -45,6 +45,8 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
 import com.andlife.designsystem.component.NachoDivider
 import com.andlife.designsystem.component.dialog.NachoDialog
 import com.andlife.designsystem.preview.PreviewTheme
@@ -91,11 +93,13 @@ fun MyInvitationDetailRoute(
     onNavigateToUpdateThanksCard: (Long) -> Unit,
     modifier: Modifier = Modifier,
     viewModel: MyInvitationDetailViewModel = hiltViewModel(),
+    guestBookViewModel: MyInvitationGuestBookViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val guestBookViewModel: MyInvitationGuestBookViewModel = hiltViewModel()
-    val guestBookUiState by guestBookViewModel.uiState.collectAsStateWithLifecycle()
-    val isGuestBookUploading = guestBookUiState.isUploading
+    val isGuestBookUploading by guestBookViewModel.uiState
+        .map { it.isUploading }
+        .distinctUntilChanged()
+        .collectAsStateWithLifecycle(initialValue = false)
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationDetailScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationDetailScreen.kt
@@ -65,6 +65,7 @@ import com.andlife.myinvitation.model.detail.MyInvitationDetailUiState
 import com.andlife.myinvitation.screen.collection.MyInvitationCollectionRoute
 import com.andlife.myinvitation.screen.guestbook.MyInvitationGuestBookRoute
 import com.andlife.myinvitation.viewmodel.MyInvitationDetailViewModel
+import com.andlife.myinvitation.viewmodel.MyInvitationGuestBookViewModel
 import com.andlife.ui.component.GenericTabRow
 import com.andlife.ui.component.dialog.NachoInfoDialog
 import com.andlife.ui.component.loading.InvitationLoadingError
@@ -92,6 +93,9 @@ fun MyInvitationDetailRoute(
     viewModel: MyInvitationDetailViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val guestBookViewModel: MyInvitationGuestBookViewModel = hiltViewModel()
+    val guestBookUiState by guestBookViewModel.uiState.collectAsStateWithLifecycle()
+    val isGuestBookUploading = guestBookUiState.isUploading
     val snackbarHostState = remember { SnackbarHostState() }
     val coroutineScope = rememberCoroutineScope()
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior()
@@ -183,6 +187,7 @@ fun MyInvitationDetailRoute(
     Box {
         MyInvitationDetailScreen(
             uiState = uiState,
+            isGuestBookUploading = isGuestBookUploading,
             snackbarHostState = snackbarHostState,
             scrollBehavior = scrollBehavior,
             onEvent = viewModel::onEvent,
@@ -267,6 +272,7 @@ fun MyInvitationDetailRoute(
 @Composable
 private fun MyInvitationDetailScreen(
     uiState: MyInvitationDetailUiState,
+    isGuestBookUploading: Boolean,
     snackbarHostState: SnackbarHostState,
     scrollBehavior: TopAppBarScrollBehavior,
     onEvent: (MyInvitationDetailUiEvent) -> Unit,
@@ -280,7 +286,6 @@ private fun MyInvitationDetailScreen(
     val tabTitles = stringArrayResource(R.array.txt_tap_title).toImmutableList()
     val coroutineScope = rememberCoroutineScope()
     var isMapVisible by remember { mutableStateOf(true) }
-    var isGuestBookUploading by remember { mutableStateOf(false) }
     var showUploadCancelDialog by remember { mutableStateOf(false) }
 
     val doNavigateBack: () -> Unit = {
@@ -375,7 +380,6 @@ private fun MyInvitationDetailScreen(
                             1 -> MyInvitationGuestBookRoute(
                                 onNavigateBack = onNavigateBack,
                                 onNavigateToLogin = onNavigateToLogin,
-                                onUploadingChanged = { isGuestBookUploading = it },
                             )
 
                             2 -> MyInvitationCollectionRoute()
@@ -676,6 +680,7 @@ private fun InvitationMoreMenu(
 private fun MyInvitationDetailScreenPreview() {
     NachoTheme {
         MyInvitationDetailScreen(
+            isGuestBookUploading = false,
             uiState =
                 MyInvitationDetailUiState(
                     isLoading = false,

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
@@ -106,10 +106,13 @@ private const val MAX_MEDIAS_COUNT = 20
 fun MyInvitationGuestBookRoute(
     onNavigateBack: () -> Unit,
     onNavigateToLogin: () -> Unit,
+    onUploadingChanged: (Boolean) -> Unit = {},
     modifier: Modifier = Modifier,
     viewModel: MyInvitationGuestBookViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    onUploadingChanged(uiState.isUploading)
     val guestBooks = viewModel.guestBooksPagingFlow.collectAsLazyPagingItems()
 
     val lifecycleOwner = LocalLifecycleOwner.current
@@ -125,7 +128,6 @@ fun MyInvitationGuestBookRoute(
     var scrollToTop by remember { mutableStateOf(false) }
     var showRecordingBottomSheet by remember { mutableStateOf(false) }
     var lastPrecachedCount by remember { mutableIntStateOf(0) }
-    var showUploadCancelDialog by remember { mutableStateOf(false) }
 
     var isMediaActive by remember { mutableStateOf(true) }
     val navigateBackWithCleanup: () -> Unit = {
@@ -381,20 +383,6 @@ fun MyInvitationGuestBookRoute(
         )
     }
 
-    if (showUploadCancelDialog) {
-        NachoInfoDialog(
-            title = stringResource(R.string.dialog_back_title),
-            message = stringResource(R.string.dialog_back_message),
-            confirmText = stringResource(R.string.dialog_back_confirm),
-            dismissText = stringResource(R.string.dialog_back_cancel),
-            onConfirm = {
-                showUploadCancelDialog = false
-                navigateBackWithCleanup()
-            },
-            onDismiss = { showUploadCancelDialog = false },
-        )
-    }
-
     if (showPermissionDialog != null) {
         NachoPermissionDialog(
             message = when (showPermissionDialog) {
@@ -440,7 +428,6 @@ fun MyInvitationGuestBookRoute(
         lazyListState = lazyListState,
         videoPlayerPool = viewModel.videoPlayerPool,
         onDeleteMenuClick = { guestBookId -> showDeleteDialog = guestBookId },
-        onBackDuringUpload = { showUploadCancelDialog = true },
         context = context,
         cameraPermissionLauncher = cameraPermissionLauncher,
         audioPermissionLauncher = audioPermissionLauncher,
@@ -495,7 +482,6 @@ private fun InvitationGuestBookScreen(
     lazyListState: LazyListState,
     videoPlayerPool: AutoVideoPlayerPool,
     onDeleteMenuClick: (Long) -> Unit,
-    onBackDuringUpload: () -> Unit,
     context: Context,
     cameraPermissionLauncher: ActivityResultLauncher<String>,
     audioPermissionLauncher: ActivityResultLauncher<String>,
@@ -512,10 +498,6 @@ private fun InvitationGuestBookScreen(
 
     BackHandler(enabled = !uiState.isUploading) {
         when {
-            uiState.isUploading -> {
-                onBackDuringUpload()
-            }
-
             isImVisible -> {
                 focusManager.clearFocus()
             }
@@ -782,7 +764,6 @@ private fun InvitationGuestBookEmptyPreview() {
             snackbarHostState = SnackbarHostState(),
             lazyListState = rememberLazyListState(),
             onDeleteMenuClick = {},
-            onBackDuringUpload = {},
             context = LocalContext.current,
             cameraPermissionLauncher = rememberLauncherForActivityResult(
                 contract = ActivityResultContracts.RequestPermission()

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
@@ -106,13 +106,10 @@ private const val MAX_MEDIAS_COUNT = 20
 fun MyInvitationGuestBookRoute(
     onNavigateBack: () -> Unit,
     onNavigateToLogin: () -> Unit,
-    onUploadingChanged: (Boolean) -> Unit = {},
     modifier: Modifier = Modifier,
     viewModel: MyInvitationGuestBookViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-
-    onUploadingChanged(uiState.isUploading)
     val guestBooks = viewModel.guestBooksPagingFlow.collectAsLazyPagingItems()
 
     val lifecycleOwner = LocalLifecycleOwner.current

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
@@ -125,6 +125,7 @@ fun MyInvitationGuestBookRoute(
     var scrollToTop by remember { mutableStateOf(false) }
     var showRecordingBottomSheet by remember { mutableStateOf(false) }
     var lastPrecachedCount by remember { mutableIntStateOf(0) }
+    var showUploadCancelDialog by remember { mutableStateOf(false) }
 
     var isMediaActive by remember { mutableStateOf(true) }
     val navigateBackWithCleanup: () -> Unit = {
@@ -380,6 +381,20 @@ fun MyInvitationGuestBookRoute(
         )
     }
 
+    if (showUploadCancelDialog) {
+        NachoInfoDialog(
+            title = stringResource(R.string.dialog_back_title),
+            message = stringResource(R.string.dialog_back_message),
+            confirmText = stringResource(R.string.dialog_back_confirm),
+            dismissText = stringResource(R.string.dialog_back_cancel),
+            onConfirm = {
+                showUploadCancelDialog = false
+                navigateBackWithCleanup()
+            },
+            onDismiss = { showUploadCancelDialog = false },
+        )
+    }
+
     if (showPermissionDialog != null) {
         NachoPermissionDialog(
             message = when (showPermissionDialog) {
@@ -425,6 +440,7 @@ fun MyInvitationGuestBookRoute(
         lazyListState = lazyListState,
         videoPlayerPool = viewModel.videoPlayerPool,
         onDeleteMenuClick = { guestBookId -> showDeleteDialog = guestBookId },
+        onBackDuringUpload = { showUploadCancelDialog = true },
         context = context,
         cameraPermissionLauncher = cameraPermissionLauncher,
         audioPermissionLauncher = audioPermissionLauncher,
@@ -479,6 +495,7 @@ private fun InvitationGuestBookScreen(
     lazyListState: LazyListState,
     videoPlayerPool: AutoVideoPlayerPool,
     onDeleteMenuClick: (Long) -> Unit,
+    onBackDuringUpload: () -> Unit,
     context: Context,
     cameraPermissionLauncher: ActivityResultLauncher<String>,
     audioPermissionLauncher: ActivityResultLauncher<String>,
@@ -493,8 +510,12 @@ private fun InvitationGuestBookScreen(
         if (!isImVisible) focusManager.clearFocus()
     }
 
-    BackHandler(enabled = true) {
+    BackHandler(enabled = !uiState.isUploading) {
         when {
+            uiState.isUploading -> {
+                onBackDuringUpload()
+            }
+
             isImVisible -> {
                 focusManager.clearFocus()
             }
@@ -761,6 +782,7 @@ private fun InvitationGuestBookEmptyPreview() {
             snackbarHostState = SnackbarHostState(),
             lazyListState = rememberLazyListState(),
             onDeleteMenuClick = {},
+            onBackDuringUpload = {},
             context = LocalContext.current,
             cameraPermissionLauncher = rememberLauncherForActivityResult(
                 contract = ActivityResultContracts.RequestPermission()

--- a/android/feature/myinvitation/src/main/res/values/strings.xml
+++ b/android/feature/myinvitation/src/main/res/values/strings.xml
@@ -55,4 +55,9 @@
     <string name="label_guestbook_empty">작성된 방명록이 없습니다.\n첫 인사를 남겨보세요!</string>
     <string name="msg_invitation_delete_failed">초대장 삭제에 실패하였습니다</string>
     <string name="msg_kakaotalk_available_failed">카카오톡이 설치되어 있지 않습니다</string>
+
+    <string name="dialog_back_title">업로드 중</string>
+    <string name="dialog_back_message">업로드 중에 나가면 업로드가 취소될 수 있습니다.\n그래도 나가시겠습니까?</string>
+    <string name="dialog_back_confirm">나가기</string>
+    <string name="dialog_back_cancel">취소</string>
 </resources>


### PR DESCRIPTION
## 🔍 변경 사항
- 미디어 업로드 중임을 확인하고(isUploading 상태) 다이얼로그를 띄우는 기능을 추가했습니다.
- 탑바의 뒤로가기와 시스템 백버튼 실행 두가지를 대응해야하기 때문에(InvitationGuestBookScreen에는 탑바가 없고 공용으로 사용됨) InvitationDetailScreen에서 상태 체크 후 다이얼로그를 띄우도록 했고, InvitationGuestBookViewModel에 접근하여 isUploading 상태를 체크하였습니다.
- invitation과 myinvitation 모듈에 적용되었습니다.
- 현재는 임시 조치이므로, 백그라운드 작업 완료 후 제거 예정입니다.

## 📸 스크린샷
<img width="270" height="555" alt="image" src="https://github.com/user-attachments/assets/19b35014-11db-4b20-a4c4-df5f2c896b2c" />

## 🔗 관련 이슈
- Close #200 

## ✅ 체크리스트
- [x] 팀 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 import는 삭제했나요?
