### PR TITLE
feat: Analytics Logger 수집 및 Crashlytics 로거 수집

### DIFF
--- a/android/app/src/main/kotlin/com/andlife/nacho/NachoApplication.kt
+++ b/android/app/src/main/kotlin/com/andlife/nacho/NachoApplication.kt
@@ -8,6 +8,8 @@ import com.andlife.deeplink.DeepLinkConfig
 import com.andlife.deeplink.DeepLinkManager
 import com.andlife.deeplink.di.AppsFlyerDevKey
 import com.andlife.deeplink.di.KakaoNativeKey
+import com.andlife.domain.util.AnalyticsEvent
+import com.andlife.domain.util.AnalyticsLogger
 import com.andlife.nacho.di.NaverMapClientId
 import com.appsflyer.AppsFlyerLib
 import com.appsflyer.deeplink.DeepLinkResult
@@ -37,6 +39,9 @@ class NachoApplication : Application(), Configuration.Provider {
     @Inject
     lateinit var deepLinkManager: DeepLinkManager
 
+    @Inject
+    lateinit var analyticsLogger: AnalyticsLogger
+
     override val workManagerConfiguration: Configuration
         get() = Configuration.Builder()
             .setWorkerFactory(workerFactory)
@@ -63,6 +68,14 @@ class NachoApplication : Application(), Configuration.Provider {
 
                 if (!invitationId.isNullOrEmpty()) {
                     Log.d("AppsFlyer", "invitationId: $invitationId")
+                    analyticsLogger.logEvent(
+                        AnalyticsEvent.Event(
+                            "Deeplink",
+                            mapOf(
+                                "invitation_id" to invitationId
+                            )
+                        )
+                    )
                     deepLinkManager.emitInvitationId(invitationId)
                 }
             } else if (status == DeepLinkResult.Status.ERROR) {

--- a/android/core/analytics/src/main/kotlin/com/andlife/analytics/analytics/FirebaseAnalyticsLogger.kt
+++ b/android/core/analytics/src/main/kotlin/com/andlife/analytics/analytics/FirebaseAnalyticsLogger.kt
@@ -1,20 +1,28 @@
 package com.andlife.analytics.analytics
 
+import android.content.Context
+import android.content.pm.ApplicationInfo
 import com.andlife.domain.util.AnalyticsEvent
 import com.andlife.domain.util.AnalyticsLogger
 import com.google.firebase.analytics.FirebaseAnalytics
 import com.google.firebase.analytics.logEvent
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 import kotlin.collections.component1
 import kotlin.collections.component2
 
 class FirebaseAnalyticsLogger @Inject constructor(
-    private val analytics: FirebaseAnalytics
+    private val analytics: FirebaseAnalytics,
+    @param:ApplicationContext private val context: Context
 ) : AnalyticsLogger {
+    private val isDebuggable = (context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
+
     override fun logEvent(event: AnalyticsEvent) {
-        analytics.logEvent(event.eventName) {
-            event.params.forEach { (key, value) ->
-                param(key, value)
+        if (!isDebuggable) {
+            analytics.logEvent(event.eventName) {
+                event.params.forEach { (key, value) ->
+                    param(key, value)
+                }
             }
         }
     }

--- a/android/core/analytics/src/main/kotlin/com/andlife/analytics/crash/FirebaseCrashlyticsLogger.kt
+++ b/android/core/analytics/src/main/kotlin/com/andlife/analytics/crash/FirebaseCrashlyticsLogger.kt
@@ -1,18 +1,28 @@
 package com.andlife.analytics.crash
 
+import android.content.Context
+import android.content.pm.ApplicationInfo
 import com.andlife.domain.util.CrashlyticsLogger
 import com.google.firebase.crashlytics.FirebaseCrashlytics
+import dagger.hilt.android.qualifiers.ApplicationContext
 import javax.inject.Inject
 
 class FirebaseCrashlyticsLogger @Inject constructor(
-    private val crashlytics: FirebaseCrashlytics
+    private val crashlytics: FirebaseCrashlytics,
+    @param:ApplicationContext private val context: Context
 ) : CrashlyticsLogger {
+    private val isDebuggable = (context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
+
     override fun recordException(message: String) {
-        crashlytics.recordException(Exception(message))
+        if (!isDebuggable) {
+            crashlytics.recordException(Exception(message))
+        }
     }
 
     override fun log(message: String) {
-        crashlytics.log(message)
+        if (!isDebuggable) {
+            crashlytics.log(message)
+        }
     }
 }
 

--- a/android/core/analytics/src/main/kotlin/com/andlife/analytics/crash/FirebaseCrashlyticsLogger.kt
+++ b/android/core/analytics/src/main/kotlin/com/andlife/analytics/crash/FirebaseCrashlyticsLogger.kt
@@ -1,12 +1,12 @@
 package com.andlife.analytics.crash
 
-import com.andlife.domain.util.CrashLogger
+import com.andlife.domain.util.CrashlyticsLogger
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import javax.inject.Inject
 
 class FirebaseCrashlyticsLogger @Inject constructor(
     private val crashlytics: FirebaseCrashlytics
-) : CrashLogger {
+) : CrashlyticsLogger {
     override fun recordException(message: String) {
         crashlytics.recordException(Exception(message))
     }

--- a/android/core/analytics/src/main/kotlin/com/andlife/analytics/crash/FirebaseCrashlyticsModule.kt
+++ b/android/core/analytics/src/main/kotlin/com/andlife/analytics/crash/FirebaseCrashlyticsModule.kt
@@ -1,6 +1,6 @@
 package com.andlife.analytics.crash
 
-import com.andlife.domain.util.CrashLogger
+import com.andlife.domain.util.CrashlyticsLogger
 import com.google.firebase.Firebase
 import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.google.firebase.crashlytics.crashlytics
@@ -25,5 +25,5 @@ abstract class FirebaseCrashlyticsBindModule {
     @Binds
     abstract fun bindFirebaseCrashlyticsLogger(
         firebaseCrashlyticsLogger: FirebaseCrashlyticsLogger
-    ): CrashLogger
+    ): CrashlyticsLogger
 }

--- a/android/domain/src/main/kotlin/com/andlife/domain/util/AnalyticsParams.kt
+++ b/android/domain/src/main/kotlin/com/andlife/domain/util/AnalyticsParams.kt
@@ -1,11 +1,49 @@
 package com.andlife.domain.util
 
 enum class Screen(val value: String) {
-
+    LOGIN("login"),
+    HOME("home"),
+    INVITATION("invitation"),
+    MY_INVITATION("my_invitation"),
+    INVITATION_DETAIL("invitation_detail"),
+    INVITATION_DETAIL_GUEST_BOOK("invitation_detail_guest_book"),
+    INVITATION_DETAIL_COLLECTION("invitation_detail_collection"),
+    MY_INVITATION_DETAIL("my_invitation_detail"),
+    MY_INVITATION_DETAIL_COLLECTION("my_invitation_detail_collection"),
+    MY_INVITATION_DETAIL_GUEST_BOOK("my_invitation_detail_guest_book"),
+    INVITATION_CREATE("invitation_create"),
+    INVITATION_PREVIEW("invitation_preview"),
+    SETTING("setting"),
 }
 
 enum class Button(val value: String) {
-
+    KAKAO_LOGIN("kakao_login"),
+    GUEST_LOGIN("guest_login"),
+    INVITATION_SORT_UPCOMING("invitation_sort_upcoming"),
+    INVITATION_SORT_PAST("invitation_sort_past"),
+    MY_INVITATION_SORT_UPCOMING("my_invitation_sort_upcoming"),
+    MY_INVITATION_SORT_PAST("my_invitation_sort_past"),
+    DELETE_INVITATION("delete_invitation"),
+    UPDATE_INVITATION("update_invitation"),
+    INVITATION_REPORT("invitation_report"),
+    INVITATION_LEAVE("invitation_leave"),
+    INVITATION_CREATE("invitation_create"),
+    PREVIEW_INVITATION("preview_invitation"),
+    CREATE_INVITATION_CARD("create_invitation_card"),
+    UPDATE_INVITATION_CARD("update_invitation_card"),
+    CREATE_THANKS_CARD("create_thanks_card"),
+    UPDATE_THANKS_CARD("update_thanks_card"),
+    DELETE_THANKS_CARD("delete_thanks_card"),
+    SHOW_THANKS_CARD("show_thanks_card"),
+    UPLOAD_GUEST_BOOK("upload_guest_book"),
+    UPDATE_GUEST_BOOK("update_guest_book"),
+    DELETE_GUEST_BOOK("delete_guest_book"),
+    GUEST_BOOK_REPORT("guest_book_report"),
+    SETTING_LOGOUT("setting_logout"),
+    SETTING_SIGN_OUT("setting_sign_out"),
+    SETTING_NICKNAME("setting_nickname"),
+    SETTING_PROFILE_IMAGE("setting_profile"),
+    MEDIA_DOWNLOAD("media_download"),
 }
 
 enum class LoginMethod(val value: String) {
@@ -19,5 +57,10 @@ enum class ShareMethod(val value: String) {
 }
 
 enum class EventType(val value: String) {
-
+    SUCCESS_REPORT_INVITATION("success_report_invitation"),
+    FAIL_REPORT_INVITATION("fail_report_invitation"),
+    SUCCESS_REPORT_GUESTBOOK("success_report_guestbook"),
+    FAIL_REPORT_GUESTBOOK("fail_report_guestbook"),
+    GUEST_BOOK_MAX_MEDIA("guest_book_max_media"),
+    GUEST_BOOK_MAX_SIZE("guest_book_max_size"),
 }

--- a/android/domain/src/main/kotlin/com/andlife/domain/util/CrashlyticsLogger.kt
+++ b/android/domain/src/main/kotlin/com/andlife/domain/util/CrashlyticsLogger.kt
@@ -1,6 +1,6 @@
 package com.andlife.domain.util
 
-interface CrashLogger {
+interface CrashlyticsLogger {
     fun recordException(message: String)
     fun log(message: String)
 }

--- a/android/feature/invitation-edit/src/main/kotlin/com/andlife/invitation_edit/model/form/InvitationFormSideEffect.kt
+++ b/android/feature/invitation-edit/src/main/kotlin/com/andlife/invitation_edit/model/form/InvitationFormSideEffect.kt
@@ -5,8 +5,8 @@ import com.andlife.ui.base.BaseSideEffect
 sealed interface InvitationFormSideEffect : BaseSideEffect {
     data object FullImage : InvitationFormSideEffect
     data object OnBack : InvitationFormSideEffect
-    data object FailLoad : InvitationFormSideEffect
     data object FailSave : InvitationFormSideEffect
     data class SuccessSave(val id: Long) : InvitationFormSideEffect
     data object InvalidTime : InvitationFormSideEffect
+    data object NavigateToPreview : InvitationFormSideEffect
 }

--- a/android/feature/invitation-edit/src/main/kotlin/com/andlife/invitation_edit/model/form/InvitationFormSideEffect.kt
+++ b/android/feature/invitation-edit/src/main/kotlin/com/andlife/invitation_edit/model/form/InvitationFormSideEffect.kt
@@ -6,6 +6,7 @@ sealed interface InvitationFormSideEffect : BaseSideEffect {
     data object FullImage : InvitationFormSideEffect
     data object OnBack : InvitationFormSideEffect
     data object FailSave : InvitationFormSideEffect
+    data object FailLoad : InvitationFormSideEffect
     data class SuccessSave(val id: Long) : InvitationFormSideEffect
     data object InvalidTime : InvitationFormSideEffect
     data object NavigateToPreview : InvitationFormSideEffect

--- a/android/feature/invitation-edit/src/main/kotlin/com/andlife/invitation_edit/model/form/InvitationFormUiEvent.kt
+++ b/android/feature/invitation-edit/src/main/kotlin/com/andlife/invitation_edit/model/form/InvitationFormUiEvent.kt
@@ -59,4 +59,6 @@ sealed interface InvitationFormUiEvent : BaseUiEvent {
     data object OnClickBack : InvitationFormUiEvent
 
     data object OnClickSave : InvitationFormUiEvent
+
+    data object OnClickPreview : InvitationFormUiEvent
 }

--- a/android/feature/invitation-edit/src/main/kotlin/com/andlife/invitation_edit/screen/create/InvitationCreateScreen.kt
+++ b/android/feature/invitation-edit/src/main/kotlin/com/andlife/invitation_edit/screen/create/InvitationCreateScreen.kt
@@ -109,6 +109,7 @@ fun InvitationCreateRoute(
             }
 
             InvitationFormSideEffect.NavigateToPreview -> onNavigateToPreview
+            InvitationFormSideEffect.FailLoad -> {}
         }
     }
 

--- a/android/feature/invitation-edit/src/main/kotlin/com/andlife/invitation_edit/screen/create/InvitationCreateScreen.kt
+++ b/android/feature/invitation-edit/src/main/kotlin/com/andlife/invitation_edit/screen/create/InvitationCreateScreen.kt
@@ -108,7 +108,7 @@ fun InvitationCreateRoute(
                 }
             }
 
-            else -> {}
+            InvitationFormSideEffect.NavigateToPreview -> onNavigateToPreview
         }
     }
 
@@ -143,7 +143,6 @@ fun InvitationCreateRoute(
         snackbarHostState = snackbarHostState,
         onEvent = viewModel::onEvent,
         onNavigateToAddressSearch = onNavigateToAddressSearch,
-        onNavigateToPreview = onNavigateToPreview,
         onAddImageClick = {
             pickMedia.launch(PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly))
         },
@@ -235,7 +234,6 @@ private fun InvitationCreateScreen(
     onStartTimeClick: () -> Unit,
     onEndTimeClick: () -> Unit,
     onNavigateToAddressSearch: () -> Unit,
-    onNavigateToPreview: () -> Unit,
     onAddAnnouncementClick: () -> Unit,
     onClickCreateCard: () -> Unit,
     onRemoveAnnouncementClick: (AnnouncementUiModel) -> Unit,
@@ -252,7 +250,7 @@ private fun InvitationCreateScreen(
             TopBarSection(
                 title = stringResource(R.string.txt_create),
                 onBackClick = { onEvent(InvitationFormUiEvent.OnClickBack) },
-                onPreviewClick = onNavigateToPreview,
+                onPreviewClick = { onEvent(InvitationFormUiEvent.OnClickPreview) },
                 isLoading = uiState.isLoading
             )
         },

--- a/android/feature/invitation-edit/src/main/kotlin/com/andlife/invitation_edit/screen/edit/InvitationEditScreen.kt
+++ b/android/feature/invitation-edit/src/main/kotlin/com/andlife/invitation_edit/screen/edit/InvitationEditScreen.kt
@@ -113,6 +113,8 @@ fun InvitationEditRoute(
                     snackbarHostState.showSnackbar(message = res.getString(R.string.snack_load_error_time))
                 }
             }
+
+            InvitationFormSideEffect.NavigateToPreview -> {}
         }
     }
 

--- a/android/feature/invitation-edit/src/main/kotlin/com/andlife/invitation_edit/viewmodel/InvitationCreateViewModel.kt
+++ b/android/feature/invitation-edit/src/main/kotlin/com/andlife/invitation_edit/viewmodel/InvitationCreateViewModel.kt
@@ -6,6 +6,11 @@ import androidx.lifecycle.viewModelScope
 import com.andlife.domain.util.Result
 import com.andlife.domain.error.DataError
 import com.andlife.domain.repository.invitation.InvitationRepository
+import com.andlife.domain.util.AnalyticsEvent
+import com.andlife.domain.util.AnalyticsEvent.*
+import com.andlife.domain.util.AnalyticsLogger
+import com.andlife.domain.util.Button
+import com.andlife.domain.util.EventType
 import com.andlife.domain.util.MediaFileProvider
 import com.andlife.domain.util.MediaUploader
 import com.andlife.domain.util.map
@@ -27,6 +32,7 @@ import com.andlife.model.editor.NachoUiCard
 import com.andlife.model.editor.toDomain
 import com.andlife.domain.util.RefreshEventHub
 import com.andlife.domain.util.RefreshEventHub.RefreshTarget
+import com.andlife.domain.util.Screen
 import com.andlife.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.toPersistentList
@@ -42,6 +48,7 @@ class InvitationCreateViewModel @Inject constructor(
     private val mediaUploader: MediaUploader,
     private val editorConverter: CardConverter,
     private val invitationRepository: InvitationRepository,
+    private val analyticsLogger: AnalyticsLogger
 ) : BaseViewModel<InvitationFormUiState, InvitationFormUiEvent, InvitationFormSideEffect>(
     InvitationFormUiState(),
 ) {
@@ -62,7 +69,15 @@ class InvitationCreateViewModel @Inject constructor(
             is InvitationFormUiEvent.RemoveImage -> updateRemoveImage(event)
             is InvitationFormUiEvent.RemoveAnnouncement -> updateRemoveAnnouncement(event)
             InvitationFormUiEvent.OnClickBack -> onBackClick()
-            InvitationFormUiEvent.OnClickSave -> createInvitation()
+            InvitationFormUiEvent.OnClickSave -> {
+                analyticsLogger.logEvent(ButtonClick(Screen.INVITATION_CREATE, Button.INVITATION_CREATE))
+                createInvitation()
+            }
+
+            InvitationFormUiEvent.OnClickPreview -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.INVITATION_PREVIEW, Button.PREVIEW_INVITATION))
+                sendEffect(InvitationFormSideEffect.NavigateToPreview)
+            }
         }
     }
 
