### PR TITLE
Scaffod -> NavigationSuiteScaffold 변경

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -139,6 +139,9 @@ dependencies {
     implementation(libs.firebase.crashlytics)
     implementation(libs.firebase.analytics)
 
+    // suite
+    implementation(libs.androidx.material3.adaptive.navigation.suite)
+
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)
     implementation(libs.androidx.activity.compose)

--- a/android/app/src/main/kotlin/com/andlife/nacho/NachoApp.kt
+++ b/android/app/src/main/kotlin/com/andlife/nacho/NachoApp.kt
@@ -6,7 +6,6 @@ import androidx.compose.ui.Modifier
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.navOptions
 import com.andlife.invitation.InvitationDetail
-import com.andlife.login.Login
 import com.andlife.nacho.model.MainSideEffect
 import com.andlife.nacho.navigation.NachoNavHost
 import com.andlife.nacho.navigation.rememberInvitationNavigator

--- a/android/app/src/main/kotlin/com/andlife/nacho/navigation/NachoNavigator.kt
+++ b/android/app/src/main/kotlin/com/andlife/nacho/navigation/NachoNavigator.kt
@@ -1,8 +1,18 @@
 package com.andlife.nacho.navigation
 
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteDefaults
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldDefaults
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldState
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
+import androidx.compose.material3.adaptive.navigationsuite.rememberNavigationSuiteScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Stable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.navigation.NavDestination
 import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.NavHostController
@@ -26,15 +36,18 @@ import com.andlife.login.Login
 import com.andlife.login.navigateToLogin
 import com.andlife.myinvitation.navigateToMyInvitation
 import com.andlife.myinvitation.navigateToMyInvitationDetail
