### PR TITLE
나의 초대 탭 적응형 UI 적용

### DIFF
--- a/android/app/src/main/kotlin/com/andlife/nacho/navigation/NavHost.kt
+++ b/android/app/src/main/kotlin/com/andlife/nacho/navigation/NavHost.kt
@@ -231,7 +231,6 @@ fun NachoNavHost(
                 createCardByInvitationNavGraph(
                     onBackClick = navigator::navigatePopBackStack,
                     onSuccessCreateCard = {
-                        RefreshEventHub.emit(RefreshEventHub.RefreshTarget.MY_INVITATION_DETAIL)
                         navigator.navigatePopBackStack()
                     }
                 )
@@ -239,7 +238,6 @@ fun NachoNavHost(
                 updateCardNavGraph(
                     onBackClick = navigator::navigatePopBackStack,
                     onSuccessCreateCard = {
-                        RefreshEventHub.emit(RefreshEventHub.RefreshTarget.MY_INVITATION_DETAIL)
                         navigator.navigatePopBackStack()
                     }
                 )
@@ -247,18 +245,12 @@ fun NachoNavHost(
                 loginNavGraph()
 
                 createThanksCardNavGraph(
-                    onSuccessfulCreate = {
-                        RefreshEventHub.emit(RefreshEventHub.RefreshTarget.MY_INVITATION_DETAIL)
-                        navigator.navigatePopBackStack()
-                    },
+                    onSuccessfulCreate = navigator::navigatePopBackStack,
                     onBackClick = navigator::navigatePopBackStack,
                 )
 
                 updateThanksCardNavGraph(
-                    onSuccessfulUpdate = {
-                        RefreshEventHub.emit(RefreshEventHub.RefreshTarget.MY_INVITATION_DETAIL)
-                        navigator.navigatePopBackStack()
-                    },
+                    onSuccessfulUpdate = navigator::navigatePopBackStack,
                     onBackClick = navigator::navigatePopBackStack
                 )
             }

--- a/android/app/src/main/kotlin/com/andlife/nacho/navigation/NavHost.kt
+++ b/android/app/src/main/kotlin/com/andlife/nacho/navigation/NavHost.kt
@@ -28,6 +28,7 @@ import com.andlife.deeplink.DeepLinkManager
 import com.andlife.designsystem.preview.PreviewTheme
 import com.andlife.designsystem.theme.NachoTheme
 import com.andlife.domain.util.AnalyticsEvent
+import com.andlife.domain.util.RefreshEventHub
 import com.andlife.home.homeNavGraph
 import com.andlife.invitation.invitationDetailNavGraph
 import com.andlife.invitation.invitationNavGraph
@@ -39,9 +40,6 @@ import com.andlife.invitation_edit.invitationCreateNavGraph
 import com.andlife.invitation_edit.invitationEditNavGraph
 import com.andlife.invitation_edit.invitationPreviewNavGraph
 import com.andlife.login.loginNavGraph
-import com.andlife.model.util.NavigationKeyConstant.CREATE_CARD_BY_INVITATION_ID
-import com.andlife.model.util.NavigationKeyConstant.CREATE_THANKS_CARD
-import com.andlife.model.util.NavigationKeyConstant.UPDATE_CARD
 import com.andlife.myinvitation.myInvitationDetailNavGraph
 import com.andlife.myinvitation.myInvitationNavGraph
 import com.andlife.nacho.LocalAnalyticsLogger
@@ -77,12 +75,15 @@ fun NachoNavHost(
             navSuiteType.isNavigationBar && isBottomTab != null -> {
                 if (suiteState.currentValue == NavigationSuiteScaffoldValue.Hidden) suiteState.show()
             }
+
             navSuiteType.isNavigationBar && isBottomTab == null -> {
                 if (suiteState.currentValue == NavigationSuiteScaffoldValue.Visible) suiteState.hide()
             }
+
             !navSuiteType.isNavigationBar && isBottomTab == null -> {
                 if (suiteState.currentValue == NavigationSuiteScaffoldValue.Visible) suiteState.hide()
             }
+
             !navSuiteType.isNavigationBar && isBottomTab != null -> {
                 if (suiteState.currentValue == NavigationSuiteScaffoldValue.Hidden) suiteState.show()
             }
@@ -169,10 +170,14 @@ fun NachoNavHost(
                 myInvitationNavGraph(
                     snackbarHostState = snackbarHostState,
                     onNavigateToCreate = navigator::navigateToMyInvitationCreate,
-                    onNavigateToDetail = navigator::navigateToMyInvitationDetail,
                     onNavigateToLogin = {
                         navigator.navigateToLogin()
-                    }
+                    },
+                    onNavigateToEditInvitation = navigator::navigateToMyInvitationEdit,
+                    onNavigateToEditCard = navigator::navigateToUpdateCard,
+                    onNavigateToCreateCard = navigator::navigateToCreateCardByInvitation,
+                    onNavigateToCreateThanksCard = navigator::navigateToCreateThanksCard,
+                    onNavigateToUpdateThanksCard = navigator::navigateToUpdateThanksCard
                 )
 
                 myInvitationDetailNavGraph(
@@ -198,7 +203,9 @@ fun NachoNavHost(
                     onNavigateToPreview = navigator::navigateToInvitationPreview,
                     onNavigateBack = navigator::navigatePopBackStack,
                     onNavigateCreateCard = navigator::navigateToCreateCard,
-                    onNavigateToInvitationDetail = navigator::navigateToMyInvitationDetailByCreate
+                    onNavigateToInvitationDetail = { id ->
+                        navigator.navigatePopBackStack()
+                    }
                 )
 
                 invitationEditNavGraph(
@@ -224,8 +231,7 @@ fun NachoNavHost(
                 createCardByInvitationNavGraph(
                     onBackClick = navigator::navigatePopBackStack,
                     onSuccessCreateCard = {
-                        navigator.navController.previousBackStackEntry?.savedStateHandle[CREATE_CARD_BY_INVITATION_ID] =
-                            true
+                        RefreshEventHub.emit(RefreshEventHub.RefreshTarget.MY_INVITATION_DETAIL)
                         navigator.navigatePopBackStack()
                     }
                 )
@@ -233,7 +239,7 @@ fun NachoNavHost(
                 updateCardNavGraph(
                     onBackClick = navigator::navigatePopBackStack,
                     onSuccessCreateCard = {
-                        navigator.navController.previousBackStackEntry?.savedStateHandle[UPDATE_CARD] = true
+                        RefreshEventHub.emit(RefreshEventHub.RefreshTarget.MY_INVITATION_DETAIL)
                         navigator.navigatePopBackStack()
                     }
                 )
@@ -242,7 +248,7 @@ fun NachoNavHost(
 
                 createThanksCardNavGraph(
                     onSuccessfulCreate = {
-                        navigator.navController.previousBackStackEntry?.savedStateHandle[CREATE_THANKS_CARD] = true
+                        RefreshEventHub.emit(RefreshEventHub.RefreshTarget.MY_INVITATION_DETAIL)
                         navigator.navigatePopBackStack()
                     },
                     onBackClick = navigator::navigatePopBackStack,
@@ -250,7 +256,7 @@ fun NachoNavHost(
 
                 updateThanksCardNavGraph(
                     onSuccessfulUpdate = {
-                        navigator.navController.previousBackStackEntry?.savedStateHandle[UPDATE_CARD] = true
+                        RefreshEventHub.emit(RefreshEventHub.RefreshTarget.MY_INVITATION_DETAIL)
                         navigator.navigatePopBackStack()
                     },
                     onBackClick = navigator::navigatePopBackStack

--- a/android/core/designsystem/src/main/res/values/strings.xml
+++ b/android/core/designsystem/src/main/res/values/strings.xml
@@ -13,5 +13,6 @@
 
     <string name="des_component_filterchip">검색결과를 정렬하는 칩 아이콘</string>
     <string name="txt_select_invitation">초대받은 초대장을 선택해주세요.</string>
+    <string name="txt_select_my_invitation">내가 생성한 초대장을 선택해주세요.</string>
 
 </resources>

--- a/android/feature/invitation-edit/src/main/kotlin/com/andlife/invitation_edit/InvitationEditGraph.kt
+++ b/android/feature/invitation-edit/src/main/kotlin/com/andlife/invitation_edit/InvitationEditGraph.kt
@@ -9,6 +9,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import com.andlife.domain.util.RefreshEventHub
 import com.andlife.invitation_edit.model.address.AddressUiModel
 import com.andlife.invitation_edit.screen.address.AddressSearchRoute
 import com.andlife.invitation_edit.screen.create.InvitationCreateRoute
@@ -92,12 +93,7 @@ fun NavGraphBuilder.invitationEditNavGraph(
             onNavigateBack = onNavigateBack,
             modifier = Modifier,
             address = selectedAddressUiModel,
-            onSuccessSave = {
-                navController.previousBackStackEntry
-                    ?.savedStateHandle
-                    ?.set(NavigationKeyConstant.INVITATION_UPDATED, true)
-                onNavigateBack()
-            },
+            onSuccessSave = onNavigateBack
         )
     }
 }

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/InvitationNavGraph.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/InvitationNavGraph.kt
@@ -11,7 +11,7 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.andlife.invitation.screen.detail.InvitationDetailRoute
-import com.andlife.invitation.screen.InvitationsListDetailScreen
+import com.andlife.invitation.screen.InvitationsListDetailRoute
 import com.andlife.invitation.viewmodel.InvitationDetailViewModel
 import com.andlife.invitation.viewmodel.InvitationGuestBookViewModel
 import kotlinx.collections.immutable.persistentListOf
@@ -55,7 +55,7 @@ fun NavGraphBuilder.invitationNavGraph(
     composable<Invitation>(
         deepLinks = persistentListOf(deepLinks)
     ) {
-        InvitationsListDetailScreen(
+        InvitationsListDetailRoute(
             snackbarHostState = snackbarHostState,
             onNavigateToLogin = onNavigateToLogin,
         )
@@ -68,8 +68,8 @@ fun NavGraphBuilder.invitationDetailNavGraph(
     onNavigateToLogin: () -> Unit,
 ) {
     composable<InvitationDetail>(
-
-    ) { val invitationDetail = it.toRoute<InvitationDetail>()
+    ) {
+        val invitationDetail = it.toRoute<InvitationDetail>()
         InvitationDetailRoute(
             selectedId = invitationDetail.id,
             onNavigateBack = onNavigateBack,

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/InvitationScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/InvitationScreen.kt
@@ -83,7 +83,7 @@ private const val SAMPLE_INVITATION_ID = 1L
 
 @OptIn(ExperimentalMaterial3AdaptiveApi::class)
 @Composable
-fun InvitationsListDetailScreen(
+fun InvitationsListDetailRoute(
     snackbarHostState: SnackbarHostState,
     onNavigateToLogin: () -> Unit,
     modifier: Modifier = Modifier,
@@ -137,7 +137,7 @@ private fun InvitationListDetailScreen(
     }
 
     LaunchedEffect(Unit) {
-        if (!isConsumeDeepLink && uiState.isFromDeelLink) {
+        if (!isConsumeDeepLink && uiState.isFromDeeplLink) {
             val id = uiState.selectedInvitationId ?: return@LaunchedEffect
             onInvitationClickShowDetailPane(id)
             isConsumeDeepLink = true
@@ -181,7 +181,7 @@ private fun InvitationListDetailScreen(
                                     viewModel = hiltViewModel<InvitationDetailViewModel, InvitationDetailViewModel.Factory>(
                                         key = "detail ${route.id}"
                                     ) { factory ->
-                                        factory.create(route.id, uiState.isFromDeelLink)
+                                        factory.create(route.id, uiState.isFromDeeplLink)
                                     },
                                     guestBookViewModel = hiltViewModel<InvitationGuestBookViewModel, InvitationGuestBookViewModel.Factory>(
                                         key = "guestbook ${route.id}"

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/Invitation2PaneViewModel.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/viewmodel/Invitation2PaneViewModel.kt
@@ -19,7 +19,7 @@ class Invitation2PaneViewModel @Inject constructor(
     private val _uiState: MutableStateFlow<Invitation2PaneUiState> = MutableStateFlow(
         Invitation2PaneUiState(
             selectedInvitationId = route.initialInvitationId,
-            isFromDeelLink = route.isFromDeepLink
+            isFromDeeplLink = route.isFromDeepLink
         )
     )
     val uiState = _uiState.asStateFlow()
@@ -31,5 +31,5 @@ class Invitation2PaneViewModel @Inject constructor(
 
 data class Invitation2PaneUiState(
     val selectedInvitationId: Long? = null,
-    val isFromDeelLink: Boolean = false,
+    val isFromDeeplLink: Boolean = false,
 )

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/MyInvitationGraph.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/MyInvitationGraph.kt
@@ -1,7 +1,6 @@
 package com.andlife.myinvitation
 
 import android.util.Log
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.LaunchedEffect
@@ -13,28 +12,30 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import androidx.navigation.toRoute
 import com.andlife.domain.util.RefreshEventHub
-import com.andlife.model.util.NavigationKeyConstant.CREATE_CARD_BY_INVITATION_ID
-import com.andlife.model.util.NavigationKeyConstant.CREATE_THANKS_CARD
-import com.andlife.model.util.NavigationKeyConstant.INVITATION_UPDATED
-import com.andlife.model.util.NavigationKeyConstant.UPDATE_CARD
-import com.andlife.myinvitation.model.detail.MyInvitationDetailUiEvent
-import com.andlife.myinvitation.screen.MyInvitationDetailRoute
-import com.andlife.myinvitation.screen.MyInvitationRoute
+import com.andlife.myinvitation.screen.detail.MyInvitationDetailRoute
+import com.andlife.myinvitation.screen.MyInvitationScreen
 import com.andlife.myinvitation.viewmodel.MyInvitationDetailViewModel
+import com.andlife.myinvitation.viewmodel.MyInvitationGuestBookViewModel
 import com.andlife.myinvitation.viewmodel.MyInvitationViewModel
 import kotlinx.serialization.Serializable
 
 @Serializable
-data object MyInvitation
+data class MyInvitation(
+    val initialInvitationId: Long? = null,
+)
 
 @Serializable
 data class MyInvitationDetail(
     val id: Long,
 )
 
-fun NavController.navigateToMyInvitation(navOptions: NavOptions) {
-    navigate(MyInvitation, navOptions)
+internal data object MyInvitationPlaceholder
+
+
+fun NavController.navigateToMyInvitation(navOptions: NavOptions, id: Long? = null) {
+    navigate(MyInvitation(id), navOptions)
 }
 
 fun NavController.navigateToMyInvitationDetail(
@@ -47,8 +48,12 @@ fun NavController.navigateToMyInvitationDetail(
 fun NavGraphBuilder.myInvitationNavGraph(
     snackbarHostState: SnackbarHostState,
     onNavigateToCreate: () -> Unit,
-    onNavigateToDetail: (Long) -> Unit,
     onNavigateToLogin: () -> Unit,
+    onNavigateToEditInvitation: (Long) -> Unit,
+    onNavigateToEditCard: (Long) -> Unit,
+    onNavigateToCreateCard: (Long) -> Unit,
+    onNavigateToCreateThanksCard: (Long) -> Unit,
+    onNavigateToUpdateThanksCard: (Long) -> Unit,
 ) {
     composable<MyInvitation> {
         val viewModel: MyInvitationViewModel = hiltViewModel()
@@ -63,13 +68,15 @@ fun NavGraphBuilder.myInvitationNavGraph(
             }
         }
 
-        MyInvitationRoute(
-            viewModel = viewModel,
+        MyInvitationScreen(
             snackbarHostState = snackbarHostState,
             onNavigateToCreate = onNavigateToCreate,
-            onNavigateToDetail = onNavigateToDetail,
             onNavigateToLogin = onNavigateToLogin,
-            modifier = Modifier
+            onNavigateToEditInvitation = onNavigateToEditInvitation,
+            onNavigateToEditCard = onNavigateToEditCard,
+            onNavigateToCreateCard = onNavigateToCreateCard,
+            onNavigateToCreateThanksCard = onNavigateToCreateThanksCard,
+            onNavigateToUpdateThanksCard = onNavigateToUpdateThanksCard,
         )
     }
 }
@@ -83,40 +90,12 @@ fun NavGraphBuilder.myInvitationDetailNavGraph(
     onNavigateToCreateThanksCard: (Long) -> Unit,
     onNavigateToUpdateThanksCard: (Long) -> Unit,
 ) {
-    composable<MyInvitationDetail> { backStackEntry ->
-        val viewModel: MyInvitationDetailViewModel = hiltViewModel()
-        val cardCreated by backStackEntry.savedStateHandle.getStateFlow<Boolean>(
-            CREATE_CARD_BY_INVITATION_ID, false
-        ).collectAsStateWithLifecycle()
+    composable<MyInvitationDetail> { backStackEntry  ->
 
-        val cardUpdated by backStackEntry.savedStateHandle.getStateFlow<Boolean>(
-            UPDATE_CARD, false
-        ).collectAsStateWithLifecycle()
-
-        val invitationUpdated by backStackEntry.savedStateHandle.getStateFlow<Boolean>(
-            INVITATION_UPDATED, false
-        ).collectAsStateWithLifecycle()
-
-        val thanksCardCreated by backStackEntry.savedStateHandle.getStateFlow<Boolean>(
-            CREATE_THANKS_CARD, false
-        ).collectAsStateWithLifecycle()
-
-        val thanksCardUpdated by backStackEntry.savedStateHandle.getStateFlow<Boolean>(
-            UPDATE_CARD, false
-        ).collectAsStateWithLifecycle()
-
-
-        LaunchedEffect(cardCreated, cardUpdated, invitationUpdated, thanksCardCreated, thanksCardUpdated) {
-            if (cardCreated || cardUpdated || invitationUpdated || thanksCardCreated || thanksCardUpdated) {
-                viewModel.onEvent(MyInvitationDetailUiEvent.RetryLoad)
-                backStackEntry.savedStateHandle.remove<Boolean>(CREATE_CARD_BY_INVITATION_ID)
-                backStackEntry.savedStateHandle.remove<Boolean>(UPDATE_CARD)
-                backStackEntry.savedStateHandle.remove<Boolean>(INVITATION_UPDATED)
-                backStackEntry.savedStateHandle.remove<Boolean>(CREATE_THANKS_CARD)
-            }
-        }
+        val id = backStackEntry.toRoute<MyInvitationDetail>().id
 
         MyInvitationDetailRoute(
+            selectedId = id,
             onNavigateBack = onNavigateBack,
             onNavigateToLogin = onNavigateToLogin,
             onNavigateToEditInvitation = onNavigateToEditInvitation,
@@ -125,7 +104,16 @@ fun NavGraphBuilder.myInvitationDetailNavGraph(
             onNavigateToCreateThanksCard = onNavigateToCreateThanksCard,
             modifier = Modifier.padding(),
             onNavigateToUpdateThanksCard = onNavigateToUpdateThanksCard,
-            viewModel = viewModel
+            viewModel = hiltViewModel<MyInvitationDetailViewModel, MyInvitationDetailViewModel.Factory>(
+                key = "myDetail $id"
+            ) { factory ->
+                factory.create(id)
+            },
+            guestBookViewModel = hiltViewModel<MyInvitationGuestBookViewModel, MyInvitationGuestBookViewModel.Factory>(
+                key = "myguestBook $id"
+            ) { factory ->
+                factory.create(id)
+            },
         )
     }
 }

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/MyInvitationGraph.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/MyInvitationGraph.kt
@@ -14,8 +14,8 @@ import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
 import com.andlife.domain.util.RefreshEventHub
+import com.andlife.myinvitation.screen.MyInvitationListDetailRoute
 import com.andlife.myinvitation.screen.detail.MyInvitationDetailRoute
-import com.andlife.myinvitation.screen.MyInvitationScreen
 import com.andlife.myinvitation.viewmodel.MyInvitationDetailViewModel
 import com.andlife.myinvitation.viewmodel.MyInvitationGuestBookViewModel
 import com.andlife.myinvitation.viewmodel.MyInvitationViewModel
@@ -68,7 +68,7 @@ fun NavGraphBuilder.myInvitationNavGraph(
             }
         }
 
-        MyInvitationScreen(
+        MyInvitationListDetailRoute(
             snackbarHostState = snackbarHostState,
             onNavigateToCreate = onNavigateToCreate,
             onNavigateToLogin = onNavigateToLogin,

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationScreen.kt
@@ -1,5 +1,7 @@
 package com.andlife.myinvitation.screen
 
+import androidx.compose.animation.AnimatedContent
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -20,6 +22,18 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.adaptive.ExperimentalMaterial3AdaptiveApi
+import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo
+import androidx.compose.material3.adaptive.layout.AnimatedPane
+import androidx.compose.material3.adaptive.layout.ListDetailPaneScaffoldRole
+import androidx.compose.material3.adaptive.layout.PaneAdaptedValue
+import androidx.compose.material3.adaptive.navigation.BackNavigationBehavior
+import androidx.compose.material3.adaptive.navigation.NavigableListDetailPaneScaffold
+import androidx.compose.material3.adaptive.navigation.ThreePaneScaffoldNavigator
+import androidx.compose.material3.adaptive.navigation.ThreePaneScaffoldPredictiveBackHandler
+import androidx.compose.material3.adaptive.navigation.rememberListDetailPaneScaffoldNavigator
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldDefaults
+import androidx.compose.material3.adaptive.navigationsuite.NavigationSuiteScaffoldValue
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -48,9 +62,16 @@ import com.andlife.designsystem.theme.NachoTheme
 import com.andlife.domain.model.auth.AuthState
 import com.andlife.domain.model.invitation.SortDirection
 import com.andlife.model.invitation.InvitationSummaryUiModel
+import com.andlife.myinvitation.MyInvitationDetail
+import com.andlife.myinvitation.MyInvitationPlaceholder
 import com.andlife.myinvitation.model.MyInvitationSideEffect
 import com.andlife.myinvitation.model.MyInvitationUiEvent
 import com.andlife.myinvitation.model.MyInvitationUiState
+import com.andlife.myinvitation.screen.detail.MyInvitationDetailRoute
+import com.andlife.myinvitation.screen.detail.MyInvitationPlaceholderScreen
+import com.andlife.myinvitation.viewmodel.MyInvitation2PaneViewModel
+import com.andlife.myinvitation.viewmodel.MyInvitationDetailViewModel
+import com.andlife.myinvitation.viewmodel.MyInvitationGuestBookViewModel
 import com.andlife.myinvitation.viewmodel.MyInvitationViewModel
 import com.andlife.ui.R
 import com.andlife.ui.component.GenericTabRow
@@ -60,11 +81,153 @@ import com.andlife.ui.component.listitem.InvitationListItem
 import com.andlife.ui.component.listitem.MenuItem
 import com.andlife.ui.component.loading.InvitationLoadingIndicator
 import com.andlife.ui.component.paging.PagingStateContent
+import com.andlife.ui.util.DetailPaneViewModelScope
+import com.andlife.ui.util.LocalNavigationSuiteState
 import com.andlife.ui.util.collectWithLifecycle
+import com.andlife.ui.util.isNavigationBar
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.launch
 import com.andlife.designsystem.R as designR
+
+@Composable
+fun MyInvitationScreen(
+    snackbarHostState: SnackbarHostState,
+    onNavigateToLogin: () -> Unit,
+    onNavigateToCreate: () -> Unit,
+    onNavigateToEditInvitation: (Long) -> Unit,
+    onNavigateToEditCard: (Long) -> Unit,
+    onNavigateToCreateCard: (Long) -> Unit,
+    onNavigateToCreateThanksCard: (Long) -> Unit,
+    onNavigateToUpdateThanksCard: (Long) -> Unit,
+    viewModel: MyInvitation2PaneViewModel = hiltViewModel()
+) {
+    val uiState by viewModel.initialInvitationId.collectAsStateWithLifecycle()
+
+    MyInvitationScreen(
+        initialInvitationId = uiState,
+        snackbarHostState = snackbarHostState,
+        onNavigateToLogin = onNavigateToLogin,
+        onNavigateToCreate = onNavigateToCreate,
+        onNavigateToEditInvitation = onNavigateToEditInvitation,
+        onNavigateToEditCard = onNavigateToEditCard,
+        onNavigateToCreateCard = onNavigateToCreateCard,
+        onNavigateToCreateThanksCard = onNavigateToCreateThanksCard,
+        onNavigateToUpdateThanksCard = onNavigateToUpdateThanksCard,
+        onNavigateToDetail = viewModel::setInitialInvitationId,
+    )
+}
+
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+@Composable
+private fun MyInvitationScreen(
+    initialInvitationId: Long?,
+    snackbarHostState: SnackbarHostState,
+    onNavigateToDetail: (Long) -> Unit,
+    onNavigateToLogin: () -> Unit,
+    onNavigateToCreate: () -> Unit,
+    onNavigateToEditInvitation: (Long) -> Unit,
+    onNavigateToEditCard: (Long) -> Unit,
+    onNavigateToCreateCard: (Long) -> Unit,
+    onNavigateToCreateThanksCard: (Long) -> Unit,
+    onNavigateToUpdateThanksCard: (Long) -> Unit,
+    modifier: Modifier = Modifier
+) {
+
+    val suiteState = LocalNavigationSuiteState.current
+
+    val navSuiteType =
+        NavigationSuiteScaffoldDefaults.navigationSuiteType(currentWindowAdaptiveInfo())
+
+    val listDetailNavigator = rememberListDetailPaneScaffoldNavigator()
+    val coroutineScope = rememberCoroutineScope()
+
+    var myInvitationRoute by remember {
+        val route = initialInvitationId?.let { MyInvitationDetail(id = it) } ?: MyInvitationPlaceholder
+        mutableStateOf(route)
+    }
+
+    fun onInvitationClickShowDetailPane(id: Long) {
+        onNavigateToDetail(id)
+        myInvitationRoute = MyInvitationDetail(id)
+        coroutineScope.launch {
+            if (navSuiteType.isNavigationBar && suiteState.currentValue == NavigationSuiteScaffoldValue.Visible) suiteState.hide()
+            listDetailNavigator.navigateTo(ListDetailPaneScaffoldRole.Detail)
+        }
+    }
+
+    ThreePaneScaffoldPredictiveBackHandler(
+        listDetailNavigator,
+        BackNavigationBehavior.PopUntilScaffoldValueChange,
+    )
+
+    NavigableListDetailPaneScaffold(
+        navigator = listDetailNavigator,
+        listPane = {
+            AnimatedPane {
+                MyInvitationRoute(
+                    snackbarHostState = snackbarHostState,
+                    onNavigateToDetail = { onInvitationClickShowDetailPane(it) },
+                    onNavigateToLogin = onNavigateToLogin,
+                    onNavigateToCreate = onNavigateToCreate,
+                    selectedInvitationId = initialInvitationId,
+                    shouldHighlightSelected = listDetailNavigator.isDetailPaneVisible(),
+                )
+            }
+        },
+        detailPane = {
+            AnimatedPane {
+                AnimatedContent(myInvitationRoute) { route ->
+                    when (route) {
+                        is MyInvitationDetail -> {
+                            DetailPaneViewModelScope {
+                                MyInvitationDetailRoute(
+                                    selectedId = route.id,
+                                    onNavigateBack = {
+                                        coroutineScope.launch {
+                                            if (navSuiteType.isNavigationBar && suiteState.currentValue == NavigationSuiteScaffoldValue.Hidden) suiteState.show()
+                                            listDetailNavigator.navigateBack()
+                                        }
+                                    },
+                                    onNavigateToLogin = onNavigateToLogin,
+                                    onNavigateToEditCard = onNavigateToEditCard,
+                                    onNavigateToEditInvitation = onNavigateToEditInvitation,
+                                    onNavigateToCreateCard = onNavigateToCreateCard,
+                                    onNavigateToCreateThanksCard = onNavigateToCreateThanksCard,
+                                    onNavigateToUpdateThanksCard = onNavigateToUpdateThanksCard,
+                                    showBackButton = !listDetailNavigator.isListPaneVisible(),
+                                    viewModel = hiltViewModel<MyInvitationDetailViewModel, MyInvitationDetailViewModel.Factory>(
+                                        key = "myDetail ${route.id}"
+                                    ) { factory ->
+                                        factory.create(route.id)
+                                    },
+                                    guestBookViewModel = hiltViewModel<MyInvitationGuestBookViewModel, MyInvitationGuestBookViewModel.Factory>(
+                                        key = "myDetail guestBook ${route.id}"
+                                    ) { factory ->
+                                        factory.create(route.id)
+                                    }
+                                )
+                            }
+                        }
+
+                        MyInvitationPlaceholder -> {
+                            MyInvitationPlaceholderScreen()
+                        }
+                    }
+                }
+            }
+        },
+        modifier = modifier.background(NachoTheme.colorScheme.backgroundPrimary),
+    )
+}
+
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+private fun <T> ThreePaneScaffoldNavigator<T>.isListPaneVisible(): Boolean =
+    scaffoldValue[ListDetailPaneScaffoldRole.List] == PaneAdaptedValue.Expanded
+
+@OptIn(ExperimentalMaterial3AdaptiveApi::class)
+private fun <T> ThreePaneScaffoldNavigator<T>.isDetailPaneVisible(): Boolean =
+    scaffoldValue[ListDetailPaneScaffoldRole.Detail] == PaneAdaptedValue.Expanded
 
 @Composable
 fun MyInvitationRoute(
@@ -72,6 +235,8 @@ fun MyInvitationRoute(
     onNavigateToCreate: () -> Unit,
     onNavigateToDetail: (Long) -> Unit,
     onNavigateToLogin: () -> Unit,
+    selectedInvitationId: Long? = null,
+    shouldHighlightSelected: Boolean = false,
     modifier: Modifier = Modifier,
     viewModel: MyInvitationViewModel = hiltViewModel(),
 ) {
@@ -196,7 +361,9 @@ fun MyInvitationRoute(
         pastItems = pastItems,
         modifier = modifier,
         onEvent = viewModel::onEvent,
-        onDeleteClick = { invitationIdToDelete = it }
+        onDeleteClick = { invitationIdToDelete = it },
+        selectedInvitationId = selectedInvitationId,
+        shouldHighlightSelected = shouldHighlightSelected,
     )
 }
 
@@ -209,6 +376,8 @@ private fun MyInvitationScreen(
     pastItems: LazyPagingItems<InvitationSummaryUiModel>,
     onEvent: (MyInvitationUiEvent) -> Unit,
     onDeleteClick: (Long) -> Unit,
+    selectedInvitationId: Long? = null,
+    shouldHighlightSelected: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
     val tabs = stringArrayResource(R.array.arr_invitation_tabs).toImmutableList()
@@ -312,6 +481,8 @@ private fun MyInvitationScreen(
                                         key = currentItems.itemKey { it.id }
                                     ) { index ->
                                         currentItems[index]?.let { invitation ->
+                                            val isSelected =
+                                                shouldHighlightSelected && invitation.id == selectedInvitationId
                                             val dDayLabel = when (val count = invitation.dDayCount) {
                                                 null -> null
                                                 0 -> stringResource(R.string.format_invitation_d_day_today)
@@ -331,7 +502,8 @@ private fun MyInvitationScreen(
                                                         title = stringResource(R.string.txt_delete_invitation_title),
                                                         onClick = { onDeleteClick(invitation.id) }
                                                     )
-                                                )
+                                                ),
+                                                isSelected = isSelected
                                             )
                                         }
                                     }

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/MyInvitationScreen.kt
@@ -91,7 +91,7 @@ import kotlinx.coroutines.launch
 import com.andlife.designsystem.R as designR
 
 @Composable
-fun MyInvitationScreen(
+fun MyInvitationListDetailRoute(
     snackbarHostState: SnackbarHostState,
     onNavigateToLogin: () -> Unit,
     onNavigateToCreate: () -> Unit,
@@ -104,7 +104,7 @@ fun MyInvitationScreen(
 ) {
     val uiState by viewModel.initialInvitationId.collectAsStateWithLifecycle()
 
-    MyInvitationScreen(
+    MyInvitationListDetailScreen(
         initialInvitationId = uiState,
         snackbarHostState = snackbarHostState,
         onNavigateToLogin = onNavigateToLogin,
@@ -120,7 +120,7 @@ fun MyInvitationScreen(
 
 @OptIn(ExperimentalMaterial3AdaptiveApi::class)
 @Composable
-private fun MyInvitationScreen(
+private fun MyInvitationListDetailScreen(
     initialInvitationId: Long?,
     snackbarHostState: SnackbarHostState,
     onNavigateToDetail: (Long) -> Unit,
@@ -354,7 +354,7 @@ fun MyInvitationRoute(
         }
     }
 
-    MyInvitationScreen(
+    MyInvitationListPaneRoute(
         uiState = uiState,
         authState = authState,
         upcomingItems = upcomingItems,
@@ -369,7 +369,7 @@ fun MyInvitationRoute(
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-private fun MyInvitationScreen(
+private fun MyInvitationListPaneRoute(
     uiState: MyInvitationUiState,
     authState: AuthState,
     upcomingItems: LazyPagingItems<InvitationSummaryUiModel>,

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/detail/MyInvitationContentsScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/detail/MyInvitationContentsScreen.kt
@@ -1,4 +1,4 @@
-package com.andlife.myinvitation.screen
+package com.andlife.myinvitation.screen.detail
 
 import android.text.Editable
 import android.view.ViewGroup

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/detail/MyInvitationDetailScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/detail/MyInvitationDetailScreen.kt
@@ -1,4 +1,4 @@
-package com.andlife.myinvitation.screen
+package com.andlife.myinvitation.screen.detail
 
 import android.text.Editable
 import android.view.ViewGroup
@@ -27,6 +27,7 @@ import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -52,6 +53,7 @@ import com.andlife.designsystem.component.dialog.NachoDialog
 import com.andlife.designsystem.preview.PreviewTheme
 import com.andlife.designsystem.theme.NachoSpacing
 import com.andlife.designsystem.theme.NachoTheme
+import com.andlife.domain.util.RefreshEventHub
 import com.andlife.editor.screen.NachoTextView
 import com.andlife.model.invitation.DateTimeInfo
 import com.andlife.model.invitation.HostInfo
@@ -66,6 +68,7 @@ import com.andlife.myinvitation.model.detail.MyInvitationDetailUiEvent
 import com.andlife.myinvitation.model.detail.MyInvitationDetailUiState
 import com.andlife.myinvitation.screen.collection.MyInvitationCollectionRoute
 import com.andlife.myinvitation.screen.guestbook.MyInvitationGuestBookRoute
+import com.andlife.myinvitation.viewmodel.MyInvitationCollectionViewModel
 import com.andlife.myinvitation.viewmodel.MyInvitationDetailViewModel
 import com.andlife.myinvitation.viewmodel.MyInvitationGuestBookViewModel
 import com.andlife.ui.component.GenericTabRow
@@ -84,6 +87,7 @@ import com.andlife.designsystem.R as designR
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun MyInvitationDetailRoute(
+    selectedId: Long,
     onNavigateBack: () -> Unit,
     onNavigateToLogin: () -> Unit,
     onNavigateToEditInvitation: (Long) -> Unit,
@@ -92,6 +96,7 @@ fun MyInvitationDetailRoute(
     onNavigateToCreateThanksCard: (Long) -> Unit,
     onNavigateToUpdateThanksCard: (Long) -> Unit,
     modifier: Modifier = Modifier,
+    showBackButton: Boolean = false,
     viewModel: MyInvitationDetailViewModel = hiltViewModel(),
     guestBookViewModel: MyInvitationGuestBookViewModel = hiltViewModel(),
 ) {
@@ -191,6 +196,8 @@ fun MyInvitationDetailRoute(
     Box {
         MyInvitationDetailScreen(
             uiState = uiState,
+            guestBookViewModel = guestBookViewModel,
+            selectedId = selectedId,
             isGuestBookUploading = isGuestBookUploading,
             snackbarHostState = snackbarHostState,
             scrollBehavior = scrollBehavior,
@@ -204,6 +211,7 @@ fun MyInvitationDetailRoute(
                     viewModel.onEvent(MyInvitationDetailUiEvent.ClickUpdateThanksCard(id))
                 }
             },
+            showBackButton = showBackButton,
             modifier = modifier,
         )
 
@@ -267,7 +275,7 @@ fun MyInvitationDetailRoute(
             onConfirm = {
                 viewModel.onEvent(MyInvitationDetailUiEvent.ClickDeleteThanksCard)
                 isDeleteThanksCardVisible = false
-            }
+            },
         )
     }
 }
@@ -276,6 +284,8 @@ fun MyInvitationDetailRoute(
 @Composable
 private fun MyInvitationDetailScreen(
     uiState: MyInvitationDetailUiState,
+    selectedId: Long,
+    guestBookViewModel: MyInvitationGuestBookViewModel,
     isGuestBookUploading: Boolean,
     snackbarHostState: SnackbarHostState,
     scrollBehavior: TopAppBarScrollBehavior,
@@ -285,6 +295,7 @@ private fun MyInvitationDetailScreen(
     onNavigateToLogin: () -> Unit,
     onEditThanksCard: () -> Unit,
     onDeleteThanksCard: () -> Unit,
+    showBackButton: Boolean = false,
     modifier: Modifier = Modifier,
 ) {
     val tabTitles = stringArrayResource(R.array.txt_tap_title).toImmutableList()
@@ -319,6 +330,7 @@ private fun MyInvitationDetailScreen(
                 hasThanksCard = uiState.hasThanksCard,
                 showActions = !uiState.isLoading && !uiState.isError,
                 onBack = navigateBackWithCleanup,
+                showBackButton = showBackButton,
                 onClickThanksCard = { onEvent(MyInvitationDetailUiEvent.ClickThanksCard) },
                 onEditThanksCard = { onEditThanksCard() },
                 onDeleteThanksCard = onDeleteThanksCard,
@@ -384,9 +396,16 @@ private fun MyInvitationDetailScreen(
                             1 -> MyInvitationGuestBookRoute(
                                 onNavigateBack = onNavigateBack,
                                 onNavigateToLogin = onNavigateToLogin,
+                                viewModel = guestBookViewModel
                             )
 
-                            2 -> MyInvitationCollectionRoute()
+                            2 -> MyInvitationCollectionRoute(
+                                viewModel = hiltViewModel<MyInvitationCollectionViewModel, MyInvitationCollectionViewModel.Factory>(
+                                    key = "collection $selectedId"
+                                ) { factory ->
+                                    factory.create(selectedId)
+                                }
+                            )
                         }
                     },
             )
@@ -423,6 +442,7 @@ private fun MyInvitationDetailTopBar(
     onDelete: () -> Unit,
     onCreateThanksCard: () -> Unit,
     modifier: Modifier = Modifier,
+    showBackButton: Boolean = false,
     showActions: Boolean = true,
     hasThanksCard: Boolean = false,
 ) {
@@ -440,12 +460,14 @@ private fun MyInvitationDetailTopBar(
             )
         },
         navigationIcon = {
-            IconButton(onClick = onBack) {
-                Icon(
-                    painter = painterResource(designR.drawable.ic_arrow_back_24),
-                    contentDescription = stringResource(R.string.desc_top_bar_back),
-                    tint = NachoTheme.colorScheme.iconSecondary,
-                )
+            if (showBackButton) {
+                IconButton(onClick = onBack) {
+                    Icon(
+                        painter = painterResource(designR.drawable.ic_arrow_back_24),
+                        contentDescription = stringResource(R.string.desc_top_bar_back),
+                        tint = NachoTheme.colorScheme.iconSecondary,
+                    )
+                }
             }
         },
         actions = {
@@ -684,6 +706,8 @@ private fun InvitationMoreMenu(
 private fun MyInvitationDetailScreenPreview() {
     NachoTheme {
         MyInvitationDetailScreen(
+            selectedId = 1L,
+            guestBookViewModel = hiltViewModel(),
             isGuestBookUploading = false,
             uiState =
                 MyInvitationDetailUiState(

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/detail/MyInvitationPlaceHolder.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/detail/MyInvitationPlaceHolder.kt
@@ -1,0 +1,46 @@
+package com.andlife.myinvitation.screen.detail
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import com.andlife.designsystem.R
+import com.andlife.designsystem.theme.NachoSpacing
+import com.andlife.designsystem.theme.NachoTheme
+
+@Composable
+fun MyInvitationPlaceholderScreen(
+    modifier: Modifier = Modifier
+) {
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(NachoTheme.colorScheme.backgroundPrimary),
+        contentAlignment = Alignment.Center
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center
+        ) {
+            Image(
+                painter = painterResource(R.drawable.ic_home_logo),
+                contentDescription = null
+            )
+            Spacer(modifier = Modifier.height(NachoSpacing.medium))
+            Text(
+                text = stringResource(R.string.txt_select_my_invitation),
+                style = NachoTheme.typography.headingMedium
+            )
+        }
+    }
+}

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitation2PaneViewModel.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitation2PaneViewModel.kt
@@ -1,0 +1,26 @@
+package com.andlife.myinvitation.viewmodel
+
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.ViewModel
+import androidx.navigation.toRoute
+import com.andlife.myinvitation.MyInvitation
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+private const val MY_INVITATION_ID = "my_invitation_id"
+
+@HiltViewModel
+class MyInvitation2PaneViewModel @Inject constructor(
+    private val savedStateHandle: SavedStateHandle
+): ViewModel() {
+    private val route = savedStateHandle.toRoute<MyInvitation>()
+
+    val initialInvitationId = savedStateHandle.getStateFlow(
+        key = MY_INVITATION_ID,
+        initialValue = route.initialInvitationId
+    )
+
+    fun setInitialInvitationId(id: Long) {
+        savedStateHandle[MY_INVITATION_ID] = id
+    }
+}

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationCollectionViewModel.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationCollectionViewModel.kt
@@ -25,6 +25,9 @@ import com.andlife.myinvitation.model.collection.MyInvitationCollectionUiEvent
 import com.andlife.myinvitation.model.collection.MyInvitationCollectionUiState
 import com.andlife.media.StoryMediaPlayerPool
 import com.andlife.ui.base.BaseViewModel
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.collections.immutable.toImmutableList
@@ -35,8 +38,8 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@HiltViewModel
-class MyInvitationCollectionViewModel @Inject constructor(
+@HiltViewModel(assistedFactory = MyInvitationCollectionViewModel.Factory::class)
+class MyInvitationCollectionViewModel @AssistedInject constructor(
     private val guestBookRepository: GuestBookRepository,
     private val mediaDownloader: MediaDownloader,
     private val userRepository: UserRepository,
@@ -44,12 +47,11 @@ class MyInvitationCollectionViewModel @Inject constructor(
     private val analyticsLogger: AnalyticsLogger,
     private val crashlyticsLogger: CrashlyticsLogger,
     @param:ApplicationContext private val context: Context,
+    @Assisted private val invitationId: Long,
     savedStateHandle: SavedStateHandle
 ) : BaseViewModel<MyInvitationCollectionUiState, MyInvitationCollectionUiEvent, MyInvitationCollectionSideEffect>(
     initialState = MyInvitationCollectionUiState(),
 ) {
-    private val invitationId: Long = savedStateHandle.toRoute<MyInvitationDetail>().id
-
     override val uiState: StateFlow<MyInvitationCollectionUiState> =
         mutableUiState
             .onStart {
@@ -232,5 +234,13 @@ class MyInvitationCollectionViewModel @Inject constructor(
 
     companion object {
         private const val FILE_NAME_PREFIX = "nacho_"
+    }
+
+
+    @AssistedFactory
+    interface Factory {
+        fun create(
+            myInvitationId: Long,
+        ): MyInvitationCollectionViewModel
     }
 }

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationDetailViewModel.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationDetailViewModel.kt
@@ -29,6 +29,9 @@ import com.andlife.myinvitation.model.detail.MyInvitationDetailUiEvent
 import com.andlife.myinvitation.model.detail.MyInvitationDetailUiState
 import com.andlife.ui.base.BaseViewModel
 import com.andlife.ui.util.toDateTimeSingleLine
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.flow.SharingStarted
@@ -38,8 +41,8 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@HiltViewModel
-class MyInvitationDetailViewModel @Inject constructor(
+@HiltViewModel(assistedFactory = MyInvitationDetailViewModel.Factory::class)
+class MyInvitationDetailViewModel @AssistedInject constructor(
     savedStateHandle: SavedStateHandle,
     private val kakaoShareManager: KakaoShareManager,
     private val invitationRepository: InvitationRepository,
@@ -47,13 +50,11 @@ class MyInvitationDetailViewModel @Inject constructor(
     private val deepLinkManager: DeepLinkManager,
     private val clipboardManager: ClipboardManager,
     private val thanksCardRepository: ThanksCardRepository,
-    private val analyticsLogger: AnalyticsLogger
+    private val analyticsLogger: AnalyticsLogger,
+    @Assisted private val myInvitationId: Long,
 ) : BaseViewModel<MyInvitationDetailUiState, MyInvitationDetailUiEvent, MyInvitationDetailSideEffect>(
     initialState = MyInvitationDetailUiState(),
 ) {
-
-    private val myInvitationId: Long = savedStateHandle.toRoute<MyInvitationDetail>().id
-
     override val uiState: StateFlow<MyInvitationDetailUiState> =
         mutableUiState
             .onStart {
@@ -272,5 +273,12 @@ class MyInvitationDetailViewModel @Inject constructor(
 
     companion object {
         private const val CLIP_LABEL_INVITATION = "invitation_link"
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(
+            myInvitationId: Long,
+        ): MyInvitationDetailViewModel
     }
 }

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationGuestBookViewModel.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/viewmodel/MyInvitationGuestBookViewModel.kt
@@ -44,6 +44,9 @@ import com.andlife.myinvitation.model.guestbook.MyInvitationGuestBookUiEvent
 import com.andlife.myinvitation.model.guestbook.MyInvitationGuestBookUiState
 import com.andlife.ui.base.BaseViewModel
 import com.andlife.ui.component.invitation.SelectedMedia
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedFactory
+import dagger.assisted.AssistedInject
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toPersistentList
@@ -59,10 +62,8 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
-@HiltViewModel
-class MyInvitationGuestBookViewModel
-@Inject
-constructor(
+@HiltViewModel(assistedFactory = MyInvitationGuestBookViewModel.Factory::class)
+class MyInvitationGuestBookViewModel @AssistedInject constructor(
     private val mediaUploader: MediaUploader,
     private val mediaFileProvider: MediaFileProvider,
     private val thumbnailGenerator: ThumbnailGenerator,
@@ -73,12 +74,11 @@ constructor(
     val videoPlayerPool: AutoVideoPlayerPool,
     private val analyticsLogger: AnalyticsLogger,
     private val crashlyticsLogger: CrashlyticsLogger,
+    @Assisted private val invitationId: Long,
     savedStateHandle: SavedStateHandle,
 ) : BaseViewModel<MyInvitationGuestBookUiState, MyInvitationGuestBookUiEvent, MyInvitationGuestBookSideEffect>(
     MyInvitationGuestBookUiState(),
 ) {
-    private val invitationId: Long = savedStateHandle.toRoute<MyInvitationDetail>().id
-
     override val uiState: StateFlow<MyInvitationGuestBookUiState> = mutableUiState.asStateFlow()
 
     private val refreshFlow = MutableStateFlow(0)
@@ -101,9 +101,9 @@ constructor(
         authStateManager.authState
             .onEach { authState ->
                 val isStateChanged = uiState.value.isAuthStateChanged(authState)
-                updateState { copy( authState = authState ) }
+                updateState { copy(authState = authState) }
                 if (isStateChanged) {
-                    sendEffect(MyInvitationGuestBookSideEffect.AuthStateChanged(authState) )
+                    sendEffect(MyInvitationGuestBookSideEffect.AuthStateChanged(authState))
                 }
             }
             .launchIn(viewModelScope)
@@ -130,9 +130,15 @@ constructor(
             is MyInvitationGuestBookUiEvent.UpdateTextContent -> updateTextContent(event.textContent)
             is MyInvitationGuestBookUiEvent.RemoveMedia -> removeMedia(event.media)
             is MyInvitationGuestBookUiEvent.UploadMedias -> {
-                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.MY_INVITATION_DETAIL_GUEST_BOOK, Button.UPLOAD_GUEST_BOOK))
+                analyticsLogger.logEvent(
+                    AnalyticsEvent.ButtonClick(
+                        Screen.MY_INVITATION_DETAIL_GUEST_BOOK,
+                        Button.UPLOAD_GUEST_BOOK
+                    )
+                )
                 handleUploadMedias()
             }
+
             is MyInvitationGuestBookUiEvent.ClickCamera -> handleCameraClick()
             is MyInvitationGuestBookUiEvent.ClickMicrophone -> handleMicrophoneClick()
             is MyInvitationGuestBookUiEvent.ClearError -> clearError()
@@ -140,14 +146,26 @@ constructor(
             is MyInvitationGuestBookUiEvent.ClickVideoPlayButton -> clickVideoPlayButton(event.url, event.itemId)
             is MyInvitationGuestBookUiEvent.ClickVisualMedia -> {}
             is MyInvitationGuestBookUiEvent.ClickEditMenu -> {
-                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.MY_INVITATION_DETAIL_GUEST_BOOK, Button.UPDATE_GUEST_BOOK))
+                analyticsLogger.logEvent(
+                    AnalyticsEvent.ButtonClick(
+                        Screen.MY_INVITATION_DETAIL_GUEST_BOOK,
+                        Button.UPDATE_GUEST_BOOK
+                    )
+                )
                 startEditing(event.guestBook)
             }
+
             is MyInvitationGuestBookUiEvent.CancelEdit -> cancelEdit()
             is MyInvitationGuestBookUiEvent.ClickDeleteMenu -> {
-                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.MY_INVITATION_DETAIL_GUEST_BOOK, Button.DELETE_GUEST_BOOK))
+                analyticsLogger.logEvent(
+                    AnalyticsEvent.ButtonClick(
+                        Screen.MY_INVITATION_DETAIL_GUEST_BOOK,
+                        Button.DELETE_GUEST_BOOK
+                    )
+                )
                 deleteGuestBook(event.guestBookId)
             }
+
             is MyInvitationGuestBookUiEvent.UpdateMediaPlayState -> updatePlayState(event.isPlaying)
             MyInvitationGuestBookUiEvent.Refresh -> refresh()
             MyInvitationGuestBookUiEvent.CheckLogin -> checkLogin()
@@ -155,7 +173,12 @@ constructor(
             is MyInvitationGuestBookUiEvent.ShowReport -> updateReportTargetId(event.guestBookId)
             MyInvitationGuestBookUiEvent.DismissReport -> updateReportTargetId(null)
             is MyInvitationGuestBookUiEvent.SubmitReport -> {
-                analyticsLogger.logEvent(AnalyticsEvent.ButtonClick(Screen.MY_INVITATION_DETAIL_GUEST_BOOK, Button.INVITATION_REPORT))
+                analyticsLogger.logEvent(
+                    AnalyticsEvent.ButtonClick(
+                        Screen.MY_INVITATION_DETAIL_GUEST_BOOK,
+                        Button.INVITATION_REPORT
+                    )
+                )
                 submitReport(event.reason, event.description)
             }
         }
@@ -585,5 +608,12 @@ constructor(
                 sendEffect(MyInvitationGuestBookSideEffect.ReportFailure(messageToShow))
             }
         }
+    }
+
+    @AssistedFactory
+    interface Factory {
+        fun create(
+            myInvitationId: Long,
+        ): MyInvitationGuestBookViewModel
     }
 }


### PR DESCRIPTION
## 🔍 변경 사항
- 초대 탭 변경사항과 동일합니다.
- DetailViewModel의 .onStart로 수정, 카드 수정 화면 집입 후 돌아왔을 시 데이터 reload 구조이기 때문에 기존 코드 삭제
```kotlin
// 기존 backStackEntry의 savedStateHandel의 KEY로 전달하여 데이터를 refresh하던 코드 삭제
val viewModel: MyInvitationDetailViewModel = hiltViewModel()
        val cardCreated by backStackEntry.savedStateHandle.getStateFlow<Boolean>(
            CREATE_CARD_BY_INVITATION_ID, false
        ).collectAsStateWithLifecycle()

        val cardUpdated by backStackEntry.savedStateHandle.getStateFlow<Boolean>(
            UPDATE_CARD, false
        ).collectAsStateWithLifecycle()

        val invitationUpdated by backStackEntry.savedStateHandle.getStateFlow<Boolean>(
            INVITATION_UPDATED, false
        ).collectAsStateWithLifecycle()

        val thanksCardCreated by backStackEntry.savedStateHandle.getStateFlow<Boolean>(
            CREATE_THANKS_CARD, false
        ).collectAsStateWithLifecycle()

        val thanksCardUpdated by backStackEntry.savedStateHandle.getStateFlow<Boolean>(
            UPDATE_CARD, false
        ).collectAsStateWithLifecycle()
```

## 📸 스크린샷 (선택)
[Screen_recording_20260316_151517.webm](https://github.com/user-attachments/assets/0e2f841c-d538-4bb0-92bd-10c5a1f9387a)

## 🔗 관련 이슈
- Close #214

## ✅ 체크리스트
- [x] 팀 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 import는 삭제했나요?