@@ -168,7 +183,7 @@ class InvitationCreateViewModel @Inject constructor(
             .toPersistentList()
             .remove(event.announcement)
         updateState {
-            copy(invitationFormUiModel = invitationFormUiModel.copy(announcement = newAnnouncementList),)
+            copy(invitationFormUiModel = invitationFormUiModel.copy(announcement = newAnnouncementList))
         }
     }
 

--- a/android/feature/invitation-edit/src/main/kotlin/com/andlife/invitation_edit/viewmodel/InvitationEditViewModel.kt
+++ b/android/feature/invitation-edit/src/main/kotlin/com/andlife/invitation_edit/viewmodel/InvitationEditViewModel.kt
@@ -69,6 +69,7 @@ class InvitationEditViewModel @Inject constructor(
             is InvitationFormUiEvent.RemoveAnnouncement -> updateRemoveAnnouncement(event)
             InvitationFormUiEvent.OnClickBack -> onBackClick()
             InvitationFormUiEvent.OnClickSave -> updateInvitation()
+            InvitationFormUiEvent.OnClickPreview -> {}
         }
     }
 

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationCollectionViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationCollectionViewModel.kt
@@ -29,6 +29,11 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 import androidx.media3.common.Player
+import com.andlife.domain.util.AnalyticsEvent
+import com.andlife.domain.util.AnalyticsLogger
+import com.andlife.domain.util.Button
+import com.andlife.domain.util.CrashlyticsLogger
+import com.andlife.domain.util.Screen
 
 @HiltViewModel
 class InvitationCollectionViewModel @Inject constructor(
@@ -36,6 +41,8 @@ class InvitationCollectionViewModel @Inject constructor(
     private val mediaDownloader: MediaDownloader,
     private val userRepository: UserRepository,
     val playerPool: StoryMediaPlayerPool,
+    private val analyticsLogger: AnalyticsLogger,
+    private val crashlyticsLogger: CrashlyticsLogger,
     @param:ApplicationContext private val context: Context,
     savedStateHandle: SavedStateHandle
 ) : BaseViewModel<InvitationCollectionUiState, InvitationCollectionUiEvent, InvitationCollectionSideEffect>(
@@ -62,7 +69,10 @@ class InvitationCollectionViewModel @Inject constructor(
             is InvitationCollectionUiEvent.CloseStory -> closeStory()
             is InvitationCollectionUiEvent.PageChanged -> pageChanged(event.index)
             is InvitationCollectionUiEvent.ToggleExpand -> toggleExpand()
-            is InvitationCollectionUiEvent.DownloadMedia -> downloadCurrentMedia()
+            is InvitationCollectionUiEvent.DownloadMedia -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.INVITATION_DETAIL_COLLECTION, Button.MEDIA_DOWNLOAD))
+                downloadCurrentMedia()
+            }
             is InvitationCollectionUiEvent.DisableNetworkDialogPermanently -> disableNetworkDialogPermanently()
         }
     }