+import com.andlife.nacho.util.isNavigationBar
 import com.andlife.setting.navigateToSetting
 import com.andlife.thanks_card.navigateToCreateThanksCard
 import com.andlife.thanks_card.navigateToUpdateThanksCard
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
 import kotlin.reflect.KClass
 
 @Stable
 class NachoNavigator(
     val navController: NavHostController,
-    val startDestination: KClass<*> = Login::class
+    val startDestination: KClass<*> = Login::class,
 ) {
     val currentDestination: NavDestination?
         @Composable get() = navController.currentBackStackEntryAsState().value?.destination
@@ -46,12 +59,6 @@ class NachoNavigator(
             MainBottomTab.entries.find { tab ->
                 currentDestination?.hasRoute(tab.route) == true
             }
-
-    @Composable
-    fun shouldShowBottomBar(): Boolean =
-        MainBottomTab.entries.any { tab ->
-            currentDestination?.hasRoute(tab.route) == true
-        }
 
     fun navigate(tab: MainBottomTab) {
         val navOptions =
@@ -167,6 +174,7 @@ class NachoNavigator(
 @Composable
 internal fun rememberInvitationNavigator(
     navController: NavHostController = rememberNavController(),
+    navigationSuiteScaffoldState: NavigationSuiteScaffoldState = rememberNavigationSuiteScaffoldState(),
     startDestination: KClass<*> = Login::class
 ): NachoNavigator =
     remember(navController) {

--- a/android/app/src/main/kotlin/com/andlife/nacho/navigation/NavHost.kt
+++ b/android/app/src/main/kotlin/com/andlife/nacho/navigation/NavHost.kt
@@ -1,34 +1,30 @@
 package com.andlife.nacho.navigation
 
-import android.util.Log
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.navigationBarsPadding
-import androidx.compose.foundation.layout.padding
-import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.NavigationItemColors
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.WideNavigationRailDefaults
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteDefaults
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteItem
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldDefaults
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldValue
+import androidx.compose.material3.adaptive.navigationsuite.rememberNavigationSuiteScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.res.vectorResource
+import androidx.navigation.NavDestination.Companion.hasRoute
 import androidx.navigation.compose.NavHost
 import androidx.navigation.navDeepLink
 import androidx.navigation.navOptions
 import com.andlife.deeplink.DeepLinkManager
 import com.andlife.designsystem.preview.PreviewTheme
-import com.andlife.designsystem.theme.NachoSpacing
 import com.andlife.designsystem.theme.NachoTheme
 import com.andlife.domain.util.AnalyticsEvent
 import com.andlife.home.homeNavGraph
@@ -48,10 +44,10 @@ import com.andlife.model.util.NavigationKeyConstant.UPDATE_CARD
 import com.andlife.myinvitation.myInvitationDetailNavGraph
 import com.andlife.myinvitation.myInvitationNavGraph
 import com.andlife.nacho.LocalAnalyticsLogger
+import com.andlife.nacho.util.isNavigationBar
 import com.andlife.setting.settingNavGraph
 import com.andlife.thanks_card.createThanksCardNavGraph
 import com.andlife.thanks_card.updateThanksCardNavGraph
-import com.andlife.ui.util.noRippleClickable
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 
@@ -61,38 +57,60 @@ fun NachoNavHost(
     deepLinkManager: DeepLinkManager,
     modifier: Modifier = Modifier,
 ) {
+    val suiteState = rememberNavigationSuiteScaffoldState()
+    val currentDestination = navigator.currentDestination
+    val navSuiteType =
+        NavigationSuiteScaffoldDefaults.navigationSuiteType(currentWindowAdaptiveInfo())
     val snackbarHostState = remember { SnackbarHostState() }
     val analyticsLogger = LocalAnalyticsLogger.current
-    LaunchedEffect(navigator.currentDestination) {
+
+    LaunchedEffect(currentDestination, navSuiteType) {
         navigator.navController.currentDestination?.route?.let { route ->
             analyticsLogger.logEvent(AnalyticsEvent.ScreenView(route))
         }
+        val isBottomTab = MainBottomTab.entries.find { tab ->
+            currentDestination?.hasRoute(tab.route) == true
+        }
+        when {
+            navSuiteType.isNavigationBar && isBottomTab != null -> {
+                if (suiteState.currentValue == NavigationSuiteScaffoldValue.Hidden) suiteState.show()
+            }
+            navSuiteType.isNavigationBar && isBottomTab == null -> {
+                if (suiteState.currentValue == NavigationSuiteScaffoldValue.Visible) suiteState.hide()
+            }
+            !navSuiteType.isNavigationBar -> {
+                if (suiteState.currentValue == NavigationSuiteScaffoldValue.Hidden) suiteState.show()
+            }
+        }
     }
 
-    Scaffold(
+    NavigationSuiteScaffold(
+        navigationItems = {
+            NachoBottomBar(
+                currentTab = navigator.currentTab,
+                tabs = navigator.mainBottomTabs.toImmutableList(),
+                onTabSelect = navigator::navigate,
+                modifier = Modifier,
+            )
+        },
         containerColor = NachoTheme.colorScheme.backgroundPrimary,
-        snackbarHost = {
-            SnackbarHost(snackbarHostState)
-        },
-        bottomBar = {
-            AnimatedVisibility(navigator.shouldShowBottomBar()) {
-                NachoBottomBar(
-                    currentTab = navigator.currentTab,
-                    tabs = navigator.mainBottomTabs.toImmutableList(),
-                    onTabSelect = navigator::navigate,
-                    modifier = Modifier,
-                )
-            }
-        },
-        modifier = modifier,
-    ) { innerPadding ->
+        navigationSuiteColors = NavigationSuiteDefaults.colors(
+            shortNavigationBarContainerColor = NachoTheme.colorScheme.backgroundPrimary,
+            navigationBarContainerColor = NachoTheme.colorScheme.backgroundPrimary,
+            navigationRailContentColor = NachoTheme.colorScheme.backgroundPrimary,
+            navigationDrawerContentColor = NachoTheme.colorScheme.backgroundPrimary,
+            wideNavigationRailColors = WideNavigationRailDefaults.colors(
+                containerColor = NachoTheme.colorScheme.backgroundPrimary
+            ),
+        ),
+        state = suiteState
+    ) {
         NavHost(
             modifier = Modifier,
             navController = navigator.navController,
             startDestination = navigator.startDestination,
         ) {
             homeNavGraph(
-                paddingValues = innerPadding,
                 snackbarHostState = snackbarHostState,
                 onNavigateToCreate = navigator::navigateToMyInvitationCreate,
                 onNavigateToLogin = { navigator.navigateToLogin() },
@@ -127,7 +145,6 @@ fun NachoNavHost(
             )
 
             invitationNavGraph(
-                paddingValues = innerPadding,
                 onNavigateToDetail = navigator::navigateToInvitationDetail,
                 onNavigateToLogin = { navigator.navigateToLogin() },
                 snackbarHostState = snackbarHostState
@@ -141,7 +158,6 @@ fun NachoNavHost(
 
             myInvitationNavGraph(
                 snackbarHostState = snackbarHostState,
-                paddingValues = innerPadding,
                 onNavigateToCreate = navigator::navigateToMyInvitationCreate,
                 onNavigateToDetail = navigator::navigateToMyInvitationDetail,
                 onNavigateToLogin = {
@@ -240,49 +256,32 @@ private fun NachoBottomBar(
     onTabSelect: (MainBottomTab) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    Column(modifier = modifier.fillMaxWidth()) {
-        HorizontalDivider(color = NachoTheme.colorScheme.backgroundBorder)
-        Row(
-            modifier = Modifier
-                .background(NachoTheme.colorScheme.backgroundPrimary)
-                .padding(horizontal = NachoSpacing.large)
-                .navigationBarsPadding(),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            tabs.forEach { tab ->
-                Column(
-                    verticalArrangement = Arrangement.spacedBy(NachoSpacing.small),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    modifier = Modifier
-                        .weight(1f)
-                        .padding(vertical = NachoSpacing.small)
-                        .noRippleClickable { onTabSelect(tab) }
-                ) {
-                    val isSelected = currentTab == tab
-                    val iconTint = if (isSelected) {
-                        NachoTheme.colorScheme.brandPrimary
-                    } else {
-                        NachoTheme.colorScheme.textTertiary
-                    }
-                    val textColor = if (isSelected) {
-                        NachoTheme.colorScheme.brandPrimary
-                    } else {
-                        NachoTheme.colorScheme.textTertiary
-                    }
-
-                    Icon(
-                        imageVector = ImageVector.vectorResource(id = tab.iconResId),
-                        contentDescription = stringResource(id = tab.labelResId),
-                        tint = iconTint,
-                    )
-                    Text(
-                        text = stringResource(id = tab.labelResId),
-                        style = NachoTheme.typography.bodySmallMedium,
-                        color = textColor,
-                    )
-                }
-            }
-        }
+    tabs.forEach { tab ->
+        NavigationSuiteItem(
+            selected = currentTab == tab,
+            onClick = { onTabSelect(tab) },
+            label = {
+                Text(
+                    text = stringResource(id = tab.labelResId),
+                    style = NachoTheme.typography.bodySmallMedium,
+                )
+            },
+            icon = {
+                Icon(
+                    imageVector = ImageVector.vectorResource(id = tab.iconResId),
+                    contentDescription = stringResource(id = tab.labelResId),
+                )
+            },
+            colors = NavigationItemColors(
+                selectedIconColor = NachoTheme.colorScheme.brandPrimary,
+                selectedTextColor = NachoTheme.colorScheme.brandPrimary,
+                selectedIndicatorColor = NachoTheme.colorScheme.backgroundPrimary,
+                unselectedIconColor = NachoTheme.colorScheme.textTertiary,
+                unselectedTextColor = NachoTheme.colorScheme.textTertiary,
+                disabledIconColor = NachoTheme.colorScheme.textTertiary,
+                disabledTextColor = NachoTheme.colorScheme.textTertiary,
+            )
+        )
     }
 }
 

--- a/android/app/src/main/kotlin/com/andlife/nacho/util/NavigationSuiteTypeUtil.kt
+++ b/android/app/src/main/kotlin/com/andlife/nacho/util/NavigationSuiteTypeUtil.kt
@@ -1,0 +1,9 @@
+package com.andlife.nacho.util
+
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
+
+internal val NavigationSuiteType.isNavigationBar
+    get() =
+        this == NavigationSuiteType.ShortNavigationBarCompact ||
+            this == NavigationSuiteType.ShortNavigationBarMedium ||
+            this == NavigationSuiteType.NavigationBar

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/InvitationTopBar.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/invitation/InvitationTopBar.kt
@@ -32,7 +32,6 @@ fun InvitationTopBar(
                     overflow = TextOverflow.Ellipsis,
                 )
             },
-            windowInsets = WindowInsets(),
             colors = TopAppBarDefaults.topAppBarColors(
                 containerColor = NachoTheme.colorScheme.backgroundPrimary,
             ),

--- a/android/feature/home/src/main/kotlin/com/andlife/home/HomeNavGraph.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/HomeNavGraph.kt
@@ -29,7 +29,6 @@ fun NavController.navigateToHome(navOptions: NavOptions) {
 }
 
 fun NavGraphBuilder.homeNavGraph(
-    paddingValues: PaddingValues,
     snackbarHostState: SnackbarHostState,
     onNavigateToCreate: () -> Unit,
     onNavigateToLogin: () -> Unit,
@@ -56,7 +55,7 @@ fun NavGraphBuilder.homeNavGraph(
             onNavigateToInvitationDetail = onNavigateToInvitationDetail,
             onNavigateToMyInvitationDetail = onNavigateToMyInvitationDetail,
             onNavigateToSetting = onNavigateToSetting,
-            modifier = Modifier.padding(paddingValues),
+            modifier = Modifier,
         )
     }
 }

--- a/android/feature/home/src/main/kotlin/com/andlife/home/screen/HomeScreen.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/screen/HomeScreen.kt
@@ -454,7 +454,6 @@ private fun HomeTopBar(
                     )
                 }
             },
-            windowInsets = WindowInsets(),
             colors = TopAppBarDefaults.topAppBarColors(
                 containerColor = NachoTheme.colorScheme.backgroundPrimary,
             ),

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/InvitationNavGraph.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/InvitationNavGraph.kt
@@ -42,7 +42,6 @@ fun NavController.navigateToInvitationDetail(
 }
 
 fun NavGraphBuilder.invitationNavGraph(
-    paddingValues: PaddingValues,
     onNavigateToDetail: (Long) -> Unit,
     onNavigateToLogin: () -> Unit,
     snackbarHostState: SnackbarHostState,
@@ -65,7 +64,7 @@ fun NavGraphBuilder.invitationNavGraph(
             onNavigateToDetail = onNavigateToDetail,
             onNavigateToLogin = onNavigateToLogin,
             snackbarHostState = snackbarHostState,
-            modifier = Modifier.padding(paddingValues)
+            modifier = Modifier
         )
     }
 }

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/MyInvitationGraph.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/MyInvitationGraph.kt
@@ -46,7 +46,6 @@ fun NavController.navigateToMyInvitationDetail(
 
 fun NavGraphBuilder.myInvitationNavGraph(
     snackbarHostState: SnackbarHostState,
-    paddingValues: PaddingValues,
     onNavigateToCreate: () -> Unit,
     onNavigateToDetail: (Long) -> Unit,
     onNavigateToLogin: () -> Unit,
@@ -70,7 +69,7 @@ fun NavGraphBuilder.myInvitationNavGraph(
             onNavigateToCreate = onNavigateToCreate,
             onNavigateToDetail = onNavigateToDetail,
             onNavigateToLogin = onNavigateToLogin,
-            modifier = Modifier.padding(paddingValues)
+            modifier = Modifier
         )
     }
 }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -52,6 +52,7 @@ androidx-compose-material3-adaptive-layout = { group = "androidx.compose.materia
 androidx-compose-material3-adaptive-navigation = { group = "androidx.compose.material3.adaptive", name = "adaptive-navigation", version.ref = "androidxComposeMaterial3Adaptive" }
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-core-splashscreen = { module = "androidx.core:core-splashscreen", version.ref = "coreSplashscreen" }
+androidx-material3-adaptive-navigation-suite = { module = "androidx.compose.material3:material3-adaptive-navigation-suite" }
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "firebaseBom" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }


### PR DESCRIPTION
## Scaffod -> NavigationSuiteScaffold 변경
적응형 UI를 위해 기존 Scaffold -> [NavigationSuiteScaffold](https://developer.android.com/develop/ui/compose/layouts/adaptive/build-adaptive-navigation?hl=ko#change_colors)로 변경했습니다.
- 기존의 최상위 Scaffold의 PaddingValue를 전달하던 파라미터 제거 
- NavigationSuiteScaffold 적용

### 핵심 변경점
- isNavigationBar의 경우 NavigationBar를 의미하며, 아닐경우 Rail을 의미합니다.
- 네비게이션바의 경우 디테일 화면으로 넘어갈 때 바텀 탭이 보이지 않는 구조였기 때문에 탭을 hide()
```kotlin
internal val NavigationSuiteType.isNavigationBar
    get() =
        this == NavigationSuiteType.ShortNavigationBarCompact ||
            this == NavigationSuiteType.ShortNavigationBarMedium ||
            this == NavigationSuiteType.NavigationBar

LaunchedEffect(currentDestination, navSuiteType) {
    navigator.navController.currentDestination?.route?.let { route ->
        analyticsLogger.logEvent(AnalyticsEvent.ScreenView(route))
    }
    val isBottomTab = MainBottomTab.entries.find { tab ->
        currentDestination?.hasRoute(tab.route) == true
    }
    when {
        navSuiteType.isNavigationBar && isBottomTab != null -> {
            if (suiteState.currentValue == NavigationSuiteScaffoldValue.Hidden) suiteState.show()
        }
        navSuiteType.isNavigationBar && isBottomTab == null -> {
            if (suiteState.currentValue == NavigationSuiteScaffoldValue.Visible) suiteState.hide()
        }
        !navSuiteType.isNavigationBar -> {
            if (suiteState.currentValue == NavigationSuiteScaffoldValue.Hidden) suiteState.show()
            }
        }
    }
```

## 📸 스크린샷 (선택)
[Screen_recording_20260227_171720.webm](https://github.com/user-attachments/assets/202cb4c3-7cea-455f-8bab-c38928ac1280)

[Screen_recording_20260227_171640.webm](https://github.com/user-attachments/assets/d3626bf9-e879-4e2b-9439-063f44b9aeb5)


## 🔗 관련 이슈
- Close #214

## ✅ 체크리스트
- [x] 팀 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 import는 삭제했나요?
