### PR TITLE
Feature/#230 방명록 데이터가 등록되거나 감사카드가 작성되었을 때 푸시 전송

### DIFF
--- a/android/app/src/main/kotlin/com/andlife/nacho/viewmodel/MainViewModel.kt
+++ b/android/app/src/main/kotlin/com/andlife/nacho/viewmodel/MainViewModel.kt
@@ -97,6 +97,7 @@ class MainViewModel @Inject constructor(
                         AuthState.Loading -> {
                             updateState { copy(isSplash = false, startDestination = Login::class) }
                         }
+
                         else -> {
                             updateState { copy(isSplash = false, startDestination = Home::class) }
                         }
@@ -109,12 +110,7 @@ class MainViewModel @Inject constructor(
     }
 
     fun handleDeepLink(intent: Intent?) {
-        Log.d("DeepLink Debug", "handleDeepLink: ${intent?.data}")
-        val data = intent?.data ?: return
-
-        val inviteId = data.getQueryParameter(DeepLinkConfig.KAKAO_PARAM_INVITE_ID)
-            ?: data.getQueryParameter(DeepLinkConfig.AF_DEEP_LINK_SUB1)
-
+        val inviteId = extractInviteId(intent)
         if (inviteId != null) {
             viewModelScope.launch {
                 if (inviteId != lastProcessedId) {
@@ -122,5 +118,23 @@ class MainViewModel @Inject constructor(
                 }
             }
         }
+    }
+
+    private fun extractInviteId(intent: Intent?): String? {
+        // URI에서 추출 (카카오, AppsFlyer)
+        intent?.data?.let { data ->
+            val inviteId = data.getQueryParameter(DeepLinkConfig.KAKAO_PARAM_INVITE_ID)
+                ?: data.getQueryParameter(DeepLinkConfig.AF_DEEP_LINK_SUB1)
+            if (inviteId != null) {
+                return inviteId
+            }
+        }
+
+        // Intent extras에서 추출 (FCM)
+        intent?.getStringExtra("invitation_id")?.let { inviteId ->
+            return inviteId
+        }
+
+        return null
     }
 }

--- a/android/app/src/main/kotlin/com/andlife/nacho/viewmodel/MainViewModel.kt
+++ b/android/app/src/main/kotlin/com/andlife/nacho/viewmodel/MainViewModel.kt
@@ -3,6 +3,7 @@ package com.andlife.nacho.viewmodel
 import android.content.Intent
 import android.util.Log
 import androidx.lifecycle.viewModelScope
+import com.andlife.fcm.NachoFirebaseMessagingService.Companion.INVITATION_ID_KEY
 import com.andlife.deeplink.DeepLinkConfig
 import com.andlife.deeplink.DeepLinkManager
 import com.andlife.domain.model.auth.AuthEvent
@@ -131,7 +132,7 @@ class MainViewModel @Inject constructor(
         }
 
         // Intent extras에서 추출 (FCM)
-        intent?.getStringExtra("invitation_id")?.let { inviteId ->
+        intent?.getStringExtra(INVITATION_ID_KEY)?.let { inviteId ->
             return inviteId
         }
 

--- a/android/core/fcm/src/main/kotlin/com/andlife/fcm/NachoFirebaseMessagingService.kt
+++ b/android/core/fcm/src/main/kotlin/com/andlife/fcm/NachoFirebaseMessagingService.kt
@@ -24,6 +24,7 @@ class NachoFirebaseMessagingService : FirebaseMessagingService() {
         private const val TAG = "NachoFirebaseMessagingService"
         private const val CHANNEL_ID = "fcm_notification_channel"
         private const val CHANNEL_NAME = "FCM 알림"
+        const val INVITATION_ID_KEY = "invitation_id"
     }
 
     // 토큰이 클라우드 서버로 등록되었을 때 호출되는 콜백
@@ -60,7 +61,7 @@ class NachoFirebaseMessagingService : FirebaseMessagingService() {
 
         val intent = packageManager.getLaunchIntentForPackage(packageName)?.apply {
             flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
-            data["invitation_id"]?.let { putExtra("invitation_id", it) }
+            data[INVITATION_ID_KEY]?.let { putExtra(INVITATION_ID_KEY, it) }
             data.forEach { (key, value) ->
                 putExtra("fcm_$key", value)
             }

--- a/android/core/fcm/src/main/kotlin/com/andlife/fcm/NachoFirebaseMessagingService.kt
+++ b/android/core/fcm/src/main/kotlin/com/andlife/fcm/NachoFirebaseMessagingService.kt
@@ -79,6 +79,10 @@ class NachoFirebaseMessagingService : FirebaseMessagingService() {
             .setSmallIcon(android.R.drawable.ic_dialog_info) // TODO: 앱 아이콘으로 변경
             .setContentTitle(title)
             .setContentText(body)
+            .setStyle(
+                NotificationCompat.BigTextStyle()
+                    .bigText(body)
+            )
             .setAutoCancel(true)
             .setPriority(NotificationCompat.PRIORITY_DEFAULT)
             .setContentIntent(pendingIntent)

--- a/android/core/fcm/src/main/kotlin/com/andlife/fcm/NachoFirebaseMessagingService.kt
+++ b/android/core/fcm/src/main/kotlin/com/andlife/fcm/NachoFirebaseMessagingService.kt
@@ -38,22 +38,15 @@ class NachoFirebaseMessagingService : FirebaseMessagingService() {
         super.onMessageReceived(remoteMessage)
         Log.d(TAG, "Message data payload: ${remoteMessage.data}")
         Log.d(TAG, "Message notification payload: ${remoteMessage.notification}")
-        if (remoteMessage.data.isNotEmpty()) {
-            sendNotification(
-                remoteMessage.data["title"].toString(),
-                remoteMessage.data["body"].toString()
-            )
-        } else {
-            remoteMessage.notification?.let {
-                sendNotification(
-                    remoteMessage.notification!!.title.toString(),
-                    remoteMessage.notification!!.body.toString()
-                )
-            }
-        }
+
+        val title = remoteMessage.notification?.title ?: remoteMessage.data["title"] ?: ""
+        val body = remoteMessage.notification?.body ?: remoteMessage.data["body"] ?: ""
+
+        sendNotification(title, body, remoteMessage.data)
     }
 
-    private fun sendNotification(title: String, body: String) {
+    // TODO
+    private fun sendNotification(title: String, body: String, data: Map<String, String> = emptyMap()) {
         val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -66,7 +59,11 @@ class NachoFirebaseMessagingService : FirebaseMessagingService() {
         }
 
         val intent = packageManager.getLaunchIntentForPackage(packageName)?.apply {
-            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TOP
+            data["invitation_id"]?.let { putExtra("invitation_id", it) }
+            data.forEach { (key, value) ->
+                putExtra("fcm_$key", value)
+            }
         }
 
         val pendingIntent = PendingIntent.getActivity(

--- a/android/core/fcm/src/main/kotlin/com/andlife/fcm/NachoFirebaseMessagingService.kt
+++ b/android/core/fcm/src/main/kotlin/com/andlife/fcm/NachoFirebaseMessagingService.kt
@@ -17,6 +17,8 @@ import javax.inject.Inject
 @AndroidEntryPoint
 class NachoFirebaseMessagingService : FirebaseMessagingService() {
 
+    // TODO: app 모듈로 이동
+
     @Inject
     lateinit var fcmTokenManager: FcmTokenManager
 
@@ -46,7 +48,6 @@ class NachoFirebaseMessagingService : FirebaseMessagingService() {
         sendNotification(title, body, remoteMessage.data)
     }
 
-    // TODO
     private fun sendNotification(title: String, body: String, data: Map<String, String> = emptyMap()) {
         val notificationManager = getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
 

--- a/android/core/fcm/src/main/kotlin/com/andlife/fcm/NachoFirebaseMessagingService.kt
+++ b/android/core/fcm/src/main/kotlin/com/andlife/fcm/NachoFirebaseMessagingService.kt
@@ -76,7 +76,7 @@ class NachoFirebaseMessagingService : FirebaseMessagingService() {
         )
 
         val notification = NotificationCompat.Builder(this, CHANNEL_ID)
-            .setSmallIcon(android.R.drawable.ic_dialog_info)
+            .setSmallIcon(android.R.drawable.ic_dialog_info) // TODO: 앱 아이콘으로 변경
             .setContentTitle(title)
             .setContentText(body)
             .setAutoCancel(true)

--- a/backend/src/main/kotlin/com/andlife/nachoserver/constant/FcmConstants.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/constant/FcmConstants.kt
@@ -1,0 +1,8 @@
+package com.andlife.nachoserver.constant
+
+// FCM data payload key 모음
+object FcmConstants {
+
+    // 서버 -> 앱으로 초대장 id 전달 (앱에서 해당 id로 navigation)
+    const val INVITATION_ID_KEY = "invitation_id"
+}

--- a/backend/src/main/kotlin/com/andlife/nachoserver/repository/participant/InvitationParticipantRepository.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/repository/participant/InvitationParticipantRepository.kt
@@ -83,4 +83,7 @@ interface InvitationParticipantRepository : JpaRepository<InvitationParticipant,
     @Transactional
     @Query("DELETE FROM InvitationParticipant p WHERE p.user.id = :userId")
     fun deleteAllByUserId(@Param("userId") userId: Long)
+
+    @Query("SELECT p FROM InvitationParticipant p JOIN FETCH p.user WHERE p.invitation.id = :invitationId")
+    fun findAllByInvitationIdWithUser(@Param("invitationId") invitationId: Long): List<InvitationParticipant>
 }

--- a/backend/src/main/kotlin/com/andlife/nachoserver/service/guestbook/GuestBookService.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/service/guestbook/GuestBookService.kt
@@ -3,6 +3,7 @@ package com.andlife.nachoserver.service.guestbook
 import com.andlife.nachoserver.auth.AuthContext
 import com.andlife.nachoserver.constant.MediaType
 import com.andlife.nachoserver.entity.*
+import com.andlife.nachoserver.constant.FcmConstants.INVITATION_ID_KEY
 import com.andlife.nachoserver.error.BusinessException
 import com.andlife.nachoserver.repository.invitation.InvitationRepository
 import com.andlife.nachoserver.repository.guestbook.GuestBookRepository
@@ -471,7 +472,7 @@ class GuestBookService(
     private fun sendGuestBookNotificationToParticipants(guestBook: GuestBook) {
         try {
             val participants = invitationParticipantRepository.findAllByInvitationIdWithUser(guestBook.invitation.id)
-            val data = mapOf("invitation_id" to guestBook.invitation.id.toString())
+            val data = mapOf(INVITATION_ID_KEY to guestBook.invitation.id.toString())
             
             participants.forEach { participant ->
                 // 방명록 작성자는 알림 제외

--- a/backend/src/main/kotlin/com/andlife/nachoserver/service/guestbook/GuestBookService.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/service/guestbook/GuestBookService.kt
@@ -19,6 +19,8 @@ import com.andlife.nachoserver.response.guestbook.GuestBookMediaResponse
 import com.andlife.nachoserver.response.guestbook.GuestBookResponse
 import com.andlife.nachoserver.response.guestbook.toGuestBookResponse
 import com.andlife.nachoserver.service.media.MediaService
+import com.andlife.nachoserver.service.user.FcmTokenService
+import com.andlife.nachoserver.repository.participant.InvitationParticipantRepository
 import jakarta.persistence.EntityNotFoundException
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
@@ -32,7 +34,9 @@ class GuestBookService(
     private val guestBookRepository: GuestBookRepository,
     private val userRepository: UserRepository,
     private val invitationRepository: InvitationRepository,
-    private val mediaService: MediaService
+    private val mediaService: MediaService,
+    private val fcmTokenService: FcmTokenService,
+    private val invitationParticipantRepository: InvitationParticipantRepository
 ) {
 
     fun getCollectionByInvitation(invitationId: Long): List<CollectionResponse> {
@@ -244,6 +248,7 @@ class GuestBookService(
         }
 
         val savedGuestBook = guestBookRepository.save(guestBook)
+        sendGuestBookNotificationToParticipants(savedGuestBook)
         return savedGuestBook.toGuestBookResponse()
     }
 
@@ -461,5 +466,26 @@ class GuestBookService(
             ),
             content = responsePage.content
         )
+    }
+
+    private fun sendGuestBookNotificationToParticipants(guestBook: GuestBook) {
+        try {
+            val participants = invitationParticipantRepository.findAllByInvitationIdWithUser(guestBook.invitation.id)
+            val data = mapOf("invitation_id" to guestBook.invitation.id.toString())
+            
+            participants.forEach { participant ->
+                // 방명록 작성자는 알림 제외
+                if (participant.user.id != guestBook.user.id) {
+                    fcmTokenService.sendNotificationToUser(
+                        participant.user,
+                        "새로운 방명록",
+                        "${guestBook.user.name}님이 ${guestBook.invitation.title}에 방명록을 남겼습니다.",
+                        data
+                    )
+                }
+            }
+        } catch (e: Exception) {
+            println("방명록 알림 전송 실패: ${e.message}")
+        }
     }
 }

--- a/backend/src/main/kotlin/com/andlife/nachoserver/service/guestbook/GuestBookService.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/service/guestbook/GuestBookService.kt
@@ -480,7 +480,7 @@ class GuestBookService(
                     fcmTokenService.sendNotificationToUser(
                         participant.user,
                         "새로운 방명록",
-                        "${guestBook.user.name}님이 ${guestBook.invitation.title}에 방명록을 남겼습니다.",
+                        "${guestBook.user.name}님이 ${guestBook.invitation.title}에 방명록을 남겼습니다: ${guestBook.textContent}",
                         data
                     )
                 }

--- a/backend/src/main/kotlin/com/andlife/nachoserver/service/thankscard/ThanksCardService.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/service/thankscard/ThanksCardService.kt
@@ -1,5 +1,6 @@
 package com.andlife.nachoserver.service.thankscard
 
+import com.andlife.nachoserver.constant.FcmConstants.INVITATION_ID_KEY
 import com.andlife.nachoserver.entity.ThanksCard
 import com.andlife.nachoserver.repository.invitation.InvitationRepository
 import com.andlife.nachoserver.repository.thankscard.ThanksCardRepository
@@ -69,7 +70,7 @@ class ThanksCardService(
     private fun sendThanksCardNotificationToParticipants(thanksCard: ThanksCard) {
         try {
             val participants = invitationParticipantRepository.findAllByInvitationIdWithUser(thanksCard.invitation.id)
-            val data = mapOf("invitation_id" to thanksCard.invitation.id.toString())
+            val data = mapOf(INVITATION_ID_KEY to thanksCard.invitation.id.toString())
             
             participants.forEach { participant ->
                 fcmTokenService.sendNotificationToUser(

--- a/backend/src/main/kotlin/com/andlife/nachoserver/service/thankscard/ThanksCardService.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/service/thankscard/ThanksCardService.kt
@@ -6,6 +6,8 @@ import com.andlife.nachoserver.repository.thankscard.ThanksCardRepository
 import com.andlife.nachoserver.request.thankscard.ThanksCardRequest
 import com.andlife.nachoserver.response.thankscard.ThanksCardResponse
 import com.andlife.nachoserver.response.thankscard.toResponse
+import com.andlife.nachoserver.service.user.FcmTokenService
+import com.andlife.nachoserver.repository.participant.InvitationParticipantRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -13,7 +15,9 @@ import org.springframework.transaction.annotation.Transactional
 @Transactional(readOnly = true)
 class ThanksCardService(
     private val thanksCardRepository: ThanksCardRepository,
-    private val invitationRepository: InvitationRepository
+    private val invitationRepository: InvitationRepository,
+    private val fcmTokenService: FcmTokenService,
+    private val invitationParticipantRepository: InvitationParticipantRepository
 ) {
 
     @Transactional
@@ -33,7 +37,9 @@ class ThanksCardService(
             backgroundImageUrl = request.backgroundImageUrl
         )
 
-        return thanksCardRepository.save(card).toResponse()
+        val savedCard = thanksCardRepository.save(card)
+        sendThanksCardNotificationToParticipants(savedCard)
+        return savedCard.toResponse()
     }
 
     @Transactional
@@ -58,5 +64,23 @@ class ThanksCardService(
     @Transactional
     fun deleteThanksCard(invitationId: Long) {
         thanksCardRepository.deleteByInvitationId(invitationId)
+    }
+
+    private fun sendThanksCardNotificationToParticipants(thanksCard: ThanksCard) {
+        try {
+            val participants = invitationParticipantRepository.findAllByInvitationIdWithUser(thanksCard.invitation.id)
+            val data = mapOf("invitation_id" to thanksCard.invitation.id.toString())
+            
+            participants.forEach { participant ->
+                fcmTokenService.sendNotificationToUser(
+                    participant.user,
+                    "감사카드 도착",
+                    "'${thanksCard.invitation.title}'의 감사카드가 도착했습니다.",
+                    data
+                )
+            }
+        } catch (e: Exception) {
+            println("감사카드 알림 전송 실패: ${e.message}")
+        }
     }
 }

--- a/backend/src/main/kotlin/com/andlife/nachoserver/service/user/FcmTokenService.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/service/user/FcmTokenService.kt
@@ -60,8 +60,8 @@ class FcmTokenService(
     }
 
     // 특정 FCM 토큰으로 알림 전송
-    fun sendNotificationToToken(fcmToken: String, title: String, body: String) {
-        val result = fcmUtil.sendToToken(fcmToken, title, body)
+    fun sendNotificationToToken(fcmToken: String, title: String, body: String, data: Map<String, String>? = null) {
+        val result = fcmUtil.sendToToken(fcmToken, title, body, data)
         
         when (result) {
             FcmSendResult.SUCCESS -> {
@@ -87,18 +87,18 @@ class FcmTokenService(
 
     // 여러 FCM 토큰으로 알림 전송
     @Transactional
-    fun sendNotificationToTokens(fcmTokens: List<String>, title: String, body: String) {
+    fun sendNotificationToTokens(fcmTokens: List<String>, title: String, body: String, data: Map<String, String>? = null) {
         fcmTokens.forEach { token ->
-            sendNotificationToToken(token, title, body)
+            sendNotificationToToken(token, title, body, data)
         }
     }
 
     // 특정 유저의 모든 기기에 알림 전송
     @Transactional
-    fun sendNotificationToUser(user: User, title: String, body: String) {
+    fun sendNotificationToUser(user: User, title: String, body: String, data: Map<String, String>? = null) {
         val tokens = fcmTokenRepository.findByUser(user)
         tokens.forEach { token ->
-            sendNotificationToToken(token.fcmToken, title, body)
+            sendNotificationToToken(token.fcmToken, title, body, data)
         }
     }
 }

--- a/backend/src/main/kotlin/com/andlife/nachoserver/util/FCMUtil.kt
+++ b/backend/src/main/kotlin/com/andlife/nachoserver/util/FCMUtil.kt
@@ -10,8 +10,8 @@ import org.springframework.stereotype.Component
 @Component
 class FCMUtil {
     // 특정 FCM 토큰으로 메시지 전송
-    fun sendToToken(fcmToken: String, title: String, body: String): FcmSendResult {
-        val message = Message.builder()
+    fun sendToToken(fcmToken: String, title: String, body: String, data: Map<String, String>? = null): FcmSendResult {
+        val messageBuilder = Message.builder()
             .setToken(fcmToken)
             .setNotification(
                 Notification.builder()
@@ -19,7 +19,9 @@ class FCMUtil {
                     .setBody(body)
                     .build()
             )
-            .build()
+        data?.let { messageBuilder.putAllData(it) }
+        
+        val message = messageBuilder.build()
 
         return try {
             val response = FirebaseMessaging.getInstance().send(message)


### PR DESCRIPTION
## 🔍 변경 사항
- 방명록 데이터가 등록되거나 감사카드가 작성되었을 때, 해당 초대장으로 초대받은 유저들에게 알림 전송
- 알림 클릭 시 해당 초대장으로 navigate

## 📸 스크린샷 (선택)
![KakaoTalk_Photo_2026-04-06-01-42-13 001](https://github.com/user-attachments/assets/57028437-b8d8-4b17-8dbb-faf2098fdcf0)
![KakaoTalk_Photo_2026-04-06-01-42-13 002](https://github.com/user-attachments/assets/98170a85-e6e6-4098-b149-f7e853cac943)


[Screen_recording_20260404_134653.webm](https://github.com/user-attachments/assets/c20831cd-c0c3-46cf-bf53-4bca151d6d94)

## 🔗 관련 이슈
- Close #230

## ✅ 체크리스트
- [x] 팀 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 import는 삭제했나요?