@@ -215,6 +225,7 @@ class InvitationCollectionViewModel @Inject constructor(
                         updateState { copy(downloadState = DownloadState.Idle) }
                     }
                     is DownloadState.Error -> {
+                        crashlyticsLogger.log(state.message)
                         updateState { copy(downloadingUrls = downloadingUrls - url) }
                         sendEffect(InvitationCollectionSideEffect.DownloadFailed)
                         updateState { copy(downloadState = DownloadState.Idle) }

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationDetailViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationDetailViewModel.kt
@@ -6,6 +6,9 @@ import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import androidx.navigation.toRoute
 import com.andlife.domain.repository.invitation.InvitationRepository
+import com.andlife.domain.util.AnalyticsEvent
+import com.andlife.domain.util.AnalyticsLogger
+import com.andlife.domain.util.Button
 import com.andlife.domain.util.onFailure
 import com.andlife.domain.util.onSuccess
 import com.andlife.invitation.InvitationDetail
@@ -15,6 +18,7 @@ import com.andlife.invitation.model.detail.InvitationDetailUiState
 import com.andlife.model.invitation.toContentsUiModel
 import com.andlife.domain.util.RefreshEventHub
 import com.andlife.domain.util.RefreshEventHub.RefreshTarget
+import com.andlife.domain.util.Screen
 import com.andlife.ui.base.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
@@ -29,6 +33,7 @@ import javax.inject.Inject
 class InvitationDetailViewModel @Inject constructor(
     savedStateHandle: SavedStateHandle,
     private val invitationRepository: InvitationRepository,
+    private val analyticsLogger: AnalyticsLogger
 ) : BaseViewModel<InvitationDetailUiState, InvitationDetailUiEvent, InvitationDetailSideEffect>(
     initialState = InvitationDetailUiState(),
 ) {
@@ -86,8 +91,14 @@ class InvitationDetailViewModel @Inject constructor(
     override fun onEvent(event: InvitationDetailUiEvent) {
         when (event) {
             is InvitationDetailUiEvent.ClickBack -> clickClose()
-            is InvitationDetailUiEvent.ClickThanksCard -> showThanksCardOnboarding()
-            is InvitationDetailUiEvent.ClickLeaveInvitation -> leaveInvitation()
+            is InvitationDetailUiEvent.ClickThanksCard -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.INVITATION_DETAIL, Button.SHOW_THANKS_CARD))
+                showThanksCardOnboarding()
+            }
+            is InvitationDetailUiEvent.ClickLeaveInvitation -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.INVITATION_DETAIL, Button.INVITATION_LEAVE))
+                leaveInvitation()
+            }
             is InvitationDetailUiEvent.ClickImage -> navigateToFullScreenImage(event.imageList, event.index)
             is InvitationDetailUiEvent.MapError -> showMapErrorSnackbar()
             is InvitationDetailUiEvent.RetryLoad -> retryLoad()

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationGuestBookViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationGuestBookViewModel.kt
@@ -15,11 +15,17 @@ import com.andlife.domain.model.guestbook.MediaType
 import com.andlife.domain.repository.auth.AuthStateManager
 import com.andlife.domain.repository.guestbook.GuestBookRepository
 import com.andlife.domain.repository.report.ReportRepository
