### PR TITLE
Feature/#201 앱 배포전 최적화를 위한 proguard rules 작성

### DIFF
--- a/android/.gitignore
+++ b/android/.gitignore
@@ -9,3 +9,5 @@
 .externalNativeBuild
 .cxx
 local.properties
+keystore.properties
+app/andlife-release-key.jks

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -65,7 +65,8 @@ android {
 
     buildTypes {
         release {
-            isMinifyEnabled = false
+            isMinifyEnabled = true
+            isShrinkResources = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -24,6 +24,22 @@ android {
         properties.load(FileInputStream(propertiesFile))
     }
 
+    val keystoreProperties = Properties().apply {
+        val file = rootProject.file("keystore.properties")
+        if (file.exists()) {
+            load(file.inputStream())
+        }
+    }
+
+    signingConfigs {
+        maybeCreate("release").apply {
+            storeFile = file(keystoreProperties["storeFile"] ?: "")
+            storePassword = keystoreProperties["storePassword"]?.toString()
+            keyAlias = keystoreProperties["keyAlias"]?.toString()
+            keyPassword = keystoreProperties["keyPassword"]?.toString()
+        }
+    }
+
     defaultConfig {
         applicationId = "com.andlife.nacho"
         minSdk = 26
@@ -45,22 +61,6 @@ android {
 
         manifestPlaceholders["KAKAO_NATIVE_APP_KEY"] = kakaoNativeAppKey
         manifestPlaceholders["APPSFLYER_DEV_KEY"] = appsflyerDevKey
-    }
-
-    signingConfigs {
-        val storePath = properties.getProperty("RELEASE_STORE_FILE")
-        val storeFileExists = storePath != null && file(storePath).exists()
-
-        maybeCreate("release").apply {
-            if (storeFileExists) {
-                storeFile = file(storePath!!)
-                storePassword = properties.getProperty("RELEASE_STORE_PASSWORD")
-                keyAlias = properties.getProperty("RELEASE_KEY_ALIAS")
-                keyPassword = properties.getProperty("RELEASE_KEY_PASSWORD")
-            } else {
-                initWith(getByName("debug"))
-            }
-        }
     }
 
     buildTypes {

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -18,6 +18,12 @@ android {
     namespace = "com.andlife.nacho"
     compileSdk = 36
 
+    val properties = Properties()
+    val propertiesFile = rootProject.file("local.properties")
+    if (propertiesFile.exists()) {
+        properties.load(FileInputStream(propertiesFile))
+    }
+
     defaultConfig {
         applicationId = "com.andlife.nacho"
         minSdk = 26
@@ -27,46 +33,42 @@ android {
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
-        var properties = Properties()
-        properties.load(FileInputStream("local.properties"))
         val kakaoRestApiKey = properties.getProperty("KAKAO_REST_API_KEY") ?: ""
         val kakaoNativeAppKey = properties.getProperty("KAKAO_NATIVE_APP_KEY") ?: ""
         val appsflyerDevKey = properties.getProperty("APPSFLYER_DEV_KEY") ?: ""
         val naverMapClientId = properties.getProperty("NAVER_MAP_CLIENT_ID") ?: ""
 
-
-        buildConfigField(
-            "String",
-            "KAKAO_REST_API_KEY",
-            "\"$kakaoRestApiKey\"",
-        )
-
-        buildConfigField(
-            "String",
-            "KAKAO_NATIVE_APP_KEY",
-            "\"$kakaoNativeAppKey\"",
-        )
-
-        buildConfigField(
-            "String",
-            "APPSFLYER_DEV_KEY",
-            "\"$appsflyerDevKey\"",
-        )
-
-        buildConfigField(
-            "String",
-            "NAVER_MAP_CLIENT_ID",
-            "\"$naverMapClientId\"",
-        )
+        buildConfigField("String", "KAKAO_REST_API_KEY", "\"$kakaoRestApiKey\"")
+        buildConfigField("String", "KAKAO_NATIVE_APP_KEY", "\"$kakaoNativeAppKey\"")
+        buildConfigField("String", "APPSFLYER_DEV_KEY", "\"$appsflyerDevKey\"")
+        buildConfigField("String", "NAVER_MAP_CLIENT_ID", "\"$naverMapClientId\"")
 
         manifestPlaceholders["KAKAO_NATIVE_APP_KEY"] = kakaoNativeAppKey
         manifestPlaceholders["APPSFLYER_DEV_KEY"] = appsflyerDevKey
+    }
+
+    signingConfigs {
+        val storePath = properties.getProperty("RELEASE_STORE_FILE")
+        val storeFileExists = storePath != null && file(storePath).exists()
+
+        maybeCreate("release").apply {
+            if (storeFileExists) {
+                storeFile = file(storePath!!)
+                storePassword = properties.getProperty("RELEASE_STORE_PASSWORD")
+                keyAlias = properties.getProperty("RELEASE_KEY_ALIAS")
+                keyPassword = properties.getProperty("RELEASE_KEY_PASSWORD")
+            } else {
+                initWith(getByName("debug"))
+            }
+        }
     }
 
     buildTypes {
         release {
             isMinifyEnabled = true
             isShrinkResources = true
+
+            signingConfig = signingConfigs.getByName("release")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",

--- a/android/app/proguard-rules.pro
+++ b/android/app/proguard-rules.pro
@@ -1,21 +1,66 @@
-# Add project specific ProGuard rules here.
-# You can control the set of applied configuration files using the
-# proguardFiles setting in build.gradle.
-#
-# For more details, see
-#   http://developer.android.com/guide/developing/tools/proguard.html
+# ============================================================
+# Attributes
+# 크래시 발생 시 난독화된 로그를 원본 코드의 라인 번호와 매칭하려 분석하기 위함
+# ============================================================
+-keepattributes SourceFile, LineNumberTable
+-renamesourcefileattribute SourceFile
+-keepattributes *Annotation*, Signature, InnerClasses, Exceptions, EnclosingMethod
 
-# If your project uses WebView with JS, uncomment the following
-# and specify the fully qualified class name to the JavaScript interface
-# class:
-#-keepclassmembers class fqcn.of.javascript.interface.for.webview {
-#   public *;
-#}
+# ============================================================
+# Kotlin Serialization
+# Kotlin Serialization 라이브러리는 컴파일 타임에 생성된 $serializer 클래스를 리플렉션으로 찾아 사용하므로 보존
+# ============================================================
+-keep,includedescriptorclasses class **$$serializer { *; }
+-keepclassmembers @kotlinx.serialization.Serializable class * {
+    static **$serializer INSTANCE;
+    *** Companion;
+    kotlinx.serialization.KSerializer serializer(...);
+}
+-dontnote kotlinx.serialization.AnnotationsKt
+-dontwarn kotlinx.serialization.**
 
-# Uncomment this to preserve the line number information for
-# debugging stack traces.
-#-keepattributes SourceFile,LineNumberTable
+# ============================================================
+# WorkManager
+# 시스템이 백그라운드 작업을 실행할 때 Worker 클래스의 생성자를 리플렉션으로 호출하므로 보존
+# ============================================================
+-keep class * extends androidx.work.ListenableWorker {
+    public <init>(android.content.Context, androidx.work.WorkerParameters);
+}
 
-# If you keep the line number information, uncomment this to
-# hide the original source file name.
-#-renamesourcefileattribute SourceFile
+# ============================================================
+# Project: Network
+# Retrofit 인터페이스는 리플렉션으로 호출되므로 메서드 보존
+# ============================================================
+-keepclassmembers interface com.andlife.network.api.** {
+    <methods>;
+}
+
+# ============================================================
+# SDK (Kakao, AppsFlyer, Naver Map, uCrop)
+# 각 외부 라이브러리는 내부적으로 특정 클래스나 필드를 이름으로 참조하는 경우가 많음
+# ============================================================
+# Kakao SDK
+-keep class com.kakao.sdk.**.model.* { <fields>; }
+-dontwarn com.kakao.**
+
+# AppsFlyer SDK
+-keep class com.appsflyer.AppsFlyerLib { *; }
+-keep class com.appsflyer.AFInAppEventType { *; }
+-keep class com.appsflyer.AFInAppEventParameterName { *; }
+-dontwarn com.appsflyer.**
+
+# Naver Map SDK
+-dontwarn com.naver.maps.**
+-dontnote com.naver.maps.**
+
+# uCrop
+-dontwarn com.yalantis.ucrop.**
+
+# ============================================================
+# Enum
+# 리플렉션으로 values()/valueOf() 호출 대비
+# ============================================================
+-keepclassmembers enum * {
+    public static **[] values();
+    public static ** valueOf(java.lang.String);
+}

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -21,3 +21,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.r8.optimizedResourceShrinking=true
+android.enableR8.fullMode=true


### PR DESCRIPTION
## 🔍 변경 사항
- proguard rules 작성
  - 코드가 컴파일되는 방식을 정의하는 설정이라서 팀원간에 공유해야하므로 gitignore 처리가 불필요하다고 판단하여 add 해뒀습니다.
  - 주석으로 각 항목에 대한 설명 작성해두었습니다.
- 앱 최적화 이후 앱 실행 테스트 완료(네트워크 통신, 데이터 전달 이상없음 확인)
- 최적화 비교 표
  <html><head></head><body>

  항목 | 최적화 전 (OFF) | 최적화 후 (ON) | 감소량 | 감소율 (%)
  -- | -- | -- | -- | --
  전체 APK 크기 (Raw) | $118.3\text{ MB}$ | $101.5\text{ MB}$ | $-16.8\text{ MB}$ | $-14.2\%$
  Download Size (압축) | $52.7\text{ MB}$ | $36.4\text{ MB}$ | $-16.3\text{ MB}$ | $-30.9\%$
  DEX (코드) | $20.6\text{ MB}$ | $4.4\text{ MB}$ | $-16.2\text{ MB}$ | $-78.6\%$
  Resource (res + arsc) | $7.2\text{ MB}$ | $6.6\text{ MB}$ | $-0.6\text{ MB}$ | $-8.3\%$
  Assets | $105.9\text{ KB}$ | $98.3\text{ KB}$ | $-7.6\text{ KB}$ | $-7.2\%$
  </body></html>

- 최적화 전 후 비교 항목 설명
  - APK Size (Raw): 빌드된 APK 파일의 순수 전체 용량
  - Download Size: 사용자가 구글 플레이 스토어에서 앱을 설치할 때 실제로 다운로드하게 되는 압축된 용량
  - DEX (코드): Java/Kotlin 코드가 안드로이드용 실행 파일로 변환된 결과물(난독화 및 최적화 성과가 제일 드러나는 항목)
  - Resource: res + resources.arsc
    - res: 이미지, 레이아웃 등 앱 UI 구성에 필요한 자원들
    - resources.arsc: 리소스의 ID와 실제 파일 이름을 연결해주는 매핑 테이블(난독화로 이름이 짧아지면 이 파일의 용량도 줄어듦)
  - assets: 폰트, 로컬 DB 등 원본 그대로 포함되는 외부 파일 폴더
  
- 배포용 서명 설정을 추가했습니다. 배포용 키스토어 정보는 제 로컬 환경에만 세팅해 두었으니, 다른 분들은 별도 설정 없이 평소처럼 빌드하시면 됩니다. 혹시 Release 빌드 시 에러가 발생하는 분이 있다면 말씀해 주세요!

## 📸 스크린샷
- 용량 비교 및 난독화

<img width="1397" height="707" alt="image" src="https://github.com/user-attachments/assets/aa114be4-63fe-48c2-acf7-dd5494024da2" />

## 🔗 관련 이슈
- Close #201

## ✅ 체크리스트
- [x] 팀 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 import는 삭제했나요?
