### PR TITLE
Detail Pane ViewModelStoreOwner scope 적용

### DIFF
--- a/android/app/src/main/kotlin/com/andlife/nacho/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/andlife/nacho/MainActivity.kt
@@ -6,6 +6,7 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.activity.viewModels
+import androidx.compose.material3.adaptive.navigationsuite.rememberNavigationSuiteScaffoldState
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.staticCompositionLocalOf
@@ -16,6 +17,7 @@ import com.andlife.domain.util.AnalyticsLogger
 import com.andlife.login.LocalLoginManager
 import com.andlife.login.social.LoginManager
 import com.andlife.nacho.viewmodel.MainViewModel
+import com.andlife.ui.util.LocalNavigationSuiteState
 import dagger.hilt.android.AndroidEntryPoint
 import javax.inject.Inject
 
@@ -39,9 +41,11 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         setContent {
             NachoTheme {
+                val suiteState = rememberNavigationSuiteScaffoldState()
                 CompositionLocalProvider(
                     LocalLoginManager provides loginManager,
-                    LocalAnalyticsLogger provides analyticsLogger
+                    LocalAnalyticsLogger provides analyticsLogger,
+                    LocalNavigationSuiteState provides suiteState
                 ) {
                     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
                     if (!uiState.isSplash) {

--- a/android/app/src/main/kotlin/com/andlife/nacho/navigation/NachoNavigator.kt
+++ b/android/app/src/main/kotlin/com/andlife/nacho/navigation/NachoNavigator.kt
@@ -36,12 +36,9 @@ import com.andlife.login.Login
 import com.andlife.login.navigateToLogin
 import com.andlife.myinvitation.navigateToMyInvitation
 import com.andlife.myinvitation.navigateToMyInvitationDetail
-import com.andlife.nacho.util.isNavigationBar
 import com.andlife.setting.navigateToSetting
 import com.andlife.thanks_card.navigateToCreateThanksCard
 import com.andlife.thanks_card.navigateToUpdateThanksCard
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 import kotlin.reflect.KClass
 
 @Stable

--- a/android/app/src/main/kotlin/com/andlife/nacho/navigation/NavHost.kt
+++ b/android/app/src/main/kotlin/com/andlife/nacho/navigation/NavHost.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteItem
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffold
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldDefaults
 import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldValue
-import androidx.compose.material3.adaptive.navigationsuite.rememberNavigationSuiteScaffoldState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
@@ -46,10 +45,11 @@ import com.andlife.model.util.NavigationKeyConstant.UPDATE_CARD
 import com.andlife.myinvitation.myInvitationDetailNavGraph
 import com.andlife.myinvitation.myInvitationNavGraph
 import com.andlife.nacho.LocalAnalyticsLogger
-import com.andlife.nacho.util.isNavigationBar
 import com.andlife.setting.settingNavGraph
 import com.andlife.thanks_card.createThanksCardNavGraph
 import com.andlife.thanks_card.updateThanksCardNavGraph
+import com.andlife.ui.util.LocalNavigationSuiteState
+import com.andlife.ui.util.isNavigationBar
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 
@@ -59,7 +59,7 @@ fun NachoNavHost(
     deepLinkManager: DeepLinkManager,
     modifier: Modifier = Modifier,
 ) {
-    val suiteState = rememberNavigationSuiteScaffoldState()
+    val suiteState = LocalNavigationSuiteState.current
     val currentDestination = navigator.currentDestination
     val navSuiteType =
         NavigationSuiteScaffoldDefaults.navigationSuiteType(currentWindowAdaptiveInfo())

--- a/android/app/src/main/kotlin/com/andlife/nacho/util/NavigationSuiteTypeUtil.kt
+++ b/android/app/src/main/kotlin/com/andlife/nacho/util/NavigationSuiteTypeUtil.kt
@@ -1,9 +1,0 @@
-package com.andlife.nacho.util
-
-import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
-
-internal val NavigationSuiteType.isNavigationBar
-    get() =
-        this == NavigationSuiteType.ShortNavigationBarCompact ||
-            this == NavigationSuiteType.ShortNavigationBarMedium ||
-            this == NavigationSuiteType.NavigationBar

--- a/android/core/ui/build.gradle.kts
+++ b/android/core/ui/build.gradle.kts
@@ -44,6 +44,7 @@ dependencies {
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
+    implementation(libs.androidx.lifecycle.viewmodel.savedstate)
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)

--- a/android/core/ui/build.gradle.kts
+++ b/android/core/ui/build.gradle.kts
@@ -41,6 +41,8 @@ dependencies {
     // Naver Map
     implementation(libs.naver.map.compose)
 
+    implementation(libs.androidx.material3.adaptive.navigation.suite)
+
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/util/DetailPaneViewModelScope.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/util/DetailPaneViewModelScope.kt
@@ -1,0 +1,57 @@
+package com.andlife.ui.util
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.remember
+import androidx.lifecycle.HasDefaultViewModelProviderFactory
+import androidx.lifecycle.SAVED_STATE_REGISTRY_OWNER_KEY
+import androidx.lifecycle.SavedStateViewModelFactory
+import androidx.lifecycle.VIEW_MODEL_STORE_OWNER_KEY
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.ViewModelStore
+import androidx.lifecycle.ViewModelStoreOwner
+import androidx.lifecycle.enableSavedStateHandles
+import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.lifecycle.viewmodel.MutableCreationExtras
+import androidx.lifecycle.viewmodel.compose.LocalViewModelStoreOwner
+import androidx.savedstate.SavedStateRegistryOwner
+import androidx.savedstate.compose.LocalSavedStateRegistryOwner
+
+@Composable
+fun DetailPaneViewModelScope(
+    content: @Composable () -> Unit
+) {
+    val viewModelStore = remember { ViewModelStore() }
+    val savedStateRegistryOwner = LocalSavedStateRegistryOwner.current
+
+    val viewModelStoreOwner = remember(viewModelStore) {
+        object : ViewModelStoreOwner, HasDefaultViewModelProviderFactory,
+            SavedStateRegistryOwner by savedStateRegistryOwner {
+            override val viewModelStore: ViewModelStore
+                get() = viewModelStore
+            override val defaultViewModelProviderFactory: ViewModelProvider.Factory
+                get() = SavedStateViewModelFactory()
+            override val defaultViewModelCreationExtras: CreationExtras
+                get() =
+                    MutableCreationExtras().also {
+                        it[SAVED_STATE_REGISTRY_OWNER_KEY] = this
+                        it[VIEW_MODEL_STORE_OWNER_KEY] = this
+                    }
+            init {
+                enableSavedStateHandles()
+            }
+        }
+    }
+
+    DisposableEffect(viewModelStoreOwner) {
+        onDispose {
+            viewModelStore.clear()
+        }
+    }
+
+    CompositionLocalProvider(LocalViewModelStoreOwner provides viewModelStoreOwner) {
+        content()
+    }
+}
+

--- a/android/core/ui/src/main/kotlin/com/andlife/ui/util/LocalSuiteState.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/util/LocalSuiteState.kt
@@ -1,0 +1,15 @@
+package com.andlife.ui.util
+
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldState
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteType
+import androidx.compose.runtime.staticCompositionLocalOf
+
+val LocalNavigationSuiteState = staticCompositionLocalOf<NavigationSuiteScaffoldState> {
+    error("Navigation Suite State 설정되지 않음")
+}
+
+val NavigationSuiteType.isNavigationBar
+    get() =
+        this == NavigationSuiteType.ShortNavigationBarCompact ||
+            this == NavigationSuiteType.ShortNavigationBarMedium ||
+            this == NavigationSuiteType.NavigationBar

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/InvitationNavGraph.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/InvitationNavGraph.kt
@@ -3,6 +3,7 @@ package com.andlife.invitation
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.ui.Modifier
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavDeepLink
 import androidx.navigation.NavGraphBuilder
@@ -11,6 +12,8 @@ import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.andlife.invitation.screen.detail.InvitationDetailRoute
 import com.andlife.invitation.screen.InvitationsListDetailScreen
+import com.andlife.invitation.viewmodel.InvitationDetailViewModel
+import com.andlife.invitation.viewmodel.InvitationGuestBookViewModel
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.serialization.Serializable
 
@@ -65,13 +68,19 @@ fun NavGraphBuilder.invitationDetailNavGraph(
     onNavigateToLogin: () -> Unit,
 ) {
     composable<InvitationDetail>(
-        deepLinks = persistentListOf(deepLinks),
+
     ) { val invitationDetail = it.toRoute<InvitationDetail>()
         InvitationDetailRoute(
             selectedId = invitationDetail.id,
             onNavigateBack = onNavigateBack,
             onNavigateToLogin = onNavigateToLogin,
             modifier = Modifier.padding(),
+            viewModel = hiltViewModel<InvitationDetailViewModel, InvitationDetailViewModel.Factory> { factory ->
+                factory.create(invitationDetail.id, false)
+            },
+            guestBookViewModel = hiltViewModel<InvitationGuestBookViewModel, InvitationGuestBookViewModel.Factory> { factory ->
+                factory.create(invitationDetail.id)
+            }
         )
     }
 }

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/InvitationScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/InvitationScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
 import androidx.compose.material3.adaptive.layout.AnimatedPane
 import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldRole
 import androidx.compose.material3.adaptive.layout.PaneAdaptedValue
@@ -21,6 +22,8 @@ import androidx.compose.material3.adaptive.navigation.NavigableListDetailPaneSca
 import androidx.compose.material3.adaptive.navigation.ThreePaneScaffoldNavigator
 import androidx.compose.material3.adaptive.navigation.ThreePaneScaffoldPredictiveBackHandler
 import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaffoldNavigator
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldDefaults
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldValue
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -69,7 +72,9 @@ import com.andlife.ui.component.loading.InvitationLoadingIndicator
 import com.andlife.ui.component.paging.PagingStateContent
 import com.andlife.ui.component.report.ReportBottomSheet
 import com.andlife.ui.util.DetailPaneViewModelScope
+import com.andlife.ui.util.LocalNavigationSuiteState
 import com.andlife.ui.util.collectWithLifecycle
+import com.andlife.ui.util.isNavigationBar
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
@@ -105,6 +110,10 @@ private fun InvitationListDetailScreen(
 ) {
     val selectedInvitationId = uiState.selectedInvitationId
 
+    val suiteState = LocalNavigationSuiteState.current
+    val navSuiteType =
+        NavigationSuiteScaffoldDefaults.navigationSuiteType(currentWindowAdaptiveInfo())
+
     val listDetailNavigator = rememberListDetailPaneScaffoldNavigator()
     val coroutineScope = rememberCoroutineScope()
 
@@ -122,6 +131,7 @@ private fun InvitationListDetailScreen(
         onInvitationClick(id)
         invitationRoute = InvitationDetail(id)
         coroutineScope.launch {
+            if (navSuiteType.isNavigationBar && suiteState.currentValue == NavigationSuiteScaffoldValue.Visible) suiteState.hide()
             listDetailNavigator.navigateTo(ListDetailPaneScaffoldRole.Detail)
         }
     }
@@ -162,6 +172,7 @@ private fun InvitationListDetailScreen(
                                     selectedId = route.id,
                                     onNavigateBack = {
                                         coroutineScope.launch {
+                                            if (navSuiteType.isNavigationBar && suiteState.currentValue == NavigationSuiteScaffoldValue.Hidden) suiteState.show()
                                             listDetailNavigator.navigateBack()
                                         }
                                     },

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/InvitationScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/InvitationScreen.kt
@@ -68,6 +68,7 @@ import com.andlife.ui.component.listitem.MenuItem
 import com.andlife.ui.component.loading.InvitationLoadingIndicator
 import com.andlife.ui.component.paging.PagingStateContent
 import com.andlife.ui.component.report.ReportBottomSheet
+import com.andlife.ui.util.DetailPaneViewModelScope
 import com.andlife.ui.util.collectWithLifecycle
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
@@ -156,26 +157,28 @@ private fun InvitationListDetailScreen(
                 AnimatedContent(invitationRoute) { route ->
                     when (route) {
                         is InvitationDetail -> {
-                            InvitationDetailRoute(
-                                selectedId = route.id,
-                                onNavigateBack = {
-                                    coroutineScope.launch {
-                                        listDetailNavigator.navigateBack()
+                            DetailPaneViewModelScope {
+                                InvitationDetailRoute(
+                                    selectedId = route.id,
+                                    onNavigateBack = {
+                                        coroutineScope.launch {
+                                            listDetailNavigator.navigateBack()
+                                        }
+                                    },
+                                    onNavigateToLogin = onNavigateToLogin,
+                                    showBackButton = !listDetailNavigator.isListPaneVisible(),
+                                    viewModel = hiltViewModel<InvitationDetailViewModel, InvitationDetailViewModel.Factory>(
+                                        key = "detail ${route.id}"
+                                    ) { factory ->
+                                        factory.create(route.id, uiState.isFromDeelLink)
+                                    },
+                                    guestBookViewModel = hiltViewModel<InvitationGuestBookViewModel, InvitationGuestBookViewModel.Factory>(
+                                        key = "guestbook ${route.id}"
+                                    ) { factory ->
+                                        factory.create(route.id)
                                     }
-                                },
-                                onNavigateToLogin = onNavigateToLogin,
-                                showBackButton = !listDetailNavigator.isListPaneVisible(),
-                                viewModel = hiltViewModel<InvitationDetailViewModel, InvitationDetailViewModel.Factory>(
-                                    key = "detail ${route.id}"
-                                ){ factory ->
-                                    factory.create(route.id, uiState.isFromDeelLink)
-                                },
-                                guestBookViewModel = hiltViewModel<InvitationGuestBookViewModel, InvitationGuestBookViewModel.Factory>(
-                                    key = "guestbook ${route.id}"
-                                ) { factory ->
-                                    factory.create(route.id)
-                                }
-                            )
+                                )
+                            }
                         }
                         is InvitationPlaceholder -> {
                             InvitationPlaceholderScreen()

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/detail/InvitationDetailScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/detail/InvitationDetailScreen.kt
@@ -82,7 +82,6 @@ fun InvitationDetailRoute(
     viewModel: InvitationDetailViewModel = hiltViewModel(),
     guestBookViewModel: InvitationGuestBookViewModel = hiltViewModel(),
 ) {
-    Log.d("InvitationDetailRoute", "vm:  ${viewModel.invitationId} ${viewModel.hashCode()}")
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val isGuestBookUploading by guestBookViewModel.uiState
         .map { it.isUploading }

--- a/android/gradle/libs.versions.toml
+++ b/android/gradle/libs.versions.toml
@@ -42,6 +42,7 @@ workManager = "2.10.5"
 hiltWork = "1.2.0"
 lottie = "6.7.1"
 ucrop = "2.2.8"
+lifecycleViewmodelSavedstate = "2.10.0"
 
 [libraries]
 androidx-compose-material-icons-core = { module = "androidx.compose.material:material-icons-core", version.ref = "materialIconsCore" }
@@ -150,6 +151,7 @@ androidx-hilt-compiler = { group = "androidx.hilt", name = "hilt-compiler", vers
 
 # Image Crop
 ucrop = { group = "com.github.yalantis", name = "ucrop", version.ref = "ucrop" }
+androidx-lifecycle-viewmodel-savedstate = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-savedstate", version.ref = "lifecycleViewmodelSavedstate" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## DetailViewModelScope

### 문제점
- NavigableListDetailPaneScaffold 적응형 UI를 적용하며 기존 2개의 Route -> 1개의 Route로 변경됨
- Detail화면 진입 후 -> 다시 리스트 화면으로 Back 시 해당 DetailViewModel clear 안됨 (리스트 탭의 NavBackEntry 사용 원인)
- 이전 Detail 화면의 상태가 그대로 남아있게 됨 -> Detail 화면이 쌓일수록 메모리 잡아먹음


### 해결방안
- 해당 Detail 화면을 벗어날 때 DetailViewModel도 Clear 
- Detail Composable에 독립적인 ViewModelStoreOwner를 제공하는 Scope Composable 구현

```kotlin
@Composable
fun DetailPaneViewModelScope(
    content: @Composable () -> Unit
) {
    val viewModelStore = remember { ViewModelStore() }
    val savedStateRegistryOwner = LocalSavedStateRegistryOwner.current

    val viewModelStoreOwner = remember(viewModelStore) {
        object : ViewModelStoreOwner, HasDefaultViewModelProviderFactory,
            SavedStateRegistryOwner by savedStateRegistryOwner {
            override val viewModelStore: ViewModelStore
                get() = viewModelStore
            override val defaultViewModelProviderFactory: ViewModelProvider.Factory
                get() = SavedStateViewModelFactory() // SavedState를 주입할 수 있게 해주는 기본 ViewModelFactory
            override val defaultViewModelCreationExtras: CreationExtras
                get() = // ViewModel을 생성하는데 데이터를 전달하기 위한 키 값 데이터 구조
                    MutableCreationExtras().also {
                        it[SAVED_STATE_REGISTRY_OWNER_KEY] = this
                        it[VIEW_MODEL_STORE_OWNER_KEY] = this
                    }
            init {
                enableSavedStateHandles()
            }
        }
    }

    DisposableEffect(viewModelStoreOwner) {
        onDispose {
            viewModelStore.clear()
        }
    }

    CompositionLocalProvider(LocalViewModelStoreOwner provides viewModelStoreOwner) {
        content()
    }
}
```
- ViewModelStore를 생성하여 ViewModelStoreOwner, HasDefaultViewModelProviderFactory, SavedStateRegistryOwner를 구현하는 커스텀 Owner 생성하여 LocalViewModelStoreOwner로 제공
- DisposableEffect를 활용하여 onDispose 될 때 viewModelStore.clear() 호출 => Composition에서 제거될 때 해당 scope의 ViewModel들도 함께 정리

### 동일한 동작을 수행했을 때
- 수정 전 (4개의 Detail 화면에 진입 후 리스트 화면으로 돌아왔을 때)
<img width="1013" height="87" alt="image" src="https://github.com/user-attachments/assets/a70885be-5f79-4924-b3e9-0131eb8abcf2" />

<br>

- 수정 후 (4개의 Detail 화면에 진입 후 리스트 화면으로 돌아왔을 때)
<img width="1021" height="67" alt="image" src="https://github.com/user-attachments/assets/85652ebd-aa9d-49cf-b75f-4301d79f4e59" />


### 참고자료 
- [Nav3 - rememberViewModelStoreNavEntryDecorator](https://cs.android.com/androidx/platform/frameworks/support/+/androidx-main:lifecycle/lifecycle-viewmodel-navigation3/src/commonMain/kotlin/androidx/lifecycle/viewmodel/navigation3/ViewModelStoreNavEntryDecorator.kt?q=file:androidx%2Flifecycle%2Fviewmodel%2Fnavigation3%2FViewModelStoreNavEntryDecorator.kt%20function:rememberViewModelStoreNavEntryDecorator)
- ComponentActivity 내부코드

<br>

## 🔗 관련 이슈
- Close #214 

## ✅ 체크리스트
- [x] 팀 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 import는 삭제했나요?