+import com.andlife.domain.util.AnalyticsEvent
+import com.andlife.domain.util.AnalyticsLogger
+import com.andlife.domain.util.Button
+import com.andlife.domain.util.CrashlyticsLogger
+import com.andlife.domain.util.EventType
 import com.andlife.domain.util.MediaFileProvider
 import com.andlife.domain.util.MediaUploader
 import com.andlife.domain.util.RefreshEventHub
 import com.andlife.domain.util.RefreshEventHub.RefreshTarget
 import com.andlife.domain.util.Result
+import com.andlife.domain.util.Screen
 import com.andlife.domain.util.ThumbnailGenerator
 import com.andlife.domain.util.onFailure
 import com.andlife.domain.util.onSuccess
@@ -65,6 +71,8 @@ constructor(
     private val authStateManager: AuthStateManager,
     val audioPlayerManager: AudioPlayerManager,
     val videoPlayerPool: AutoVideoPlayerPool,
+    private val analyticsLogger: AnalyticsLogger,
+    private val crashlyticsLogger: CrashlyticsLogger,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<InvitationGuestBookUiState, InvitationGuestBookUiEvent, InvitationGuestBookSideEffect>(
     InvitationGuestBookUiState(),
@@ -121,23 +129,35 @@ constructor(
 
             is InvitationGuestBookUiEvent.UpdateTextContent -> updateTextContent(event.textContent)
             is InvitationGuestBookUiEvent.RemoveMedia -> removeMedia(event.media)
-            is InvitationGuestBookUiEvent.UploadMedias -> handleUploadMedias()
+            is InvitationGuestBookUiEvent.UploadMedias -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.INVITATION_DETAIL_GUEST_BOOK, Button.UPLOAD_GUEST_BOOK))
+                handleUploadMedias()
+            }
             is InvitationGuestBookUiEvent.ClickCamera -> handleCameraClick()
             is InvitationGuestBookUiEvent.ClickMicrophone -> handleMicrophoneClick()
             is InvitationGuestBookUiEvent.ClearError -> clearError()
             is InvitationGuestBookUiEvent.ClickAudioMedia -> clickAudioMedia(event.url)
             is InvitationGuestBookUiEvent.ClickVideoPlayButton -> clickVideoPlayButton(event.url, event.itemId)
             is InvitationGuestBookUiEvent.ClickVisualMedia -> {}
-            is InvitationGuestBookUiEvent.ClickEditMenu -> startEditing(event.guestBook)
+            is InvitationGuestBookUiEvent.ClickEditMenu -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.INVITATION_DETAIL_GUEST_BOOK, Button.UPDATE_GUEST_BOOK))
+                startEditing(event.guestBook)
+            }
             is InvitationGuestBookUiEvent.CancelEdit -> cancelEdit()
-            is InvitationGuestBookUiEvent.ClickDeleteMenu -> deleteGuestBook(event.guestBookId)
+            is InvitationGuestBookUiEvent.ClickDeleteMenu -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.INVITATION_DETAIL_GUEST_BOOK, Button.DELETE_GUEST_BOOK))
+                deleteGuestBook(event.guestBookId)
+            }
             is InvitationGuestBookUiEvent.UpdateMediaPlayState -> updatePlayState(event.isPlaying)
             InvitationGuestBookUiEvent.Refresh -> refresh()
             InvitationGuestBookUiEvent.CheckLogin -> checkLogin()
             InvitationGuestBookUiEvent.DismissLoginDialog -> dismissLoginDialog()
             is InvitationGuestBookUiEvent.ShowReport -> updateReportTargetId(event.targetId)
             InvitationGuestBookUiEvent.DismissReport -> updateReportTargetId(null)
-            is InvitationGuestBookUiEvent.SubmitReport -> submitReport(event.reason, event.description)
+            is InvitationGuestBookUiEvent.SubmitReport -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.INVITATION_DETAIL_GUEST_BOOK, Button.GUEST_BOOK_REPORT))
+                submitReport(event.reason, event.description)
+            }
         }
     }
 
