### PR TITLE
초대장 탭 적응형 UI 적용 (listpane)

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -28,6 +28,7 @@
     <application
         android:name=".NachoApplication"
         android:allowBackup="true"
+        android:enableOnBackInvokedCallback="true"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/backup_rules"
         android:icon="@mipmap/ic_launcher"

--- a/android/app/src/main/kotlin/com/andlife/nacho/NachoApp.kt
+++ b/android/app/src/main/kotlin/com/andlife/nacho/NachoApp.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.navOptions
+import com.andlife.invitation.Invitation
 import com.andlife.invitation.InvitationDetail
 import com.andlife.nacho.model.MainSideEffect
 import com.andlife.nacho.navigation.NachoNavHost
@@ -27,8 +28,8 @@ fun NachoApp(
             is MainSideEffect.NavigateToDetail -> {
                 Log.d("DeepLink Debug", "Received Deferred DeepLink invitationId: ${effect.invitationId}")
                 navigator.navController.navigate(
-                    InvitationDetail(
-                        id = effect.invitationId,
+                    Invitation(
+                        initialInvitationId = effect.invitationId,
                         isFromDeepLink = true
                     )
                 ) {

--- a/android/app/src/main/kotlin/com/andlife/nacho/navigation/NavHost.kt
+++ b/android/app/src/main/kotlin/com/andlife/nacho/navigation/NavHost.kt
@@ -2,6 +2,8 @@ package com.andlife.nacho.navigation
 
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationItemColors
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.WideNavigationRailDefaults
@@ -105,146 +107,152 @@ fun NachoNavHost(
         ),
         state = suiteState
     ) {
-        NavHost(
-            modifier = Modifier,
-            navController = navigator.navController,
-            startDestination = navigator.startDestination,
-        ) {
-            homeNavGraph(
-                snackbarHostState = snackbarHostState,
-                onNavigateToCreate = navigator::navigateToMyInvitationCreate,
-                onNavigateToLogin = { navigator.navigateToLogin() },
-                onNavigateToInvitationDetail = navigator::navigateToInvitationDetail,
-                onNavigateToMyInvitationDetail = navigator::navigateToMyInvitationDetail,
-                onNavigateToSetting = navigator::navigateToSetting,
-            )
-
-            settingNavGraph(
-                onNavigateBack = navigator::navigatePopBackStack,
-                onNavigateToLogin = {
-                    navigator.navigateToLogin()
-                },
-                onSignedOut = {
-                    val navOptions = navOptions {
-                        popUpTo(navigator.navController.graph.id) {
-                            inclusive = true
-                        }
-                        launchSingleTop = true
-                    }
-                    navigator.navigateToLogin(navOptions)
-                },
-                onLogout = {
-                    val navOptions = navOptions {
-                        popUpTo(navigator.navController.graph.id) {
-                            inclusive = true
-                        }
-                        launchSingleTop = true
-                    }
-                    navigator.navigateToLogin(navOptions)
-                }
-            )
-
-            invitationNavGraph(
-                onNavigateToDetail = navigator::navigateToInvitationDetail,
-                onNavigateToLogin = { navigator.navigateToLogin() },
-                snackbarHostState = snackbarHostState
-            )
-
-            invitationDetailNavGraph(
-                deepLinks = navDeepLink { uriPattern = deepLinkManager.getKakaoDeepLinkPattern() },
-                onNavigateBack = navigator::navigatePopBackStack,
-                onNavigateToLogin = { navigator.navigateToLogin() }
-            )
-
-            myInvitationNavGraph(
-                snackbarHostState = snackbarHostState,
-                onNavigateToCreate = navigator::navigateToMyInvitationCreate,
-                onNavigateToDetail = navigator::navigateToMyInvitationDetail,
-                onNavigateToLogin = {
-                    navigator.navigateToLogin()
-                }
-            )
-
-            myInvitationDetailNavGraph(
-                onNavigateBack = navigator::navigatePopBackStack,
-                onNavigateToLogin = {
-                    val navOptions = navOptions {
-                        popUpTo(navigator.navController.graph.id) {
-                            inclusive = true
-                        }
-                        launchSingleTop = true
-                    }
-                    navigator.navigateToLogin(navOptions)
-                },
-                onNavigateToEditInvitation = navigator::navigateToMyInvitationEdit,
-                onNavigateToEditCard = navigator::navigateToUpdateCard,
-                onNavigateToCreateCard = navigator::navigateToCreateCardByInvitation,
-                onNavigateToCreateThanksCard = navigator::navigateToCreateThanksCard,
-                onNavigateToUpdateThanksCard = navigator::navigateToUpdateThanksCard
-            )
-
-            invitationCreateNavGraph(
-                onNavigateToAddressSearch = navigator::navigateToAddressSearch,
-                onNavigateToPreview = navigator::navigateToInvitationPreview,
-                onNavigateBack = navigator::navigatePopBackStack,
-                onNavigateCreateCard = navigator::navigateToCreateCard,
-                onNavigateToInvitationDetail = navigator::navigateToMyInvitationDetailByCreate
-            )
-
-            invitationEditNavGraph(
+        Scaffold(
+            snackbarHost = {
+                SnackbarHost(snackbarHostState)
+            }
+        ) { innerPadding ->
+            NavHost(
+                modifier = Modifier,
                 navController = navigator.navController,
-                onNavigateToAddressSearch = navigator::navigateToAddressSearch,
-                onNavigateBack = navigator::navigatePopBackStack,
-            )
+                startDestination = navigator.startDestination,
+            ) {
+                homeNavGraph(
+                    snackbarHostState = snackbarHostState,
+                    onNavigateToCreate = navigator::navigateToMyInvitationCreate,
+                    onNavigateToLogin = { navigator.navigateToLogin() },
+                    onNavigateToInvitationDetail = navigator::navigateToInvitationDetail,
+                    onNavigateToMyInvitationDetail = navigator::navigateToMyInvitationDetail,
+                    onNavigateToSetting = navigator::navigateToSetting,
+                )
 
-            addressSearchNavGraph(
-                navController = navigator.navController,
-                onNavigateBack = navigator::navigatePopBackStack,
-            )
+                settingNavGraph(
+                    onNavigateBack = navigator::navigatePopBackStack,
+                    onNavigateToLogin = {
+                        navigator.navigateToLogin()
+                    },
+                    onSignedOut = {
+                        val navOptions = navOptions {
+                            popUpTo(navigator.navController.graph.id) {
+                                inclusive = true
+                            }
+                            launchSingleTop = true
+                        }
+                        navigator.navigateToLogin(navOptions)
+                    },
+                    onLogout = {
+                        val navOptions = navOptions {
+                            popUpTo(navigator.navController.graph.id) {
+                                inclusive = true
+                            }
+                            launchSingleTop = true
+                        }
+                        navigator.navigateToLogin(navOptions)
+                    }
+                )
 
-            invitationPreviewNavGraph(
-                navController = navigator.navController,
-                onNavigateBack = navigator::navigatePopBackStack,
-            )
+                invitationNavGraph(
+                    deepLinks = navDeepLink { uriPattern = deepLinkManager.getKakaoDeepLinkPattern() },
+                    onNavigateToLogin = { navigator.navigateToLogin() },
+                    snackbarHostState = snackbarHostState
+                )
 
-            createCardNavGraph(
-                onBackClick = navigator::navigatePopBackStack
-            )
+                invitationDetailNavGraph(
+                    deepLinks = navDeepLink { uriPattern = deepLinkManager.getKakaoDeepLinkPattern() },
+                    onNavigateBack = navigator::navigatePopBackStack,
+                    onNavigateToLogin = { navigator.navigateToLogin() }
+                )
 
-            createCardByInvitationNavGraph(
-                onBackClick = navigator::navigatePopBackStack,
-                onSuccessCreateCard = {
-                    navigator.navController.previousBackStackEntry?.savedStateHandle[CREATE_CARD_BY_INVITATION_ID] =
-                        true
-                    navigator.navigatePopBackStack()
-                }
-            )
+                myInvitationNavGraph(
+                    snackbarHostState = snackbarHostState,
+                    onNavigateToCreate = navigator::navigateToMyInvitationCreate,
+                    onNavigateToDetail = navigator::navigateToMyInvitationDetail,
+                    onNavigateToLogin = {
+                        navigator.navigateToLogin()
+                    }
+                )
 
-            updateCardNavGraph(
-                onBackClick = navigator::navigatePopBackStack,
-                onSuccessCreateCard = {
-                    navigator.navController.previousBackStackEntry?.savedStateHandle[UPDATE_CARD] = true
-                    navigator.navigatePopBackStack()
-                }
-            )
+                myInvitationDetailNavGraph(
+                    onNavigateBack = navigator::navigatePopBackStack,
+                    onNavigateToLogin = {
+                        val navOptions = navOptions {
+                            popUpTo(navigator.navController.graph.id) {
+                                inclusive = true
+                            }
+                            launchSingleTop = true
+                        }
+                        navigator.navigateToLogin(navOptions)
+                    },
+                    onNavigateToEditInvitation = navigator::navigateToMyInvitationEdit,
+                    onNavigateToEditCard = navigator::navigateToUpdateCard,
+                    onNavigateToCreateCard = navigator::navigateToCreateCardByInvitation,
+                    onNavigateToCreateThanksCard = navigator::navigateToCreateThanksCard,
+                    onNavigateToUpdateThanksCard = navigator::navigateToUpdateThanksCard
+                )
 
-            loginNavGraph()
+                invitationCreateNavGraph(
+                    onNavigateToAddressSearch = navigator::navigateToAddressSearch,
+                    onNavigateToPreview = navigator::navigateToInvitationPreview,
+                    onNavigateBack = navigator::navigatePopBackStack,
+                    onNavigateCreateCard = navigator::navigateToCreateCard,
+                    onNavigateToInvitationDetail = navigator::navigateToMyInvitationDetailByCreate
+                )
 
-            createThanksCardNavGraph(
-                onSuccessfulCreate = {
-                    navigator.navController.previousBackStackEntry?.savedStateHandle[CREATE_THANKS_CARD] = true
-                    navigator.navigatePopBackStack()
-                },
-                onBackClick = navigator::navigatePopBackStack,
-            )
+                invitationEditNavGraph(
+                    navController = navigator.navController,
+                    onNavigateToAddressSearch = navigator::navigateToAddressSearch,
+                    onNavigateBack = navigator::navigatePopBackStack,
+                )
 
-            updateThanksCardNavGraph(
-                onSuccessfulUpdate = {
-                    navigator.navController.previousBackStackEntry?.savedStateHandle[UPDATE_CARD] = true
-                    navigator.navigatePopBackStack()
-                },
-                onBackClick = navigator::navigatePopBackStack
-            )
+                addressSearchNavGraph(
+                    navController = navigator.navController,
+                    onNavigateBack = navigator::navigatePopBackStack,
+                )
+
+                invitationPreviewNavGraph(
+                    navController = navigator.navController,
+                    onNavigateBack = navigator::navigatePopBackStack,
+                )
+
+                createCardNavGraph(
+                    onBackClick = navigator::navigatePopBackStack
+                )
+
+                createCardByInvitationNavGraph(
+                    onBackClick = navigator::navigatePopBackStack,
+                    onSuccessCreateCard = {
+                        navigator.navController.previousBackStackEntry?.savedStateHandle[CREATE_CARD_BY_INVITATION_ID] =
+                            true
+                        navigator.navigatePopBackStack()
+                    }
+                )
+
+                updateCardNavGraph(
+                    onBackClick = navigator::navigatePopBackStack,
+                    onSuccessCreateCard = {
+                        navigator.navController.previousBackStackEntry?.savedStateHandle[UPDATE_CARD] = true
+                        navigator.navigatePopBackStack()
+                    }
+                )
+
+                loginNavGraph()
+
+                createThanksCardNavGraph(
+                    onSuccessfulCreate = {
+                        navigator.navController.previousBackStackEntry?.savedStateHandle[CREATE_THANKS_CARD] = true
+                        navigator.navigatePopBackStack()
+                    },
+                    onBackClick = navigator::navigatePopBackStack,
+                )
+
+                updateThanksCardNavGraph(
+                    onSuccessfulUpdate = {
+                        navigator.navController.previousBackStackEntry?.savedStateHandle[UPDATE_CARD] = true
+                        navigator.navigatePopBackStack()
+                    },
+                    onBackClick = navigator::navigatePopBackStack
+                )
+            }
         }
     }
 }

--- a/android/app/src/main/kotlin/com/andlife/nacho/navigation/NavHost.kt
+++ b/android/app/src/main/kotlin/com/andlife/nacho/navigation/NavHost.kt
@@ -80,7 +80,10 @@ fun NachoNavHost(
             navSuiteType.isNavigationBar && isBottomTab == null -> {
                 if (suiteState.currentValue == NavigationSuiteScaffoldValue.Visible) suiteState.hide()
             }
-            !navSuiteType.isNavigationBar -> {
+            !navSuiteType.isNavigationBar && isBottomTab == null -> {
+                if (suiteState.currentValue == NavigationSuiteScaffoldValue.Visible) suiteState.hide()
+            }
+            !navSuiteType.isNavigationBar && isBottomTab != null -> {
                 if (suiteState.currentValue == NavigationSuiteScaffoldValue.Hidden) suiteState.show()
             }
         }

--- a/android/core/designsystem/src/main/res/values/strings.xml
+++ b/android/core/designsystem/src/main/res/values/strings.xml
@@ -12,5 +12,6 @@
     </string-array>
 
     <string name="des_component_filterchip">검색결과를 정렬하는 칩 아이콘</string>
+    <string name="txt_select_invitation">초대받은 초대장을 선택해주세요.</string>
 
 </resources>

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/listitem/InvitationListItem.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/listitem/InvitationListItem.kt
@@ -58,6 +58,7 @@ fun InvitationListItem(
     dDayText: String?,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
+    isSelected: Boolean = false,
     menuItems: ImmutableList<MenuItem> = persistentListOf(),
 ) {
     var isMenuExpanded by remember { mutableStateOf(false) }
@@ -70,7 +71,7 @@ fun InvitationListItem(
         ),
         border = BorderStroke(
             NachoStroke.small,
-            NachoTheme.colorScheme.backgroundBorder,
+            if (isSelected) NachoTheme.colorScheme.brandPrimary else NachoTheme.colorScheme.backgroundBorder,
         ),
         modifier = modifier,
     ) {

--- a/android/feature/invitation/build.gradle.kts
+++ b/android/feature/invitation/build.gradle.kts
@@ -23,6 +23,11 @@ dependencies {
     // Paging
     implementation(libs.androidx.paging.compose)
 
+    // adaptive
+    implementation(libs.androidx.compose.material3.adaptive)
+    implementation(libs.androidx.compose.material3.adaptive.layout)
+    implementation(libs.androidx.compose.material3.adaptive.navigation)
+
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/InvitationNavGraph.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/InvitationNavGraph.kt
@@ -1,28 +1,24 @@
 package com.andlife.invitation
 
-import android.util.Log
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavDeepLink
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
-import com.andlife.invitation.screen.InvitationRoute
+import androidx.navigation.toRoute
 import com.andlife.invitation.screen.detail.InvitationDetailRoute
-import com.andlife.invitation.viewmodel.InvitationViewModel
-import com.andlife.domain.util.RefreshEventHub
+import com.andlife.invitation.screen.InvitationsListDetailScreen
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object Invitation
+data class Invitation(
+    val initialInvitationId: Long? = null,
+    val isFromDeepLink: Boolean = false
+)
 
 @Serializable
 data class InvitationDetail(
@@ -30,8 +26,15 @@ data class InvitationDetail(
     val isFromDeepLink: Boolean = false
 )
 
-fun NavController.navigateToInvitation(navOptions: NavOptions) {
-    navigate(Invitation, navOptions)
+@Serializable
+internal data object InvitationPlaceholder
+
+fun NavController.navigateToInvitation(
+    navOptions: NavOptions? = null,
+    initialInvitationId: Long? = null,
+    isFromDeepLink: Boolean = false
+) {
+    navigate(Invitation(initialInvitationId, isFromDeepLink), navOptions)
 }
 
 fun NavController.navigateToInvitationDetail(
@@ -42,29 +45,16 @@ fun NavController.navigateToInvitationDetail(
 }
 
 fun NavGraphBuilder.invitationNavGraph(
-    onNavigateToDetail: (Long) -> Unit,
+    deepLinks: NavDeepLink,
     onNavigateToLogin: () -> Unit,
     snackbarHostState: SnackbarHostState,
 ) {
-    composable<Invitation> {
-        val viewModel: InvitationViewModel = hiltViewModel()
-
-        val needsRefresh by RefreshEventHub.invitationRefresh.collectAsStateWithLifecycle()
-
-        LaunchedEffect(needsRefresh) {
-            Log.d("RefreshEventHub", "invitation needsRefresh: $needsRefresh")
-            if (needsRefresh) {
-                viewModel.handleRefresh()
-                RefreshEventHub.consumeInvitation()
-            }
-        }
-
-        InvitationRoute(
-            viewModel = viewModel,
-            onNavigateToDetail = onNavigateToDetail,
-            onNavigateToLogin = onNavigateToLogin,
+    composable<Invitation>(
+        deepLinks = persistentListOf(deepLinks)
+    ) {
+        InvitationsListDetailScreen(
             snackbarHostState = snackbarHostState,
-            modifier = Modifier
+            onNavigateToLogin = onNavigateToLogin,
         )
     }
 }
@@ -76,8 +66,9 @@ fun NavGraphBuilder.invitationDetailNavGraph(
 ) {
     composable<InvitationDetail>(
         deepLinks = persistentListOf(deepLinks),
-    ) {
+    ) { val invitationDetail = it.toRoute<InvitationDetail>()
         InvitationDetailRoute(
+            selectedId = invitationDetail.id,
             onNavigateBack = onNavigateBack,
             onNavigateToLogin = onNavigateToLogin,
             modifier = Modifier.padding(),

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/InvitationScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/InvitationScreen.kt
@@ -1,5 +1,8 @@
 package com.andlife.invitation.screen
 
+import android.util.Log
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
@@ -9,6 +12,15 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.adaptive.layout.AnimatedPane
+import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldRole
+import androidx.compose.material3.adaptive.layout.PaneAdaptedValue
+import androidx.compose.material3.adaptive.navigation.BackNavigationBehavior
+import androidx.compose.material3.adaptive.navigation.NavigableListDetailPaneScaffold
+import androidx.compose.material3.adaptive.navigation.ThreePaneScaffoldNavigator
+import androidx.compose.material3.adaptive.navigation.ThreePaneScaffoldPredictiveBackHandler
+import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaffoldNavigator
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -17,6 +29,7 @@ import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringArrayResource
@@ -31,9 +44,18 @@ import com.andlife.ui.component.dialog.NachoInfoDialog
 import com.andlife.designsystem.theme.NachoSpacing
 import com.andlife.designsystem.theme.NachoTheme
 import com.andlife.domain.model.invitation.SortDirection
+import com.andlife.domain.util.RefreshEventHub
+import com.andlife.invitation.InvitationDetail
+import com.andlife.invitation.InvitationPlaceholder
 import com.andlife.invitation.model.InvitationSideEffect
 import com.andlife.invitation.model.InvitationUiEvent
 import com.andlife.invitation.model.InvitationUiState
+import com.andlife.invitation.screen.detail.InvitationDetailRoute
+import com.andlife.invitation.screen.detail.InvitationPlaceholderScreen
+import com.andlife.invitation.viewmodel.Invitation2PaneUiState
+import com.andlife.invitation.viewmodel.Invitation2PaneViewModel
+import com.andlife.invitation.viewmodel.InvitationDetailViewModel
+import com.andlife.invitation.viewmodel.InvitationGuestBookViewModel
 import com.andlife.invitation.viewmodel.InvitationViewModel
 import com.andlife.model.invitation.InvitationSummaryUiModel
 import com.andlife.ui.R
@@ -53,15 +75,140 @@ import kotlinx.coroutines.launch
 
 private const val SAMPLE_INVITATION_ID = 1L
 
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+@Composable
+fun InvitationsListDetailScreen(
+    snackbarHostState: SnackbarHostState,
+    onNavigateToLogin: () -> Unit,
+    modifier: Modifier = Modifier,
+    viewModel: Invitation2PaneViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+
+    InvitationListDetailScreen(
+        uiState = uiState,
+        snackbarHostState = snackbarHostState,
+        onNavigateToLogin = onNavigateToLogin,
+        onInvitationClick = viewModel::onInvitationClick
+    )
+}
+
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+@Composable
+private fun InvitationListDetailScreen(
+    uiState: Invitation2PaneUiState,
+    snackbarHostState: SnackbarHostState,
+    onNavigateToLogin: () -> Unit,
+    onInvitationClick: (Long) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    val selectedInvitationId = uiState.selectedInvitationId
+
+    val listDetailNavigator = rememberListDetailPaneScaffoldNavigator()
+    val coroutineScope = rememberCoroutineScope()
+
+    var invitationRoute by remember {
+        val route = selectedInvitationId?.let { InvitationDetail(id = it) } ?: InvitationPlaceholder
+        mutableStateOf(route)
+    }
+
+    var isConsumeDeepLink by rememberSaveable {
+        mutableStateOf(false)
+    }
+
+    fun onInvitationClickShowDetailPane(id: Long) {
+        Log.d("onInvitationClickShowDetailPane", "onInvitationClickShowDetailPane: $id")
+        onInvitationClick(id)
+        invitationRoute = InvitationDetail(id)
+        coroutineScope.launch {
+            listDetailNavigator.navigateTo(ListDetailPaneScaffoldRole.Detail)
+        }
+    }
+
+    LaunchedEffect(Unit) {
+        if (!isConsumeDeepLink && uiState.isFromDeelLink) {
+            val id = uiState.selectedInvitationId ?: return@LaunchedEffect
+            onInvitationClickShowDetailPane(id)
+            isConsumeDeepLink = true
+        }
+    }
+
+    ThreePaneScaffoldPredictiveBackHandler(
+        listDetailNavigator,
+        BackNavigationBehavior.PopUntilScaffoldValueChange,
+    )
+
+    NavigableListDetailPaneScaffold(
+        navigator = listDetailNavigator,
+        listPane = {
+            AnimatedPane {
+                InvitationRoute(
+                    snackbarHostState = snackbarHostState,
+                    onNavigateToDetail = { onInvitationClickShowDetailPane(it) },
+                    onNavigateToLogin = onNavigateToLogin,
+                    selectedInvitationId = uiState.selectedInvitationId,
+                    shouldHighlightSelected = listDetailNavigator.isDetailPaneVisible(),
+                )
+            }
+        },
+        detailPane = {
+            AnimatedPane {
+                AnimatedContent(invitationRoute) { route ->
+                    when (route) {
+                        is InvitationDetail -> {
+                            InvitationDetailRoute(
+                                selectedId = route.id,
+                                onNavigateBack = {
+                                    coroutineScope.launch {
+                                        listDetailNavigator.navigateBack()
+                                    }
+                                },
+                                onNavigateToLogin = onNavigateToLogin,
+                                showBackButton = !listDetailNavigator.isListPaneVisible(),
+                                viewModel = hiltViewModel<InvitationDetailViewModel, InvitationDetailViewModel.Factory>(
+                                    key = "detail ${route.id}"
+                                ){ factory ->
+                                    factory.create(route.id, uiState.isFromDeelLink)
+                                },
+                                guestBookViewModel = hiltViewModel<InvitationGuestBookViewModel, InvitationGuestBookViewModel.Factory>(
+                                    key = "guestbook ${route.id}"
+                                ) { factory ->
+                                    factory.create(route.id)
+                                }
+                            )
+                        }
+                        is InvitationPlaceholder -> {
+                            InvitationPlaceholderScreen()
+                        }
+                    }
+                }
+            }
+        },
+        modifier = modifier.background(NachoTheme.colorScheme.backgroundPrimary),
+    )
+}
+
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+private fun <T> ThreePaneScaffoldNavigator<T>.isListPaneVisible(): Boolean =
+    scaffoldValue[ListDetailPaneScaffoldRole.List] == PaneAdaptedValue.Expanded
+
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+private fun <T> ThreePaneScaffoldNavigator<T>.isDetailPaneVisible(): Boolean =
+    scaffoldValue[ListDetailPaneScaffoldRole.Detail] == PaneAdaptedValue.Expanded
+
 @Composable
 fun InvitationRoute(
     snackbarHostState: SnackbarHostState,
     onNavigateToDetail: (Long) -> Unit,
     onNavigateToLogin: () -> Unit,
     modifier: Modifier = Modifier,
+    selectedInvitationId: Long? = null,
+    shouldHighlightSelected: Boolean = false,
     viewModel: InvitationViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val needsRefresh by RefreshEventHub.invitationRefresh.collectAsStateWithLifecycle()
+
     val upcomingItems = viewModel.upcomingInvitationPagingFlow.collectAsLazyPagingItems()
     val pastItems = viewModel.pastInvitationPagingFlow.collectAsLazyPagingItems()
 
@@ -114,6 +261,14 @@ fun InvitationRoute(
                     snackbarHostState.showSnackbar(effect.message ?: reportFailureMessage)
                 }
             }
+        }
+    }
+
+    LaunchedEffect(needsRefresh) {
+        Log.d("RefreshEventHub", "invitation needsRefresh: $needsRefresh")
+        if (needsRefresh) {
+            viewModel.handleRefresh()
+            RefreshEventHub.consumeInvitation()
         }
     }
 
@@ -172,7 +327,9 @@ fun InvitationRoute(
         pastItems = pastItems,
         modifier = modifier,
         onEvent = viewModel::onEvent,
-        onLeaveClick = { invitationIdToLeave = it }
+        onLeaveClick = { invitationIdToLeave = it },
+        selectedInvitationId = selectedInvitationId,
+        shouldHighlightSelected = shouldHighlightSelected
     )
 }
 
@@ -184,7 +341,9 @@ private fun InvitationScreen(
     pastItems: LazyPagingItems<InvitationSummaryUiModel>,
     onEvent: (InvitationUiEvent) -> Unit,
     onLeaveClick: (Long) -> Unit,
-    modifier: Modifier = Modifier
+    modifier: Modifier = Modifier,
+    selectedInvitationId: Long? = null,
+    shouldHighlightSelected: Boolean = false,
 ) {
     val tabs = stringArrayResource(R.array.arr_invitation_tabs).toImmutableList()
     val upcomingSortOptions = stringArrayResource(R.array.arr_invitation_sort_options).toImmutableList()
@@ -268,6 +427,7 @@ private fun InvitationScreen(
                                 key = currentItems.itemKey { it.id }
                             ) { index ->
                                 currentItems[index]?.let { invitation ->
+                                    val isSelected = shouldHighlightSelected && invitation.id == selectedInvitationId
                                     val dDayLabel = when (val count = invitation.dDayCount) {
                                         null -> null
                                         0 -> stringResource(R.string.format_invitation_d_day_today)
@@ -302,7 +462,8 @@ private fun InvitationScreen(
                                         address = invitation.address,
                                         dDayText = dDayLabel,
                                         onClick = { onEvent(InvitationUiEvent.ClickInvitation(invitation.id)) },
-                                        menuItems = menuItems
+                                        menuItems = menuItems,
+                                        isSelected = isSelected
                                     )
                                 }
                             }
@@ -319,3 +480,11 @@ private fun InvitationScreen(
         )
     }
 }
+
+/**
+ * 딥링크인가?
+ * 2paneViewModel에서 event를 가진다. (채널로 가진다)
+ * 딥링크가 true라면 이벤트를 한번 소비시킨다.
+ * 그 후 다른 초대장을 클릭하면? false로 이동하긴 해야 한다. true false 값이 바뀌어야 함, 딥링크로 들어온 id들을 배열로 관리하면?(상태관리)
+ * 값은
+ */

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/collection/InvitationCollectionScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/collection/InvitationCollectionScreen.kt
@@ -29,6 +29,7 @@ fun InvitationCollectionRoute(
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     InvitationCollectionScreen(
+        viewModel = viewModel,
         uiState = uiState,
         onOpenStory = { index ->
             viewModel.onEvent(InvitationCollectionUiEvent.OpenStory(index))
@@ -48,6 +49,7 @@ fun InvitationCollectionRoute(
 
 @Composable
 fun InvitationCollectionScreen(
+    viewModel: InvitationCollectionViewModel,
     uiState: InvitationCollectionUiState,
     onOpenStory: (Int) -> Unit,
     onCloseStory: () -> Unit,
@@ -72,6 +74,7 @@ fun InvitationCollectionScreen(
                 onPageChanged = onPageChanged,
                 onToggleExpand = onToggleExpand,
                 onClose = onCloseStory,
+                viewModel = viewModel,
             )
         }
     }
@@ -121,6 +124,7 @@ private fun NachoCollectionPreview() {
 
     NachoTheme {
         InvitationCollectionScreen(
+            viewModel = hiltViewModel(),
             uiState = mockState,
             onOpenStory = {},
             onCloseStory = {},

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/detail/InvitationDetailScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/detail/InvitationDetailScreen.kt
@@ -1,6 +1,7 @@
 package com.andlife.invitation.screen.detail
 
 import android.text.Editable
+import android.util.Log
 import android.view.ViewGroup
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.background
@@ -56,6 +57,7 @@ import com.andlife.invitation.model.detail.InvitationDetailUiEvent
 import com.andlife.invitation.model.detail.InvitationDetailUiState
 import com.andlife.invitation.screen.collection.InvitationCollectionRoute
 import com.andlife.invitation.screen.guestbook.InvitationGuestBookRoute
+import com.andlife.invitation.viewmodel.InvitationCollectionViewModel
 import com.andlife.invitation.viewmodel.InvitationDetailViewModel
 import com.andlife.invitation.viewmodel.InvitationGuestBookViewModel
 import com.andlife.ui.component.GenericTabRow
@@ -72,12 +74,15 @@ import com.andlife.designsystem.R as designR
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun InvitationDetailRoute(
+    selectedId: Long,
     onNavigateBack: () -> Unit,
     onNavigateToLogin: () -> Unit,
     modifier: Modifier = Modifier,
+    showBackButton: Boolean = false,
     viewModel: InvitationDetailViewModel = hiltViewModel(),
     guestBookViewModel: InvitationGuestBookViewModel = hiltViewModel(),
 ) {
+    Log.d("InvitationDetailRoute", "vm:  ${viewModel.invitationId} ${viewModel.hashCode()}")
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val isGuestBookUploading by guestBookViewModel.uiState
         .map { it.isUploading }
@@ -122,6 +127,8 @@ fun InvitationDetailRoute(
     Box {
         InvitationDetailScreen(
             uiState = uiState,
+            guestBookViewModel = guestBookViewModel,
+            selectedId = selectedId,
             isGuestBookUploading = isGuestBookUploading,
             snackbarHostState = snackbarHostState,
             scrollBehavior = scrollBehavior,
@@ -130,6 +137,7 @@ fun InvitationDetailRoute(
             onNavigateToLogin = onNavigateToLogin,
             onEditableSave = viewModel::saveEditable,
             modifier = modifier,
+            showBackButton = showBackButton
         )
 
         if (uiState.isOverlayLoading) {
@@ -186,6 +194,8 @@ fun InvitationDetailRoute(
 @Composable
 private fun InvitationDetailScreen(
     uiState: InvitationDetailUiState,
+    guestBookViewModel: InvitationGuestBookViewModel,
+    selectedId: Long,
     isGuestBookUploading: Boolean,
     snackbarHostState: SnackbarHostState,
     scrollBehavior: TopAppBarScrollBehavior,
@@ -194,6 +204,7 @@ private fun InvitationDetailScreen(
     onNavigateToLogin: () -> Unit,
     onEditableSave: (Editable) -> Unit,
     modifier: Modifier = Modifier,
+    showBackButton: Boolean = false,
 ) {
     val tabTitles = stringArrayResource(R.array.txt_tap_title).toImmutableList()
     val coroutineScope = rememberCoroutineScope()
@@ -227,6 +238,7 @@ private fun InvitationDetailScreen(
                 hasThanksCard = uiState.hasThanksCard,
                 showActions = !uiState.isLoading && !uiState.isError,
                 onBack = navigateBackWithCleanup,
+                showBackButton = showBackButton,
                 onClickThanksCard = { onEvent(InvitationDetailUiEvent.ClickThanksCard) },
                 onLeave = { onEvent(InvitationDetailUiEvent.ClickLeaveInvitation) },
             )
@@ -279,9 +291,17 @@ private fun InvitationDetailScreen(
 
                         1 -> InvitationGuestBookRoute(
                             onNavigateBack = onNavigateBack,
-                            onNavigateToLogin = onNavigateToLogin
+                            onNavigateToLogin = onNavigateToLogin,
+                            viewModel = guestBookViewModel
                         )
-                        2 -> InvitationCollectionRoute()
+
+                        2 -> InvitationCollectionRoute(
+                            viewModel = hiltViewModel<InvitationCollectionViewModel, InvitationCollectionViewModel.Factory>(
+                                key = "collection $selectedId"
+                            ) { factory ->
+                                factory.create(selectedId)
+                            }
+                        )
                     }
                 },
             )
@@ -314,6 +334,7 @@ private fun InvitationDetailTopBar(
     modifier: Modifier = Modifier,
     showActions: Boolean = true,
     hasThanksCard: Boolean = false,
+    showBackButton: Boolean = false,
 ) {
     val alpha = 1f - scrollBehavior.state.collapsedFraction
 
@@ -329,12 +350,14 @@ private fun InvitationDetailTopBar(
             )
         },
         navigationIcon = {
-            IconButton(onClick = onBack) {
-                Icon(
-                    painter = painterResource(designR.drawable.ic_arrow_back_24),
-                    contentDescription = stringResource(R.string.desc_top_bar_back),
-                    tint = NachoTheme.colorScheme.iconSecondary,
-                )
+            if (showBackButton) {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        painter = painterResource(designR.drawable.ic_arrow_back_24),
+                        contentDescription = stringResource(R.string.desc_top_bar_back),
+                        tint = NachoTheme.colorScheme.iconSecondary,
+                    )
+                }
             }
         },
         actions = {

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/detail/InvitationPlaceholderScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/detail/InvitationPlaceholderScreen.kt
@@ -1,0 +1,49 @@
+package com.andlife.invitation.screen.detail
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.res.vectorResource
+import com.andlife.designsystem.R
+import com.andlife.designsystem.theme.NachoSpacing
+import com.andlife.designsystem.theme.NachoTheme
+
+@Composable
+fun InvitationPlaceholderScreen(
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(NachoTheme.colorScheme.backgroundPrimary),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Image(
+                painter = painterResource(R.drawable.ic_home_logo),
+                contentDescription = null
+            )
+            Spacer(modifier = Modifier.height(NachoSpacing.medium))
+            Text(
+                text = stringResource(R.string.txt_select_invitation),
+                style = NachoTheme.typography.headingMedium
+            )
+        }
+    }
+}

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
@@ -107,7 +107,7 @@ fun InvitationGuestBookRoute(
     onNavigateBack: () -> Unit,
     onNavigateToLogin: () -> Unit,
     modifier: Modifier = Modifier,
-    viewModel: InvitationGuestBookViewModel = hiltViewModel(),
+    viewModel: InvitationGuestBookViewModel,
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val guestBooks = viewModel.guestBooksPagingFlow.collectAsLazyPagingItems()
@@ -549,7 +549,7 @@ private fun InvitationGuestBookScreen(
 
                 val shouldChangeTo = when {
                     playVideoIndex != -1 && currentPlayingRatio < 0.2f -> -1
-                    playVideoIndex == -1 -> if (bestVisibilityRatio >= 0.6f) bestIndex else -1
+                    playVideoIndex == -1 -> if (bestVisibilityRatio >= 0.5f) bestIndex else -1
                     bestIndex != playVideoIndex && bestVisibilityRatio > currentPlayingRatio + 0.3f -> bestIndex
                     else -> playVideoIndex
                 }

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/Invitation2PaneViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/Invitation2PaneViewModel.kt
@@ -1,0 +1,35 @@
+package com.andlife.invitation.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.navigation.toRoute
+import com.andlife.invitation.Invitation
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+@HiltViewModel
+class Invitation2PaneViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle
+) : ViewModel() {
+    private val route = savedStateHandle.toRoute<Invitation>()
+
+    private val _uiState: MutableStateFlow<Invitation2PaneUiState> = MutableStateFlow(
+        Invitation2PaneUiState(
+            selectedInvitationId = route.initialInvitationId,
+            isFromDeelLink = route.isFromDeepLink
+        )
+    )
+    val uiState = _uiState.asStateFlow()
+
+    fun onInvitationClick(invitationId: Long?) {
+        _uiState.update { it.copy(selectedInvitationId = invitationId) }
+    }
+}
+
+data class Invitation2PaneUiState(
+    val selectedInvitationId: Long? = null,
+    val isFromDeelLink: Boolean = false,
+)

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationCollectionViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationCollectionViewModel.kt
@@ -34,9 +34,12 @@ import com.andlife.domain.util.AnalyticsLogger
 import com.andlife.domain.util.Button
 import com.andlife.domain.util.CrashlyticsLogger
 import com.andlife.domain.util.Screen
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 
-@HiltViewModel
-class InvitationCollectionViewModel @Inject constructor(
+@HiltViewModel(assistedFactory = InvitationCollectionViewModel.Factory::class)
+class InvitationCollectionViewModel @AssistedInject constructor(
     private val guestBookRepository: GuestBookRepository,
     private val mediaDownloader: MediaDownloader,
     private val userRepository: UserRepository,
@@ -44,13 +47,10 @@ class InvitationCollectionViewModel @Inject constructor(
     private val analyticsLogger: AnalyticsLogger,
     private val crashlyticsLogger: CrashlyticsLogger,
     @param:ApplicationContext private val context: Context,
-    savedStateHandle: SavedStateHandle
+    @Assisted val invitationId: Long,
 ) : BaseViewModel<InvitationCollectionUiState, InvitationCollectionUiEvent, InvitationCollectionSideEffect>(
     initialState = InvitationCollectionUiState(),
 ) {
-
-    private val invitationId: Long = savedStateHandle.toRoute<InvitationDetail>().id
-
     override val uiState: StateFlow<InvitationCollectionUiState> =
         mutableUiState
             .onStart {
@@ -243,5 +243,12 @@ class InvitationCollectionViewModel @Inject constructor(
 
     companion object {
         private const val FILE_NAME_PREFIX = "nacho_"
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(
+            invitationId: Long,
+        ): InvitationCollectionViewModel
     }
 }

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationDetailViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationDetailViewModel.kt
@@ -42,13 +42,6 @@ class InvitationDetailViewModel @AssistedInject constructor(
 ) : BaseViewModel<InvitationDetailUiState, InvitationDetailUiEvent, InvitationDetailSideEffect>(
     initialState = InvitationDetailUiState(),
 ) {
-    //private val route = savedStateHandle.toRoute<InvitationDetail>()
-    //private val isFromDeepLink: Boolean = route.isFromDeepLink
-    //private val invitationId: Long = route.id
-
-    init {
-        Log.d("InvitationDetailViewModel", "init VM id: $invitationId, hash: ${hashCode()}")
-    }
 
     override val uiState: StateFlow<InvitationDetailUiState> =
         mutableUiState

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationDetailViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationDetailViewModel.kt
@@ -20,6 +20,9 @@ import com.andlife.domain.util.RefreshEventHub
 import com.andlife.domain.util.RefreshEventHub.RefreshTarget
 import com.andlife.domain.util.Screen
 import com.andlife.ui.base.BaseViewModel
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.SharingStarted
@@ -29,22 +32,28 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@HiltViewModel
-class InvitationDetailViewModel @Inject constructor(
+@HiltViewModel(assistedFactory = InvitationDetailViewModel.Factory::class)
+class InvitationDetailViewModel @AssistedInject constructor(
     savedStateHandle: SavedStateHandle,
     private val invitationRepository: InvitationRepository,
-    private val analyticsLogger: AnalyticsLogger
+    private val analyticsLogger: AnalyticsLogger,
+    @Assisted val invitationId: Long,
+    @Assisted val isFromDeepLink: Boolean,
 ) : BaseViewModel<InvitationDetailUiState, InvitationDetailUiEvent, InvitationDetailSideEffect>(
     initialState = InvitationDetailUiState(),
 ) {
-    private val route = savedStateHandle.toRoute<InvitationDetail>()
-    private val isFromDeepLink: Boolean = route.isFromDeepLink
-    private val invitationId: Long = route.id
+    //private val route = savedStateHandle.toRoute<InvitationDetail>()
+    //private val isFromDeepLink: Boolean = route.isFromDeepLink
+    //private val invitationId: Long = route.id
+
+    init {
+        Log.d("InvitationDetailViewModel", "init VM id: $invitationId, hash: ${hashCode()}")
+    }
 
     override val uiState: StateFlow<InvitationDetailUiState> =
         mutableUiState
             .onStart {
-                Log.d("DeepLink Debug", "[${this@InvitationDetailViewModel.hashCode()}] 딥링크 진입 : $isFromDeepLink")
+                Log.d("InvitationDetailViewModel", "[${this@InvitationDetailViewModel.hashCode()}] 딥링크 진입 : $isFromDeepLink")
                 if (isFromDeepLink) {
                     joinAndLoadInvitation()
                 } else {
@@ -62,8 +71,10 @@ class InvitationDetailViewModel @Inject constructor(
 
         invitationRepository.joinInvitation(invitationId)
             .onSuccess {
-                RefreshEventHub.emit(RefreshTarget.HOME)
-                RefreshEventHub.emit(RefreshTarget.INVITATION)
+                if (!it.alreadyJoined) {
+                    RefreshEventHub.emit(RefreshTarget.HOME)
+                    RefreshEventHub.emit(RefreshTarget.INVITATION)
+                }
                 loadInvitation()
             }
             .onFailure { error, _ ->
@@ -72,6 +83,7 @@ class InvitationDetailViewModel @Inject constructor(
     }
 
     private suspend fun loadInvitation() {
+        Log.d("InvitationDetailViewModel", "id: $invitationId")
         updateState { copy(isLoading = true, isError = false, editableCache = null) }
 
         invitationRepository.getInvitation(invitationId)
@@ -95,10 +107,12 @@ class InvitationDetailViewModel @Inject constructor(
                 analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.INVITATION_DETAIL, Button.SHOW_THANKS_CARD))
                 showThanksCardOnboarding()
             }
+
             is InvitationDetailUiEvent.ClickLeaveInvitation -> {
                 analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.INVITATION_DETAIL, Button.INVITATION_LEAVE))
                 leaveInvitation()
             }
+
             is InvitationDetailUiEvent.ClickImage -> navigateToFullScreenImage(event.imageList, event.index)
             is InvitationDetailUiEvent.MapError -> showMapErrorSnackbar()
             is InvitationDetailUiEvent.RetryLoad -> retryLoad()
@@ -130,7 +144,8 @@ class InvitationDetailViewModel @Inject constructor(
         sendEffect(InvitationDetailSideEffect.ThanksCardOnBoarding)
     }
 
-    private fun navigateToFullScreenImage(imageList: ImmutableList<String>, index: Int) { /* TODO: 이미지 풀스크린*/ }
+    private fun navigateToFullScreenImage(imageList: ImmutableList<String>, index: Int) { /* TODO: 이미지 풀스크린*/
+    }
 
     private fun showMapErrorSnackbar() {
         sendEffect(InvitationDetailSideEffect.ShowMapErrorSnackbar)
@@ -155,4 +170,11 @@ class InvitationDetailViewModel @Inject constructor(
         updateState { copy(hasShownLottie = true) }
     }
 
+    @AssistedFactory
+    interface Factory {
+        fun create(
+            invitationId: Long,
+            isFromDeepLink: Boolean
+        ): InvitationDetailViewModel
+    }
 }

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationGuestBookViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/InvitationGuestBookViewModel.kt
@@ -44,6 +44,9 @@ import com.andlife.model.guestbook.UiMediaType
 import com.andlife.model.guestbook.toUiModel
 import com.andlife.ui.base.BaseViewModel
 import com.andlife.ui.component.invitation.SelectedMedia
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
@@ -59,10 +62,8 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@HiltViewModel
-class InvitationGuestBookViewModel
-@Inject
-constructor(
+@HiltViewModel(assistedFactory = InvitationGuestBookViewModel.Factory::class)
+class InvitationGuestBookViewModel @AssistedInject constructor(
     private val mediaUploader: MediaUploader,
     private val mediaFileProvider: MediaFileProvider,
     private val thumbnailGenerator: ThumbnailGenerator,
@@ -73,12 +74,10 @@ constructor(
     val videoPlayerPool: AutoVideoPlayerPool,
     private val analyticsLogger: AnalyticsLogger,
     private val crashlyticsLogger: CrashlyticsLogger,
-    savedStateHandle: SavedStateHandle,
+    @Assisted val invitationId: Long,
 ) : BaseViewModel<InvitationGuestBookUiState, InvitationGuestBookUiEvent, InvitationGuestBookSideEffect>(
     InvitationGuestBookUiState(),
 ) {
-    private val invitationId: Long = savedStateHandle.toRoute<InvitationDetail>().id
-
     override val uiState: StateFlow<InvitationGuestBookUiState> = mutableUiState.asStateFlow()
 
     private val refreshFlow = MutableStateFlow(0)
@@ -595,5 +594,12 @@ constructor(
                 sendEffect(InvitationGuestBookSideEffect.ReportFailure(messageToShow))
             }
         }
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(
+            invitationId: Long,
+        ): InvitationGuestBookViewModel
     }
 }


### PR DESCRIPTION
## AssistedInject 
기존 Navigation2에서 리스트 - 상세 화면일 경우 ListRoute, DetailRoute 2개의 Route로 분리하여 사용했습니다.
<img width="644" height="135" alt="image" src="https://github.com/user-attachments/assets/7f30afb9-a9dc-4355-87cd-e76cbb5f4b4f" />
각 Route로 분리되어있었기 때문에 Navigation에 지원하는 .toRoute() 함수를 통해 ViewModel에서 Navigation Route에 전달된 데이터에 쉽게 접근할 수 있었습니다. toRoute의 내부 동작이 Runtime에 해당 Route 모델을 디코딩하여 id 값을 쉽게 사용할 수 있었습니다.
```kotlin
class ViewModel @Inject constructor(
    savedStateHandle: SavedStateHandle
) : ViewModel() {
    private val myInvitationId: Long = savedStateHandle.toRoute<MyInvitationDetail>().id
}
```

<br>

적응형 UI를 위해 NavigableListDetailPaneScaffold를 적용하며 두 개의 Route에서 1개의 Route만 필요하게 되었습니다.
기존: ListRoute, DetailRotue -> ListRoute에서 다 처리함
<img width="582" height="198" alt="image" src="https://github.com/user-attachments/assets/50928182-3b40-4ebe-8148-3b9f932a8e28" />

그러다 보니 DetailViewModel에서 toRoute를 사용하여 id 값을 꺼내오지 못하고 되는 문제가 발생했습니다.
이를 해결하기 위해 ViewModel 인스턴스를 생성할 때 런타임에 id를 주입하는 방법으로 대체하였습니다.
의존성 주입으로 hilt를 사용하고 있고 런타임에 의존성을 주입하기 위해서 @AssistedInject로 변경하였습니다.
<img width="779" height="221" alt="image" src="https://github.com/user-attachments/assets/a7fc95fc-7be6-4b4a-87a9-aa73b20fe55b" />


## 📸 스크린샷 (선택)
<img width="1920" height="1200" alt="Screenshot_20260306_133111" src="https://github.com/user-attachments/assets/972d1ae1-1bb2-442d-89cb-d7e56f040d9e" />

## 🔗 관련 이슈
> 해당 PR과 연결된 이슈 번호를 적어주세요. (예: #1)

- Close #214 

## ✅ 체크리스트
- [x] 팀 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 import는 삭제했나요?
