### PR TITLE
영상 전체 화면에서 네비게이션바가 잠시 올라오는 버그 해결

### DIFF
--- a/android/core/ui/src/main/kotlin/com/andlife/ui/component/media/video/FullscreenVideoPlayerContainer.kt
+++ b/android/core/ui/src/main/kotlin/com/andlife/ui/component/media/video/FullscreenVideoPlayerContainer.kt
@@ -22,7 +22,6 @@ import androidx.compose.runtime.mutableLongStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
@@ -73,9 +72,9 @@ fun FullscreenVideoPlayerContainer(
     var isVideoReadyInFullscreen by remember { mutableStateOf(false) }
     var currentPositionMs by remember { mutableLongStateOf(0L) }
     var totalDurationMs by remember { mutableLongStateOf(0L) }
-    var isSeeking by rememberSaveable { mutableStateOf(false) }
-    var seekPositionMs by rememberSaveable { mutableLongStateOf(0L) }
-    var isControlVisible by rememberSaveable { mutableStateOf(false) }
+    var isSeeking by remember { mutableStateOf(false) }
+    var seekPositionMs by remember { mutableLongStateOf(0L) }
+    var isControlVisible by remember { mutableStateOf(false) }
     var isPlaying by remember { mutableStateOf(false) }
 
     val displayPositionMs = if (isSeeking) seekPositionMs else currentPositionMs

--- a/android/feature/home/src/main/kotlin/com/andlife/home/screen/HomeScreen.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/screen/HomeScreen.kt
@@ -1,6 +1,5 @@
 package com.andlife.home.screen
 
-import android.app.Activity
 import android.view.ViewGroup
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -84,6 +83,7 @@ import com.andlife.ui.component.loading.InvitationLoadingIndicator
 import com.andlife.ui.component.media.video.FullscreenVideoPlayerContainer
 import com.andlife.ui.component.report.ReportBottomSheet
 import com.andlife.ui.util.collectWithLifecycle
+import com.andlife.ui.util.findActivity
 import com.andlife.ui.util.toDDayText
 import com.andlife.ui.util.toDateTimeSingleLine
 import kotlinx.coroutines.delay
@@ -271,7 +271,7 @@ fun HomeRoute(
     DisposableEffect(uiState.fullscreenVideoUrl) {
         val videoUrl = uiState.fullscreenVideoUrl ?: return@DisposableEffect onDispose {}
 
-        val activity = context as Activity
+        val activity = context.findActivity() ?: return@DisposableEffect onDispose {}
         val decorView = activity.window.decorView as ViewGroup
 
         WindowInsetsControllerCompat(activity.window, decorView).apply {

--- a/android/feature/home/src/main/kotlin/com/andlife/home/screen/HomeScreen.kt
+++ b/android/feature/home/src/main/kotlin/com/andlife/home/screen/HomeScreen.kt
@@ -1,13 +1,12 @@
 package com.andlife.home.screen
 
-import android.graphics.Color as AndroidColor
+import android.app.Activity
 import android.view.ViewGroup
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -30,7 +29,6 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -43,15 +41,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.geometry.Rect
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
-import androidx.compose.ui.window.DialogWindowProvider
-import androidx.core.graphics.drawable.toDrawable
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -114,6 +110,7 @@ fun HomeRoute(
     viewModel: HomeViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    val context = LocalContext.current
     var isMediaActive by remember { mutableStateOf(true) }
     val upcomingInvitations = viewModel.upcomingInvitationsPagingFlow.collectAsLazyPagingItems()
     val guestBooks = viewModel.guestBooksPagingFlow.collectAsLazyPagingItems()
@@ -271,46 +268,45 @@ fun HomeRoute(
         )
     }
 
-    uiState.fullscreenVideoUrl?.let { url ->
-        val player = viewModel.videoPlayerPool.getPlayer(url)
-        val isMuted by viewModel.videoPlayerPool.isMuted.collectAsStateWithLifecycle()
+    DisposableEffect(uiState.fullscreenVideoUrl) {
+        val videoUrl = uiState.fullscreenVideoUrl ?: return@DisposableEffect onDispose {}
 
-        Dialog(
-            onDismissRequest = {},
-            properties = DialogProperties(
-                usePlatformDefaultWidth = false,
-                dismissOnBackPress = false,
-                dismissOnClickOutside = false,
-                decorFitsSystemWindows = false,
-            ),
-        ) {
-            val view = LocalView.current
-            val window = (view.parent as? DialogWindowProvider)?.window
+        val activity = context as Activity
+        val decorView = activity.window.decorView as ViewGroup
 
-            SideEffect {
-                window?.apply {
-                    setLayout(
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                    )
-                    setBackgroundDrawable(
-                        AndroidColor.BLACK.toDrawable()
-                    )
-                    WindowInsetsControllerCompat(this, decorView).apply {
-                        hide(WindowInsetsCompat.Type.systemBars())
-                        systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-                    }
-                }
+        WindowInsetsControllerCompat(activity.window, decorView).apply {
+            hide(WindowInsetsCompat.Type.systemBars())
+            systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        }
+
+        val composeView = ComposeView(activity).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
+            setContent {
+                val player = remember { viewModel.videoPlayerPool.getPlayer(videoUrl) }
+                val isMuted by viewModel.videoPlayerPool.isMuted.collectAsStateWithLifecycle()
+
+                FullscreenVideoPlayerContainer(
+                    player = player,
+                    thumbnailUrl = uiState.fullscreenThumbnailUrl,
+                    startBounds = uiState.fullscreenStartBounds,
+                    isMuted = isMuted,
+                    onDismiss = { viewModel.onEvent(HomeUiEvent.DismissFullscreenVideo) },
+                    onMuteToggle = { viewModel.onEvent(HomeUiEvent.ToggleVideoMute) }
+                )
             }
+        }
 
-            FullscreenVideoPlayerContainer(
-                player = player,
-                thumbnailUrl = uiState.fullscreenThumbnailUrl,
-                startBounds = uiState.fullscreenStartBounds,
-                isMuted = isMuted,
-                onDismiss = { viewModel.onEvent(HomeUiEvent.DismissFullscreenVideo) },
-                onMuteToggle = { viewModel.onEvent(HomeUiEvent.ToggleVideoMute) }
+        decorView.addView(
+            composeView,
+            ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
             )
+        )
+
+        onDispose {
+            decorView.removeView(composeView)
+            WindowInsetsControllerCompat(activity.window, decorView).show(WindowInsetsCompat.Type.systemBars())
         }
     }
 

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
@@ -1,6 +1,7 @@
 package com.andlife.invitation.screen.guestbook
 
 import android.Manifest
+import android.app.Activity
 import android.content.Context
 import android.content.pm.PackageManager
 import android.net.Uri
@@ -31,7 +32,6 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -42,20 +42,16 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalResources
-import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
-import androidx.compose.ui.window.DialogWindowProvider
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
-import androidx.core.graphics.drawable.toDrawable
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
-import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -106,7 +102,6 @@ import kotlinx.datetime.LocalDateTime
 import java.io.File
 import kotlin.math.max
 import kotlin.math.min
-import android.graphics.Color as AndroidColor
 import com.andlife.ui.R as uiR
 
 private const val CAMERA_IMAGES_DIR = "camera_images"
@@ -416,46 +411,45 @@ fun InvitationGuestBookRoute(
         )
     }
 
-    uiState.fullscreenVideoUrl?.let { url ->
-        val player = viewModel.videoPlayerPool.getPlayer(url)
-        val isMuted by viewModel.videoPlayerPool.isMuted.collectAsStateWithLifecycle()
+    DisposableEffect(uiState.fullscreenVideoUrl) {
+        val videoUrl = uiState.fullscreenVideoUrl ?: return@DisposableEffect onDispose {}
 
-        Dialog(
-            onDismissRequest = {},
-            properties = DialogProperties(
-                usePlatformDefaultWidth = false,
-                dismissOnBackPress = false,
-                dismissOnClickOutside = false,
-                decorFitsSystemWindows = false,
-            ),
-        ) {
-            val view = LocalView.current
-            val window = (view.parent as? DialogWindowProvider)?.window
+        val activity = context as Activity
+        val decorView = activity.window.decorView as ViewGroup
 
-            SideEffect {
-                window?.apply {
-                    setLayout(
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                    )
-                    setBackgroundDrawable(
-                        AndroidColor.BLACK.toDrawable()
-                    )
-                    WindowInsetsControllerCompat(this, decorView).apply {
-                        hide(WindowInsetsCompat.Type.systemBars())
-                        systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-                    }
-                }
+        WindowInsetsControllerCompat(activity.window, decorView).apply {
+            hide(WindowInsetsCompat.Type.systemBars())
+            systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        }
+
+        val composeView = ComposeView(activity).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
+            setContent {
+                val player = remember { viewModel.videoPlayerPool.getPlayer(videoUrl) }
+                val isMuted by viewModel.videoPlayerPool.isMuted.collectAsStateWithLifecycle()
+
+                FullscreenVideoPlayerContainer(
+                    player = player,
+                    thumbnailUrl = uiState.fullscreenThumbnailUrl,
+                    startBounds = uiState.fullscreenStartBounds,
+                    isMuted = isMuted,
+                    onDismiss = { viewModel.onEvent(InvitationGuestBookUiEvent.DismissFullscreenVideo) },
+                    onMuteToggle = { viewModel.onEvent(InvitationGuestBookUiEvent.ToggleVideoMute) }
+                )
             }
+        }
 
-            FullscreenVideoPlayerContainer(
-                player = player,
-                thumbnailUrl = uiState.fullscreenThumbnailUrl,
-                startBounds = uiState.fullscreenStartBounds,
-                isMuted = isMuted,
-                onDismiss = { viewModel.onEvent(InvitationGuestBookUiEvent.DismissFullscreenVideo) },
-                onMuteToggle = { viewModel.onEvent(InvitationGuestBookUiEvent.ToggleVideoMute) }
+        decorView.addView(
+            composeView,
+            ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
             )
+        )
+
+        onDispose {
+            decorView.removeView(composeView)
+            WindowInsetsControllerCompat(activity.window, decorView).show(WindowInsetsCompat.Type.systemBars())
         }
     }
 

--- a/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
+++ b/android/feature/invitation/src/main/kotlin/com/andlife/invitation/screen/guestbook/InvitationGuestBookScreen.kt
@@ -1,7 +1,6 @@
 package com.andlife.invitation.screen.guestbook
 
 import android.Manifest
-import android.app.Activity
 import android.content.Context
 import android.content.pm.PackageManager
 import android.net.Uri
@@ -91,6 +90,7 @@ import com.andlife.ui.component.paging.PagingStateContent
 import com.andlife.ui.component.report.ReportBottomSheet
 import com.andlife.ui.util.audio.AudioRecorder
 import com.andlife.ui.util.collectWithLifecycle
+import com.andlife.ui.util.findActivity
 import com.andlife.ui.util.imeWithoutNavBars
 import com.andlife.ui.util.media.uriToSelectedMedia
 import com.andlife.ui.util.shouldRequestNotificationPermission
@@ -414,7 +414,7 @@ fun InvitationGuestBookRoute(
     DisposableEffect(uiState.fullscreenVideoUrl) {
         val videoUrl = uiState.fullscreenVideoUrl ?: return@DisposableEffect onDispose {}
 
-        val activity = context as Activity
+        val activity = context.findActivity() ?: return@DisposableEffect onDispose {}
         val decorView = activity.window.decorView as ViewGroup
 
         WindowInsetsControllerCompat(activity.window, decorView).apply {

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
@@ -1,9 +1,9 @@
 package com.andlife.myinvitation.screen.guestbook
 
 import android.Manifest
+import android.app.Activity
 import android.content.Context
 import android.content.pm.PackageManager
-import android.graphics.Color as AndroidColor
 import android.net.Uri
 import android.view.ViewGroup
 import androidx.activity.compose.BackHandler
@@ -32,7 +32,6 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -43,17 +42,14 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusManager
+import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.platform.LocalResources
-import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.window.Dialog
-import androidx.compose.ui.window.DialogProperties
-import androidx.compose.ui.window.DialogWindowProvider
 import androidx.core.content.ContextCompat
 import androidx.core.content.FileProvider
-import androidx.core.graphics.drawable.toDrawable
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -85,9 +81,8 @@ import com.andlife.myinvitation.model.guestbook.MyInvitationGuestBookSideEffect
 import com.andlife.myinvitation.model.guestbook.MyInvitationGuestBookUiEvent
 import com.andlife.myinvitation.model.guestbook.MyInvitationGuestBookUiState
 import com.andlife.myinvitation.viewmodel.MyInvitationGuestBookViewModel
-import com.andlife.ui.R as uiR
-import com.andlife.ui.component.dialog.LoginDialog
 import com.andlife.ui.component.AudioRecordingBottomSheet
+import com.andlife.ui.component.dialog.LoginDialog
 import com.andlife.ui.component.dialog.NachoInfoDialog
 import com.andlife.ui.component.dialog.NachoPermissionDialog
 import com.andlife.ui.component.guestbook.GuestBookItem
@@ -108,6 +103,7 @@ import kotlinx.datetime.LocalDateTime
 import java.io.File
 import kotlin.math.max
 import kotlin.math.min
+import com.andlife.ui.R as uiR
 
 private const val CAMERA_IMAGES_DIR = "camera_images"
 
@@ -415,46 +411,45 @@ fun MyInvitationGuestBookRoute(
         )
     }
 
-    uiState.fullscreenVideoUrl?.let { url ->
-        val player = viewModel.videoPlayerPool.getPlayer(url)
-        val isMuted by viewModel.videoPlayerPool.isMuted.collectAsStateWithLifecycle()
+    DisposableEffect(uiState.fullscreenVideoUrl) {
+        val videoUrl = uiState.fullscreenVideoUrl ?: return@DisposableEffect onDispose {}
 
-        Dialog(
-            onDismissRequest = {},
-            properties = DialogProperties(
-                usePlatformDefaultWidth = false,
-                dismissOnBackPress = false,
-                dismissOnClickOutside = false,
-                decorFitsSystemWindows = false,
-            ),
-        ) {
-            val view = LocalView.current
-            val window = (view.parent as? DialogWindowProvider)?.window
+        val activity = context as Activity
+        val decorView = activity.window.decorView as ViewGroup
 
-            SideEffect {
-                window?.apply {
-                    setLayout(
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                        ViewGroup.LayoutParams.MATCH_PARENT,
-                    )
-                    setBackgroundDrawable(
-                        AndroidColor.BLACK.toDrawable()
-                    )
-                    WindowInsetsControllerCompat(this, decorView).apply {
-                        hide(WindowInsetsCompat.Type.systemBars())
-                        systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
-                    }
-                }
+        WindowInsetsControllerCompat(activity.window, decorView).apply {
+            hide(WindowInsetsCompat.Type.systemBars())
+            systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE
+        }
+
+        val composeView = ComposeView(activity).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnDetachedFromWindow)
+            setContent {
+                val player = remember { viewModel.videoPlayerPool.getPlayer(videoUrl) }
+                val isMuted by viewModel.videoPlayerPool.isMuted.collectAsStateWithLifecycle()
+
+                FullscreenVideoPlayerContainer(
+                    player = player,
+                    thumbnailUrl = uiState.fullscreenThumbnailUrl,
+                    startBounds = uiState.fullscreenStartBounds,
+                    isMuted = isMuted,
+                    onDismiss = { viewModel.onEvent(MyInvitationGuestBookUiEvent.DismissFullscreenVideo) },
+                    onMuteToggle = { viewModel.onEvent(MyInvitationGuestBookUiEvent.ToggleVideoMute) }
+                )
             }
+        }
 
-            FullscreenVideoPlayerContainer(
-                player = player,
-                thumbnailUrl = uiState.fullscreenThumbnailUrl,
-                startBounds = uiState.fullscreenStartBounds,
-                isMuted = isMuted,
-                onDismiss = { viewModel.onEvent(MyInvitationGuestBookUiEvent.DismissFullscreenVideo) },
-                onMuteToggle = { viewModel.onEvent(MyInvitationGuestBookUiEvent.ToggleVideoMute) }
+        decorView.addView(
+            composeView,
+            ViewGroup.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT,
             )
+        )
+
+        onDispose {
+            decorView.removeView(composeView)
+            WindowInsetsControllerCompat(activity.window, decorView).show(WindowInsetsCompat.Type.systemBars())
         }
     }
 

--- a/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
+++ b/android/feature/myinvitation/src/main/kotlin/com/andlife/myinvitation/screen/guestbook/MyInvitationGuestBookScreen.kt
@@ -1,7 +1,6 @@
 package com.andlife.myinvitation.screen.guestbook
 
 import android.Manifest
-import android.app.Activity
 import android.content.Context
 import android.content.pm.PackageManager
 import android.net.Uri
@@ -92,6 +91,7 @@ import com.andlife.ui.component.paging.PagingStateContent
 import com.andlife.ui.component.report.ReportBottomSheet
 import com.andlife.ui.util.audio.AudioRecorder
 import com.andlife.ui.util.collectWithLifecycle
+import com.andlife.ui.util.findActivity
 import com.andlife.ui.util.imeWithoutNavBars
 import com.andlife.ui.util.media.uriToSelectedMedia
 import com.andlife.ui.util.shouldRequestNotificationPermission
@@ -414,7 +414,7 @@ fun MyInvitationGuestBookRoute(
     DisposableEffect(uiState.fullscreenVideoUrl) {
         val videoUrl = uiState.fullscreenVideoUrl ?: return@DisposableEffect onDispose {}
 
-        val activity = context as Activity
+        val activity = context.findActivity() ?: return@DisposableEffect onDispose {}
         val decorView = activity.window.decorView as ViewGroup
 
         WindowInsetsControllerCompat(activity.window, decorView).apply {


### PR DESCRIPTION
## 🔍 변경 사항

- [문제상황 및 해결 영상](https://www.canva.com/design/DAHFDR8771A/ue39XbW8PtTNfMdfUWMNwQ/view?utm_content=DAHFDR8771A&utm_campaign=designshare&utm_medium=link2&utm_source=uniquelinks&utlId=h8636aef7e8)
- Dialog -> MainActivity + DecorView 변경
- Dialog에서 왜 저런 현상이 발생하는 지는 아직 원인을 잘 모름. 하지만 Dialog도 Window를 가지기 때문에 Dialog Window만의 어떤 특징이 있어서 그런 것 같습니다.
- 따라서 MainActivity에서 DecorView를 이용해 시스템 바와 네비게이션 바를 조절하도록 수정했습니다
- 참고) Activity를 따로 만들까도 생각했는데 이 썸네일이 잠시 보이는 시간이 길어서 선택하지 않았습니다.

## 📸 스크린샷 (선택)
> UI 변경 사항이 있다면 이미지를 첨부해주세요.

## 🔗 관련 이슈
> 해당 PR과 연결된 이슈 번호를 적어주세요. (예: #1)

- Close #229 

## ✅ 체크리스트
- [x] 팀 컨벤션을 준수했나요?
- [x] 불필요한 주석이나 import는 삭제했나요?