@@ -175,6 +195,7 @@ constructor(
 
         // 용량 초과로 거부된 파일이 있으면 스낵바로 알림
         if (exceededAvailableBytes) {
+            analyticsLogger.logEvent(AnalyticsEvent.Event(EventType.GUEST_BOOK_MAX_SIZE.value))
             sendEffect(
                 InvitationGuestBookSideEffect.ShowSnackbar(
                     "파일이 500MB를 초과하여 제외되었습니다."
@@ -184,6 +205,7 @@ constructor(
 
         // 제외된 파일이 있으면 스낵바로 알림(후순위)
         else if (exceededAvailableSlots) {
+            analyticsLogger.logEvent(AnalyticsEvent.Event(EventType.GUEST_BOOK_MAX_MEDIA.value))
             sendEffect(
                 InvitationGuestBookSideEffect.ShowSnackbar(
                     "파일은 20개까지만 추가 가능합니다."
@@ -295,6 +317,7 @@ constructor(
                     updateGuestBook(state.editingGuestBookId, uploadedUrls, thumbnailUrls, state.selectedMedias)
                 }
             } catch (e: Exception) {
+                crashlyticsLogger.log(e.message ?: "upload Error")
                 updateState { copy(isUploading = false) }
                 sendEffect(InvitationGuestBookSideEffect.ShowSnackbar("업로드 중 오류 발생: ${e.message}"))
                 return@launch
@@ -551,9 +574,19 @@ constructor(
                 reason = reason.name,
                 description = description
             ).onSuccess {
+                analyticsLogger.logEvent(AnalyticsEvent.Event(EventType.SUCCESS_REPORT_GUESTBOOK.value))
                 updateState { copy(reportTargetId = null) }
                 sendEffect(InvitationGuestBookSideEffect.ReportSuccess)
             }.onFailure { error, message ->
+                analyticsLogger.logEvent(
+                    AnalyticsEvent.Event(
+                        EventType.FAIL_REPORT_GUESTBOOK.value, mapOf(
+                            "id" to targetId.toString(),
+                            "error" to "$error: $message"
+                        )
+                    )
+                )
+                crashlyticsLogger.recordException("$targetId: $error - $message")
                 val messageToShow = if (error == DataError.Network.CONFLICT) {
                     message
                 } else {

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationViewModel.kt
@@ -12,8 +12,14 @@ import com.andlife.domain.model.invitation.SortDirection
 import com.andlife.domain.repository.auth.AuthStateManager
 import com.andlife.domain.repository.invitation.InvitationRepository
 import com.andlife.domain.repository.report.ReportRepository
+import com.andlife.domain.util.AnalyticsEvent
+import com.andlife.domain.util.AnalyticsLogger
+import com.andlife.domain.util.Button
+import com.andlife.domain.util.CrashlyticsLogger
+import com.andlife.domain.util.EventType
 import com.andlife.domain.util.RefreshEventHub
 import com.andlife.domain.util.RefreshEventHub.RefreshTarget
+import com.andlife.domain.util.Screen
 import com.andlife.domain.util.onFailure
 import com.andlife.domain.util.onSuccess
 import com.andlife.invitation.model.InvitationSideEffect
@@ -42,7 +48,9 @@ import javax.inject.Inject
 class InvitationViewModel @Inject constructor(
     private val invitationRepository: InvitationRepository,
     private val reportRepository: ReportRepository,
-    private val authStateManager: AuthStateManager
+    private val authStateManager: AuthStateManager,
+    private val analyticsLogger: AnalyticsLogger,
+    private val crashlyticsLogger: CrashlyticsLogger,
 ) : BaseViewModel<InvitationUiState, InvitationUiEvent, InvitationSideEffect>(
     initialState = InvitationUiState()
 ) {
@@ -110,16 +118,27 @@ class InvitationViewModel @Inject constructor(
             is InvitationUiEvent.ClickInvitation -> {
                 sendEffect(InvitationSideEffect.NavigateToDetail(event.id))
             }
+
             is InvitationUiEvent.ChangeSort -> {
                 if (event.isUpcoming) {
+                    analyticsLogger.logEvent(
+                        AnalyticsEvent.ButtonClick(
+                            Screen.INVITATION,
+                            Button.INVITATION_SORT_UPCOMING
+                        )
+                    )
                     _upcomingSort.value = event.newSort
                 } else {
+                    analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.INVITATION, Button.INVITATION_SORT_PAST))
                     _pastSort.value = event.newSort
                 }
             }
+
             is InvitationUiEvent.ClickLeaveInvitation -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.INVITATION, Button.INVITATION_LEAVE))
                 leaveInvitation(event.id)
             }
+
             is InvitationUiEvent.ShowReport -> {
                 val authState = authStateManager.authState.value
                 if (authState !is AuthState.Authenticated) {
@@ -129,12 +148,16 @@ class InvitationViewModel @Inject constructor(
                     updateState { copy(reportTargetId = event.invitationId) }
                 }
             }
+
             is InvitationUiEvent.DismissReport -> {
                 updateState { copy(reportTargetId = null) }
             }
+
             is InvitationUiEvent.SubmitReport -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.INVITATION, Button.INVITATION_REPORT))
                 submitReport(event.reason, event.description)
             }
+
             is InvitationUiEvent.DismissLoginDialog -> {
                 updateState { copy(showLoginDialog = false) }
             }
@@ -175,9 +198,19 @@ class InvitationViewModel @Inject constructor(
                 reason = reason.name,
                 description = description
             ).onSuccess {
+                analyticsLogger.logEvent(AnalyticsEvent.Event(EventType.SUCCESS_REPORT_INVITATION.value))
                 updateState { copy(reportTargetId = null) }
                 sendEffect(InvitationSideEffect.ReportSuccess)
             }.onFailure { error, message ->
+                analyticsLogger.logEvent(
+                    AnalyticsEvent.Event(
+                        EventType.FAIL_REPORT_INVITATION.value, mapOf(
+                            "id" to targetId.toString(),
+                            "error" to "$error: $message"
+                        )
+                    )
+                )
+                crashlyticsLogger.recordException("$targetId: $error - $message")
                 val messageToShow = if (error == DataError.Network.CONFLICT) {
                     message
                 } else {

--- a/android/feature/login/src/main/kotlin/com/andlife/login/viewmodel/LoginViewModel.kt
+++ b/android/feature/login/src/main/kotlin/com/andlife/login/viewmodel/LoginViewModel.kt
@@ -1,13 +1,16 @@
 package com.andlife.login.viewmodel
 
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
-import androidx.navigation.toRoute
 import com.andlife.domain.repository.auth.AuthStateManager
 import com.andlife.domain.repository.user.UserRepository
+import com.andlife.domain.util.AnalyticsEvent
+import com.andlife.domain.util.AnalyticsLogger
+import com.andlife.domain.util.Button
+import com.andlife.domain.util.CrashlyticsLogger
+import com.andlife.domain.util.LoginMethod
+import com.andlife.domain.util.Screen
 import com.andlife.domain.util.onFailure
 import com.andlife.domain.util.onSuccess
-import com.andlife.login.Login
 import com.andlife.login.model.LoginSideEffect
 import com.andlife.login.model.LoginUiEvent
 import com.andlife.login.model.LoginUiState
@@ -22,13 +25,21 @@ import javax.inject.Inject
 class LoginViewModel @Inject constructor(
     private val userRepository: UserRepository,
     private val authStateManager: AuthStateManager,
+    private val analyticsLogger: AnalyticsLogger,
+    private val crashLogger: CrashlyticsLogger,
 ) : BaseViewModel<LoginUiState, LoginUiEvent, LoginSideEffect>(LoginUiState()) {
 
     override val uiState: StateFlow<LoginUiState> = mutableUiState.asStateFlow()
     override fun onEvent(event: LoginUiEvent) {
         when (event) {
-            LoginUiEvent.GuestLogin -> guest()
-            is LoginUiEvent.SocialLoginSuccess -> login(event.accessToken)
+            LoginUiEvent.GuestLogin -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.LOGIN, Button.GUEST_LOGIN))
+                guest()
+            }
+            is LoginUiEvent.SocialLoginSuccess -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.LOGIN, Button.KAKAO_LOGIN))
+                login(event.accessToken)
+            }
             LoginUiEvent.TestLogin -> testLogin()
         }
     }
@@ -38,9 +49,11 @@ class LoginViewModel @Inject constructor(
             updateState { copy(true) }
             userRepository.login(accessToken)
                 .onFailure { error, msg ->
+                    crashLogger.recordException("$error: $msg")
                     sendEffect(LoginSideEffect.FailSocialLogin)
                 }
                 .onSuccess {
+                    analyticsLogger.logEvent(AnalyticsEvent.Login(LoginMethod.KAKAO))
                     authStateManager.navigateToHome()
                 }
             updateState { copy(false) }
@@ -66,9 +79,11 @@ class LoginViewModel @Inject constructor(
             updateState { copy(true) }
             userRepository.guestLogin()
                 .onFailure { error, msg ->
+                    crashLogger.recordException("$error: $msg")
                     sendEffect(LoginSideEffect.FailGuestLogin)
                 }
                 .onSuccess {
+                    analyticsLogger.logEvent(AnalyticsEvent.Login(LoginMethod.GUEST))
                     authStateManager.navigateToHome()
                 }
             updateState { copy(false) }

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationCollectionViewModel.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationCollectionViewModel.kt
@@ -9,7 +9,12 @@ import com.andlife.domain.model.guestbook.DownloadState
 import com.andlife.domain.model.guestbook.MediaType
 import com.andlife.domain.repository.guestbook.GuestBookRepository
 import com.andlife.domain.repository.user.UserRepository
+import com.andlife.domain.util.AnalyticsEvent
+import com.andlife.domain.util.AnalyticsLogger
+import com.andlife.domain.util.Button
+import com.andlife.domain.util.CrashlyticsLogger
 import com.andlife.domain.util.MediaDownloader
+import com.andlife.domain.util.Screen
 import com.andlife.domain.util.onFailure
 import com.andlife.domain.util.onSuccess
 import com.andlife.model.collection.toUiModel
@@ -36,6 +41,8 @@ class MyInvitationCollectionViewModel @Inject constructor(
     private val mediaDownloader: MediaDownloader,
     private val userRepository: UserRepository,
     val playerPool: StoryMediaPlayerPool,
+    private val analyticsLogger: AnalyticsLogger,
+    private val crashlyticsLogger: CrashlyticsLogger,
     @param:ApplicationContext private val context: Context,
     savedStateHandle: SavedStateHandle
 ) : BaseViewModel<MyInvitationCollectionUiState, MyInvitationCollectionUiEvent, MyInvitationCollectionSideEffect>(
@@ -61,7 +68,10 @@ class MyInvitationCollectionViewModel @Inject constructor(
             is MyInvitationCollectionUiEvent.CloseStory -> closeStory()
             is MyInvitationCollectionUiEvent.PageChanged -> pageChanged(event.index)
             is MyInvitationCollectionUiEvent.ToggleExpand -> toggleExpand()
-            is MyInvitationCollectionUiEvent.DownloadMedia -> downloadCurrentMedia()
+            is MyInvitationCollectionUiEvent.DownloadMedia -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.MY_INVITATION_DETAIL_COLLECTION, Button.MEDIA_DOWNLOAD))
+                downloadCurrentMedia()
+            }
             is MyInvitationCollectionUiEvent.DisableNetworkDialogPermanently -> disableNetworkDialogPermanently()
         }
     }
@@ -200,6 +210,7 @@ class MyInvitationCollectionViewModel @Inject constructor(
                     }
 
                     is DownloadState.Error -> {
+                        crashlyticsLogger.log(state.message)
                         updateState { copy(downloadingUrls = downloadingUrls - url) }
                         sendEffect(MyInvitationCollectionSideEffect.DownloadFailed)
                         updateState { copy(downloadState = DownloadState.Idle) }

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationDetailViewModel.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationDetailViewModel.kt
@@ -11,8 +11,13 @@ import androidx.navigation.toRoute
 import com.andlife.deeplink.DeepLinkManager
 import com.andlife.domain.repository.invitation.InvitationRepository
 import com.andlife.domain.repository.thankscard.ThanksCardRepository
+import com.andlife.domain.util.AnalyticsEvent
+import com.andlife.domain.util.AnalyticsLogger
+import com.andlife.domain.util.Button
 import com.andlife.domain.util.RefreshEventHub
 import com.andlife.domain.util.RefreshEventHub.RefreshTarget
+import com.andlife.domain.util.Screen
+import com.andlife.domain.util.ShareMethod
 import com.andlife.domain.util.onFailure
 import com.andlife.domain.util.onSuccess
 import com.andlife.editor.util.CreateCardSession
@@ -42,6 +47,7 @@ class MyInvitationDetailViewModel @Inject constructor(
     private val deepLinkManager: DeepLinkManager,
     private val clipboardManager: ClipboardManager,
     private val thanksCardRepository: ThanksCardRepository,
+    private val analyticsLogger: AnalyticsLogger
 ) : BaseViewModel<MyInvitationDetailUiState, MyInvitationDetailUiEvent, MyInvitationDetailSideEffect>(
     initialState = MyInvitationDetailUiState(),
 ) {
@@ -80,18 +86,55 @@ class MyInvitationDetailViewModel @Inject constructor(
         when (event) {
             is MyInvitationDetailUiEvent.ClickBack -> clickClose()
             is MyInvitationDetailUiEvent.ClickThanksCard -> showThanksCardOnboarding()
-            is MyInvitationDetailUiEvent.ClickShare -> shareInvitation()
-            is MyInvitationDetailUiEvent.ClickEdit -> navigateToEditInvitation()
-            is MyInvitationDetailUiEvent.ClickDelete -> deleteInvitation()
-            is MyInvitationDetailUiEvent.CreateThanksCard -> navigateToCreateThanksCard()
-            is MyInvitationDetailUiEvent.ClickEditCard -> navigateToEditCard()
+            is MyInvitationDetailUiEvent.ClickShare -> {
+                analyticsLogger.logEvent(
+                    AnalyticsEvent.Share(
+                        myInvitationId.toString(),
+                        ShareMethod.KAKAO_LINK
+                    )
+                )
+                shareInvitation()
+            }
+            is MyInvitationDetailUiEvent.ClickEdit -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.MY_INVITATION_DETAIL, Button.UPDATE_INVITATION))
+                navigateToEditInvitation()
+            }
+            is MyInvitationDetailUiEvent.ClickDelete -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.MY_INVITATION_DETAIL, Button.DELETE_INVITATION))
+                deleteInvitation()
+            }
+            is MyInvitationDetailUiEvent.CreateThanksCard -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.MY_INVITATION_DETAIL, Button.CREATE_THANKS_CARD))
+                navigateToCreateThanksCard()
+            }
+            is MyInvitationDetailUiEvent.ClickEditCard -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.MY_INVITATION_DETAIL, Button.UPDATE_INVITATION_CARD))
+                navigateToEditCard()
+            }
             is MyInvitationDetailUiEvent.ClickImage -> navigateToFullScreenImage(event.imageList, event.index)
             is MyInvitationDetailUiEvent.MapError -> showMapErrorSnackbar()
             is MyInvitationDetailUiEvent.RetryLoad -> retryLoad()
-            MyInvitationDetailUiEvent.ClickCreateCard -> navigateToCreateCard()
-            MyInvitationDetailUiEvent.CopyInvitationLink -> copyInvitationLink()
-            MyInvitationDetailUiEvent.ClickDeleteThanksCard -> deleteThanksCard()
-            is MyInvitationDetailUiEvent.ClickUpdateThanksCard -> updateThanksCard(event.cardId)
+            MyInvitationDetailUiEvent.ClickCreateCard -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.MY_INVITATION_DETAIL, Button.CREATE_INVITATION_CARD))
+                navigateToCreateCard()
+            }
+            MyInvitationDetailUiEvent.CopyInvitationLink -> {
+                analyticsLogger.logEvent(
+                    AnalyticsEvent.Share(
+                        myInvitationId.toString(),
+                        ShareMethod.CLIPBOARD
+                    )
+                )
+                copyInvitationLink()
+            }
+            MyInvitationDetailUiEvent.ClickDeleteThanksCard -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.MY_INVITATION_DETAIL, Button.DELETE_THANKS_CARD))
+                deleteThanksCard()
+            }
+            is MyInvitationDetailUiEvent.ClickUpdateThanksCard -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.MY_INVITATION_DETAIL, Button.UPDATE_THANKS_CARD))
+                updateThanksCard(event.cardId)
+            }
             MyInvitationDetailUiEvent.LottieStarted -> updateLottieStarted()
         }
     }

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationGuestBookViewModel.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationGuestBookViewModel.kt
@@ -15,11 +15,17 @@ import com.andlife.domain.model.guestbook.MediaType
 import com.andlife.domain.repository.auth.AuthStateManager
 import com.andlife.domain.repository.guestbook.GuestBookRepository
 import com.andlife.domain.repository.report.ReportRepository
+import com.andlife.domain.util.AnalyticsEvent
+import com.andlife.domain.util.AnalyticsLogger
+import com.andlife.domain.util.Button
+import com.andlife.domain.util.CrashlyticsLogger
+import com.andlife.domain.util.EventType
 import com.andlife.domain.util.MediaFileProvider
 import com.andlife.domain.util.MediaUploader
 import com.andlife.domain.util.RefreshEventHub
 import com.andlife.domain.util.RefreshEventHub.RefreshTarget
 import com.andlife.domain.util.Result
+import com.andlife.domain.util.Screen
 import com.andlife.domain.util.ThumbnailGenerator
 import com.andlife.domain.util.onFailure
 import com.andlife.domain.util.onSuccess
@@ -65,6 +71,8 @@ constructor(
     private val authStateManager: AuthStateManager,
     val audioPlayerManager: AudioPlayerManager,
     val videoPlayerPool: AutoVideoPlayerPool,
+    private val analyticsLogger: AnalyticsLogger,
+    private val crashlyticsLogger: CrashlyticsLogger,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<MyInvitationGuestBookUiState, MyInvitationGuestBookUiEvent, MyInvitationGuestBookSideEffect>(
     MyInvitationGuestBookUiState(),
@@ -121,23 +129,35 @@ constructor(
 
             is MyInvitationGuestBookUiEvent.UpdateTextContent -> updateTextContent(event.textContent)
             is MyInvitationGuestBookUiEvent.RemoveMedia -> removeMedia(event.media)
-            is MyInvitationGuestBookUiEvent.UploadMedias -> handleUploadMedias()
+            is MyInvitationGuestBookUiEvent.UploadMedias -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.MY_INVITATION_DETAIL_GUEST_BOOK, Button.UPLOAD_GUEST_BOOK))
+                handleUploadMedias()
+            }
             is MyInvitationGuestBookUiEvent.ClickCamera -> handleCameraClick()
             is MyInvitationGuestBookUiEvent.ClickMicrophone -> handleMicrophoneClick()
             is MyInvitationGuestBookUiEvent.ClearError -> clearError()
             is MyInvitationGuestBookUiEvent.ClickAudioMedia -> clickAudioMedia(event.url)
             is MyInvitationGuestBookUiEvent.ClickVideoPlayButton -> clickVideoPlayButton(event.url, event.itemId)
             is MyInvitationGuestBookUiEvent.ClickVisualMedia -> {}
-            is MyInvitationGuestBookUiEvent.ClickEditMenu -> startEditing(event.guestBook)
+            is MyInvitationGuestBookUiEvent.ClickEditMenu -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.MY_INVITATION_DETAIL_GUEST_BOOK, Button.UPDATE_GUEST_BOOK))
+                startEditing(event.guestBook)
+            }
             is MyInvitationGuestBookUiEvent.CancelEdit -> cancelEdit()
-            is MyInvitationGuestBookUiEvent.ClickDeleteMenu -> deleteGuestBook(event.guestBookId)
+            is MyInvitationGuestBookUiEvent.ClickDeleteMenu -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.MY_INVITATION_DETAIL_GUEST_BOOK, Button.DELETE_GUEST_BOOK))
+                deleteGuestBook(event.guestBookId)
+            }
             is MyInvitationGuestBookUiEvent.UpdateMediaPlayState -> updatePlayState(event.isPlaying)
             MyInvitationGuestBookUiEvent.Refresh -> refresh()
             MyInvitationGuestBookUiEvent.CheckLogin -> checkLogin()
             MyInvitationGuestBookUiEvent.DismissLoginDialog -> dismissLoginDialog()
             is MyInvitationGuestBookUiEvent.ShowReport -> updateReportTargetId(event.guestBookId)
             MyInvitationGuestBookUiEvent.DismissReport -> updateReportTargetId(null)
-            is MyInvitationGuestBookUiEvent.SubmitReport -> submitReport(event.reason, event.description)
+            is MyInvitationGuestBookUiEvent.SubmitReport -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.MY_INVITATION_DETAIL_GUEST_BOOK, Button.INVITATION_REPORT))
+                submitReport(event.reason, event.description)
+            }
         }
     }
 
@@ -175,6 +195,7 @@ constructor(
 
         // 용량 초과로 거부된 파일이 있으면 스낵바로 알림
         if (exceededAvailableBytes) {
+            analyticsLogger.logEvent(AnalyticsEvent.Event(EventType.GUEST_BOOK_MAX_SIZE.value))
             sendEffect(
                 MyInvitationGuestBookSideEffect.ShowSnackbar(
                     "파일이 500MB를 초과하여 제외되었습니다."
@@ -184,6 +205,7 @@ constructor(
 
         // 제외된 파일이 있으면 스낵바로 알림 (후순위)
         else if (exceededAvailableSlots) {
+            analyticsLogger.logEvent(AnalyticsEvent.Event(EventType.GUEST_BOOK_MAX_MEDIA.value))
             sendEffect(
                 MyInvitationGuestBookSideEffect.ShowSnackbar(
                     "파일은 20개까지만 추가 가능합니다."
@@ -285,6 +307,7 @@ constructor(
                     updateGuestBook(state.editingGuestBookId, uploadedUrls, thumbnailUrls, state.selectedMedias)
                 }
             } catch (e: Exception) {
+                crashlyticsLogger.log(e.message ?: "upload Error")
                 updateState { copy(isUploading = false) }
                 sendEffect(MyInvitationGuestBookSideEffect.ShowSnackbar("업로드 중 오류 발생: ${e.message}"))
                 return@launch
@@ -541,9 +564,19 @@ constructor(
                 reason = reason.name,
                 description = description
             ).onSuccess {
+                analyticsLogger.logEvent(AnalyticsEvent.Event(EventType.SUCCESS_REPORT_GUESTBOOK.value))
                 updateState { copy(reportTargetId = null) }
                 sendEffect(MyInvitationGuestBookSideEffect.ReportSuccess)
             }.onFailure { error, message ->
+                analyticsLogger.logEvent(
+                    AnalyticsEvent.Event(
+                        EventType.FAIL_REPORT_GUESTBOOK.value, mapOf(
+                            "id" to targetId.toString(),
+                            "error" to "$error: $message"
+                        )
+                    )
+                )
+                crashlyticsLogger.recordException("$targetId: $error - $message")
                 val messageToShow = if (error == DataError.Network.CONFLICT) {
                     message
                 } else {

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationViewModel.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationViewModel.kt
@@ -8,6 +8,10 @@ import com.andlife.domain.model.invitation.InvitationStatus
 import com.andlife.domain.model.invitation.SortDirection
 import com.andlife.domain.repository.auth.AuthStateManager
 import com.andlife.domain.repository.invitation.InvitationRepository
+import com.andlife.domain.util.AnalyticsEvent
+import com.andlife.domain.util.AnalyticsLogger
+import com.andlife.domain.util.Button
+import com.andlife.domain.util.Screen
 import com.andlife.domain.util.onFailure
 import com.andlife.domain.util.onSuccess
 import com.andlife.model.invitation.InvitationSummaryUiModel
@@ -34,7 +38,8 @@ import javax.inject.Inject
 @HiltViewModel
 class MyInvitationViewModel @Inject constructor(
     private val invitationRepository: InvitationRepository,
-    private val authStateManager: AuthStateManager
+    private val authStateManager: AuthStateManager,
+    private val analyticsLogger: AnalyticsLogger
 ) : BaseViewModel<MyInvitationUiState, MyInvitationUiEvent, MyInvitationSideEffect>(
     initialState = MyInvitationUiState()
 ) {
@@ -104,8 +109,10 @@ class MyInvitationViewModel @Inject constructor(
             }
             is MyInvitationUiEvent.ChangeSort -> {
                 if (event.isUpcoming) {
+                    analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.MY_INVITATION, Button.MY_INVITATION_SORT_UPCOMING))
                     _upcomingSort.value = event.newSort
                 } else {
+                    analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.MY_INVITATION, Button.MY_INVITATION_SORT_PAST))
                     _pastSort.value = event.newSort
                 }
             }
@@ -113,6 +120,7 @@ class MyInvitationViewModel @Inject constructor(
                 sendEffect(MyInvitationSideEffect.NavigateToCreate)
             }
             is MyInvitationUiEvent.ClickDeleteInvitation -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.MY_INVITATION, Button.DELETE_INVITATION))
                 deleteInvitation(event.id)
             }
 

--- a/android/feature/setting/src/main/kotlin/com/andlife/setting/viewmodel/SettingViewModel.kt
+++ b/android/feature/setting/src/main/kotlin/com/andlife/setting/viewmodel/SettingViewModel.kt
@@ -3,6 +3,10 @@ package com.andlife.setting.viewmodel
 import androidx.lifecycle.viewModelScope
 import com.andlife.domain.model.auth.AuthState
 import com.andlife.domain.repository.user.UserRepository
+import com.andlife.domain.util.AnalyticsEvent
+import com.andlife.domain.util.AnalyticsLogger
+import com.andlife.domain.util.Button
+import com.andlife.domain.util.Screen
 import com.andlife.domain.util.onFailure
 import com.andlife.domain.util.onSuccess
 import com.andlife.setting.model.NicknameError
@@ -21,7 +25,8 @@ import javax.inject.Inject
 
 @HiltViewModel
 class SettingViewModel @Inject constructor(
-    private val userRepository: UserRepository
+    private val userRepository: UserRepository,
+    private val analyticsLogger: AnalyticsLogger
 ) : BaseViewModel<SettingUiState, SettingUiEvent, SettingSideEffect>(SettingUiState()) {
 
     override val uiState: StateFlow<SettingUiState> = mutableUiState
@@ -37,11 +42,23 @@ class SettingViewModel @Inject constructor(
     override fun onEvent(event: SettingUiEvent) {
         when (event) {
             is SettingUiEvent.OnNicknameChanged -> validateNickname(event.nickname)
-            is SettingUiEvent.ClickConfirmNickname -> updateProfile(event.nickname)
-            is SettingUiEvent.ClickConfirmProfileImage -> updateProfile(imageUri = event.uri)
+            is SettingUiEvent.ClickConfirmNickname -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.SETTING, Button.SETTING_NICKNAME))
+                updateProfile(event.nickname)
+            }
+            is SettingUiEvent.ClickConfirmProfileImage -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.SETTING, Button.SETTING_PROFILE_IMAGE))
+                updateProfile(imageUri = event.uri)
+            }
             SettingUiEvent.ClickBack -> sendEffect(SettingSideEffect.PopBackStack)
-            SettingUiEvent.ClickLogout -> logout()
-            SettingUiEvent.ClickSignOut -> signOut()
+            SettingUiEvent.ClickLogout -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.SETTING, Button.SETTING_LOGOUT))
+                logout()
+            }
+            SettingUiEvent.ClickSignOut -> {
+                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.SETTING, Button.SETTING_SIGN_OUT))
+                signOut()
+            }
         }
     }
 


### PR DESCRIPTION
## 🔍 변경 사항
- [x] Analytics 로그 수집
- [x] Crashlytics 수집

### 무엇을 수집할 것인가?
Analytics에선 무엇을 수집해야하고, Crashlytics에서는 무엇을 수집해야 할까 고민해봤습니다.

우선 Analytics의 주 목적은 우리 앱을 사용하는 사용자드의 행동 패턴을 분석하기 위함이라고 생각합니다.
- 어떤 스크린에 얼마나 머무르는지?
- 어떤 버튼을 자주 클릭하는지(어떤 기능을 많이 사용하는지?)

그럼 API 성공 / 실패에 대한 로그도 필요할까? 에 대한 고민을 했습니다.
버튼을 클릭한 것만으로 얼마나 많은 초대장이 생성되었고 또 실패했는지 지표를 알 수 없다고 생각했습니다.

클라이언트에서는 위에서도 언급햇듯이 사용자 행동 패턴을 주로 분석이 목적이라고 생각했고 API 요청에 대한 성공 / 실패에 대한 데이터 수집은 서버에서 하는 것이 적절하다고 생각하여 아래와 같은 로그만 수집했습니다.
- 기능 버튼클릭
- 스크린이 변경될 때마다 체류 시간

### Crashlytics
[Firebase-Crashlytics](https://firebase.google.com/docs/crashlytics/android/customize-crash-reports?hl=ko&_gl=1*1h8hkyd*_up*MQ..*_ga*MzM5NzE0OTkwLjE3NzE0Nzk2NDI.*_ga_CW55HF8NVT*czE3NzE0Nzk2NDEkbzEkZzAkdDE3NzE0Nzk2NDEkajYwJGwwJGgw#add-keys)에서 앱이 비정상 종료되었을 때 자동으로 수집되지만 앱이 죽지 않았음에도 수집해야 하는 경우를 생각해봤습니다.

- 로그인에 실패했을 때 (유저 모집에 대한 기능이라 중요하다고 생각)
- 신고에 실패했을 때(게시글 id와 에러 원인 crash 기록)
앱이 비정상 종료되지 않은 예외에 대해서 recordException 옵션을 통해 데이터를 수집할 수 있으며 최대 8개까지 수집 가능합니다.
<img width="648" height="79" alt="image" src="https://github.com/user-attachments/assets/3189ff3b-9b2f-443b-a717-8e115d1533c3" />


## 🔗 관련 이슈
- Close #199 

## ✅ 체크리스트
- [ ] 팀 컨벤션을 준수했나요?
- [ ] 불필요한 주석이나 import는 삭제했나요?
